### PR TITLE
Added feature to rotated label: now it can be centered to line and have ...

### DIFF
--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -173,7 +173,7 @@ These properties affect the styling of an edge's line:
  * **`control-point-weight`** : Weights control points along the line from source to target.  This value ranges on [0, 1], with 0 towards the source node and 1 towards the target node.
  * **`line-color`** : The colour of the edge's line.
  * **`line-style`** : The style of the edge's line; may be `solid`, `dotted`, or `dashed`.
- * **`edge-text-rotation`** : Whether to rotate edge labels as the relative angle of an edge changes; may be `none` for page-aligned labels or `autorotate` for edge-aligned labels.  This works best with left-to-right text.
+ * **`edge-text-rotation`** : Whether to rotate edge labels as the relative angle of an edge changes; may be `none` for page-aligned labels, `autorotate` for edge-aligned labels, or `autorotate-with-background` for edge-aligned labels with a filled background. This works best with left-to-right text.
 
 
 

--- a/src/extensions/renderer.canvas.drawing-label-text.js
+++ b/src/extensions/renderer.canvas.drawing-label-text.js
@@ -30,7 +30,7 @@
     if( !$$.is.number( rs.labelX ) || !$$.is.number( rs.labelY ) ){ return; } // no pos => label can't be rendered
 
     var style = edge._private.style;
-    var autorotate = style['edge-text-rotation'].strValue === 'autorotate';
+    var autorotate = style['edge-text-rotation'].strValue === 'autorotate' || style['edge-text-rotation'].strValue === 'autorotate-with-background';
     var theta, dx, dy;
     
     if( autorotate ){
@@ -49,7 +49,11 @@
       context.translate(rs.labelX, rs.labelY);
       context.rotate(theta);
 
-      this.drawText(context, edge, 0, -4); // make label offset from the edge a bit
+      if (style['edge-text-rotation'].strValue === 'autorotate') {
+        this.drawRotatedText(context, edge, false);
+      } else {
+        this.drawRotatedText(context, edge, true);
+      }
 
       context.rotate(-theta);
       context.translate(-rs.labelX, -rs.labelY);
@@ -194,6 +198,55 @@
       }
 
       context.fillText(text, textX, textY);
+    }
+  };
+
+  function roundRect(ctx, x, y, width, height, radius) {
+    var radius = radius || 5;
+    ctx.beginPath();
+    ctx.moveTo(x + radius, y);
+    ctx.lineTo(x + width - radius, y);
+    ctx.quadraticCurveTo(x + width, y, x + width, y + radius);
+    ctx.lineTo(x + width, y + height - radius);
+    ctx.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
+    ctx.lineTo(x + radius, y + height);
+    ctx.quadraticCurveTo(x, y + height, x, y + height - radius);
+    ctx.lineTo(x, y + radius);
+    ctx.quadraticCurveTo(x, y, x + radius, y);
+    ctx.closePath();
+    ctx.fill();
+  }
+
+  CanvasRenderer.prototype.drawRotatedText = function(context, element, background) {
+    var textX = 0,
+        textY = background === true ? 0 : -4;
+    var style = element._private.style;
+    var parentOpacity = element.effectiveOpacity();
+    if( parentOpacity === 0 ){ return; }
+
+    var text = this.setupTextStyle( context, element );
+    
+    if ( text != null && !isNaN(textX) && !isNaN(textY) ) {
+     
+      var lineWidth = 2  * style['text-outline-width'].value; // *2 b/c the stroke is drawn centred on the middle
+      if (lineWidth > 0) {
+        context.lineWidth = lineWidth;
+        context.strokeText(text, textX, textY);
+      }
+      if (!background) {
+        context.fillText(text, textX, textY);
+      } else {
+        var metrics = context.measureText(text);
+        var lineColor = style['line-color'].value;
+        context.fillStyle = this.fillStyle(context, lineColor[0], lineColor[1], lineColor[2], 1);
+        context.strokeStyle  = this.strokeStyle(context, lineColor[0], lineColor[1], lineColor[2], 1);
+        var bgWidth = metrics.width + 4;
+        var bgHeight = style['font-size'].pxValue;
+        roundRect(context, textX - bgWidth / 2, textY - bgHeight / 2, bgWidth, bgHeight, 2);
+        var color = style['color'].value;
+        context.fillStyle = this.fillStyle(context, color[0], color[1], color[2], 1);
+        context.fillText(text, textX, textY);
+      }
     }
   };
 

--- a/src/style.js
+++ b/src/style.js
@@ -87,7 +87,7 @@
       url: { regex: '^url\\s*\\(\\s*([^\\s]+)\\s*\\s*\\)|none|(.+)$' },
       propList: { propList: true },
       angle: { number: true, units: 'deg|rad' },
-      textRotation: { enums: ['none', 'autorotate'] }
+      textRotation: { enums: ['none', 'autorotate', 'autorotate-with-background'] },
     };
 
     // define visual style properties


### PR DESCRIPTION
@maxkfranz Our project recently required a feature that the rotated labels have a filled background. I basically implemented it and wanted to contribute it back to cytoscape.js. So previously we have autorotate label, but now I added another option autorotate-with-background. It looks like this once it's turned on:
![capture](https://cloud.githubusercontent.com/assets/2195250/6202209/da127950-b530-11e4-9c73-139f8e1cb0e8.PNG)

Let me know how you think of this. Feel free to merge it if you want to.
