### PR TITLE
Element’s “transparent” function doesn’t return the correct result

### DIFF
--- a/src/collection-style.js
+++ b/src/collection-style.js
@@ -257,7 +257,7 @@
 
       if( ele ){
         if( !hasCompoundNodes ){
-          return ele._private.style.opacity === 0;
+          return ele._private.style.opacity.value === 0;
         } else {
           return ele.effectiveOpacity() === 0;
         }


### PR DESCRIPTION
When the opacity of an element is equal to zero, the transparent function should return true, but the strict comparison (===) is actually comparing an object with an integer, hence the function returns false in any case.
This issue causes the edgehandles extension to fail as it creates a transparent “ghost” node that shouldn’t trigger any mouse events.
