### PR TITLE
Check mousewhell source

### DIFF
--- a/src/extensions/cytoscape.renderer.canvas.js
+++ b/src/extensions/cytoscape.renderer.canvas.js
@@ -847,6 +847,10 @@
 		}, false);
 		
 		var wheelHandler = function(e) {
+			// Do not process mousewheel event if its source is not overlay
+			if (e.srcElement !== r.data.overlay)
+				return;
+
 			var cy = r.data.cy; var pos = r.projectIntoViewport(e.pageX, e.pageY);
 			
 			var unpos = [pos[0] * cy.zoom() + cy.pan().x,


### PR DESCRIPTION
If source is not overlay then do not zoom graph as this event comes from some other container.
As by specification mousewhell event bubbling can't be stopped, the only right solution is to check it's origin in all watchers.
