### PR TITLE
Updated the checkPoint function in ellipse.

### DIFF
--- a/src/extensions/renderer.canvas.node-shapes.js
+++ b/src/extensions/renderer.canvas.node-shapes.js
@@ -68,6 +68,7 @@
 		checkPoint: function(
 			x, y, padding, width, height, centerX, centerY) {
 			
+			centerX += width / 2;
 //			console.log(arguments);
 			
 			x -= centerX;


### PR DESCRIPTION
CenterX is not correct when being passed to checkPoint when dealing with Ellipses.

Seems that the centerX that is pulled from node._private is off by the radius of the ellipse. This throws off the function that determines if any nodes are under the mouse coordinates. 

You can test this attempting to click a ellipse node. The left side of the node will correctly be detected as being clicked by the user. Also, clicking slightly to the left of the node will be detected as clicked. This is because the of the centerX problem.

I attempted to find the origin of the problem where _private.position was being stored. Since my monkey patch worked and I don't have time to fully learn the code base I settled on this patch.

// lance
