### PR TITLE
Log correct variable in map example.

### DIFF
--- a/documentation/md/collection/map.md
+++ b/documentation/md/collection/map.md
@@ -6,5 +6,5 @@ var weights = cy.nodes().map(function( ele ){
   return ele.data('weight');
 });
 
-console.log(map);
+console.log(weights);
 ```


### PR DESCRIPTION
Hi - this updates the the example for `eles.map()` so that it logs the defined variable.

Regards,

Szymon