### PR TITLE
fix #793 leaked labelCalcDiv used to calculate label dimensions

### DIFF
--- a/src/extensions/renderer.canvas.define-and-init-etc.js
+++ b/src/extensions/renderer.canvas.define-and-init-etc.js
@@ -177,6 +177,10 @@
     if( this.removeObserver ){
       this.removeObserver.disconnect();
     }
+
+    if( this.labelCalcDiv ){
+      document.body.removeChild(this.labelCalcDiv);
+    }
   };
 
   


### PR DESCRIPTION
Hi, this PR fix the leaked div reported on #793 that is used to calculate the label dimensions.
This div is appended to the body at the init and it's never removed or reused during the cy.destroy().

I'm not sure if this is the best way to solve this issue. Maybe it can be better to add the labelCalcDiv into the current cytoscape container (not into the body) and remove everything during the destroy changing the line https://github.com/cytoscape/cytoscape.js/blob/master/src/extensions/renderer.canvas.coord-ele-math.js#L659 with the following:


      this.data.container.appendChild( div );

