### PR TITLE
Linting cleanup

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -161,7 +161,11 @@
 		},
 
 		registered: function(){
-			return !! this._private;
+            if( this._private && this._private.instanceId != null ){
+                return true;
+            } else {
+                return false;
+            }
 		},
 
 		registeredId: function(){


### PR DESCRIPTION
minor cleanup to core.js:
- rm trailing white space on lines
- almost all indentation in file is tabs, change two lines that use spaces for indentation inside a comment block to use tabs as well
- add a missing semicolon
- change lone instance of != to be !== like all other inequality comparisons in the file

Mocha tests all pass.
