### PR TITLE
Add length property to springy edge

### DIFF
--- a/src/extensions/layout.springy.js
+++ b/src/extensions/layout.springy.js
@@ -61,7 +61,8 @@
         
         edge.scratch('springy', {
           model: graph.newEdge(fdSrc, fdTgt, {
-            element: edge
+            element: edge,
+            length: (typeof options.edgeLength === "function") ? options.edgeLength.call(edge, edge) : edge.data('length')
           })
         });
       });


### PR DESCRIPTION
https://github.com/dhotson/springy/issues/39
The length can be set on edge objects. ie edge.data.length
If the length property exists it will be used in the physics calculations (default length is 1).