### PR TITLE
Fix canvas resize issue

### DIFF
--- a/src/extensions/renderer.canvas.define-and-init-etc.js
+++ b/src/extensions/renderer.canvas.define-and-init-etc.js
@@ -18,54 +18,54 @@
   CanvasRenderer.MOTIONBLUR_BUFFER_NODE = 1;
   CanvasRenderer.MOTIONBLUR_BUFFER_DRAG = 2;
 
-  function CanvasRenderer(options) {  
+  function CanvasRenderer(options) {
 
     this.options = options;
 
     this.data = {
-        
-      select: [undefined, undefined, undefined, undefined, 0], // Coordinates for selection box, plus enabled flag 
+
+      select: [undefined, undefined, undefined, undefined, 0], // Coordinates for selection box, plus enabled flag
       renderer: this, cy: options.cy, container: options.cy.container(),
-      
+
       canvases: new Array(CanvasRenderer.CANVAS_LAYERS),
       contexts: new Array(CanvasRenderer.CANVAS_LAYERS),
       canvasNeedsRedraw: new Array(CanvasRenderer.CANVAS_LAYERS),
-      
+
       bufferCanvases: new Array(CanvasRenderer.BUFFER_COUNT),
       bufferContexts: new Array(CanvasRenderer.CANVAS_LAYERS)
 
     };
-    
+
     //--Pointer-related data
-    this.hoverData = {down: null, last: null, 
-        downTime: null, triggerMode: null, 
-        dragging: false, 
+    this.hoverData = {down: null, last: null,
+        downTime: null, triggerMode: null,
+        dragging: false,
         initialPan: [null, null], capture: false};
-    
+
     this.timeoutData = {panTimeout: null};
-    
+
     this.dragData = {possibleDragElements: []};
-    
+
     this.touchData = {start: null, capture: false,
         // These 3 fields related to tap, taphold events
         startPosition: [null, null, null, null, null, null],
         singleTouchStartTime: null,
         singleTouchMoved: true,
-        
-        
-        now: [null, null, null, null, null, null], 
+
+
+        now: [null, null, null, null, null, null],
         earlier: [null, null, null, null, null, null] };
     //--
-    
-    //--Wheel-related data 
+
+    //--Wheel-related data
     this.zoomData = {freeToZoom: false, lastPointerX: null};
     //--
-    
+
     this.redraws = 0;
     this.showFps = options.showFps;
 
     this.bindings = [];
-    
+
     this.data.canvasContainer = document.createElement('div');
     var containerStyle = this.data.canvasContainer.style;
     containerStyle.position = 'absolute';
@@ -81,7 +81,7 @@
       this.data.canvases[i].setAttribute('data-id', 'layer' + i);
       this.data.canvases[i].style.zIndex = String(CanvasRenderer.CANVAS_LAYERS - i);
       this.data.canvasContainer.appendChild(this.data.canvases[i]);
-      
+
       this.data.canvasNeedsRedraw[i] = false;
     }
     this.data.topCanvas = this.data.canvases[0];
@@ -89,7 +89,7 @@
     this.data.canvases[CanvasRenderer.NODE].setAttribute('data-id', 'layer' + CanvasRenderer.NODE + '-node');
     this.data.canvases[CanvasRenderer.SELECT_BOX].setAttribute('data-id', 'layer' + CanvasRenderer.SELECT_BOX + '-selectbox');
     this.data.canvases[CanvasRenderer.DRAG].setAttribute('data-id', 'layer' + CanvasRenderer.DRAG + '-drag');
-    
+
     for (var i = 0; i < CanvasRenderer.BUFFER_COUNT; i++) {
       this.data.bufferCanvases[i] = document.createElement('canvas');
       this.data.bufferContexts[i] = this.data.bufferCanvases[i].getContext('2d');
@@ -166,10 +166,12 @@
 
       if( type === 'load' || type === 'resize' ){
         this.invalidateContainerClientCoordsCache();
-        this.matchCanvasSize(this.data.container);
+        setTimeout(function(){
+          this.matchCanvasSize(this.data.container);
+        }.bind(this), 1)
       }
     } // for
-    
+
     this.data.canvasNeedsRedraw[CanvasRenderer.NODE] = true;
     this.data.canvasNeedsRedraw[CanvasRenderer.DRAG] = true;
 
@@ -195,7 +197,7 @@
     }
   };
 
-  
+
 
   // copy the math functions into the renderer prototype
   // unfortunately these functions are used interspersed t/o the code
@@ -204,8 +206,8 @@
   for( var fnName in $$.math ){
     CanvasRenderer.prototype[ fnName ] = $$.math[ fnName ];
   }
-  
-  
+
+
   $$('renderer', 'canvas', CanvasRenderer);
-  
+
 })( cytoscape );

--- a/src/extensions/renderer.canvas.load-and-listeners.js
+++ b/src/extensions/renderer.canvas.load-and-listeners.js
@@ -116,10 +116,10 @@
         inDragLayer: opts.inDragLayer
       } );
     };
-    
+
     var freeDraggedElements = function( draggedElements ){
       if( !draggedElements ){ return; }
-      
+
       for (var i=0; i < draggedElements.length; i++) {
 
         var dEi_p = draggedElements[i]._private;
@@ -221,9 +221,11 @@
     r.registerBinding(window, 'resize', $$.util.debounce( function(e) {
       r.invalidateContainerClientCoordsCache();
 
-      r.matchCanvasSize(r.data.container);
-      r.data.canvasNeedsRedraw[CR.NODE] = true;
-      r.redraw();
+      setTimeout(function(){
+        r.matchCanvasSize(r.data.container);
+        r.data.canvasNeedsRedraw[CR.NODE] = true;
+        r.redraw();
+      }, 1);
     }, 100 ) );
 
     var invalCtnrBBOnScroll = function(domEle){
@@ -268,7 +270,7 @@
       var draggedElements = r.dragData.possibleDragElements;
 
       r.hoverData.mdownPos = pos;
-      
+
       var needsRedraw = r.data.canvasNeedsRedraw;
 
       var checkForTaphold = function(){
@@ -988,10 +990,10 @@
         // Cancel drag pan
         if( r.hoverData.dragging ){
           r.hoverData.dragging = false;
-          
+
           needsRedraw[CR.SELECT_BOX] = true;
           needsRedraw[CR.NODE] = true;
-          
+
           r.redraw();
         }
 
@@ -1382,7 +1384,7 @@
       var cy = r.data.cy;
       var now = r.touchData.now; var earlier = r.touchData.earlier;
       var zoom = cy.zoom();
-      
+
       var needsRedraw = r.data.canvasNeedsRedraw;
 
       if (e.touches[0]) { var pos = r.projectIntoViewport(e.touches[0].clientX, e.touches[0].clientY); now[0] = pos[0]; now[1] = pos[1]; }
@@ -1582,7 +1584,7 @@
 
             if( draggedEles ){ for( var i = 0; i < draggedEles.length; i++ ){
               var dEi_p = draggedEles[i]._private;
-              
+
               dEi_p.grabbed = false;
               dEi_p.rscratch.inDragLayer = false;
             } }
@@ -1645,7 +1647,7 @@
 
                 if( justStartedDrag ){
                   addNodeToDrag( draggedEle, { inDragLayer: true } );
-                  
+
                   needsRedraw[CR.NODE] = true;
 
                   var dragDelta = r.touchData.dragDelta;
@@ -1843,7 +1845,7 @@
       var zoom = cy.zoom();
       var now = r.touchData.now;
       var earlier = r.touchData.earlier;
-      
+
       var needsRedraw = r.data.canvasNeedsRedraw;
 
       if (e.touches[0]) { var pos = r.projectIntoViewport(e.touches[0].clientX, e.touches[0].clientY); now[0] = pos[0]; now[1] = pos[1]; }
@@ -1952,18 +1954,18 @@
 
         r.data.bgActivePosistion = undefined;
         needsRedraw[CR.SELECT_BOX] = true;
-        
+
         var draggedEles = r.dragData.touchDragEles;
 
         if (start != null ) {
 
           var startWasGrabbed = start._private.grabbed;
-          
+
           freeDraggedElements( draggedEles );
 
           needsRedraw[CR.DRAG] = true;
           needsRedraw[CR.NODE] = true;
-          
+
           if( startWasGrabbed ){
             start.trigger('free');
           }


### PR DESCRIPTION
This issue is calling resize() on cytoscape object when container was
resized. Due to how browsers works with this kind of changes we need to
add a milisecond timeout to properly get container size.

Source:
http://stackoverflow.com/questions/2643396/get-width-of-element-after-resizing-it

Some images:

Opened column on the left side:
![open_bf](https://cloud.githubusercontent.com/assets/301700/8251128/2cd2dd24-167a-11e5-813f-da3d71e78c2e.png)

Closed before fix:
![closed_bf](https://cloud.githubusercontent.com/assets/301700/8251131/3499603c-167a-11e5-82a7-dcdc7a652d12.png)

Closed after fix:
![closed_af](https://cloud.githubusercontent.com/assets/301700/8251134/39cf9238-167a-11e5-893f-b54f0c3f6097.png)

As you can see before fix images are chopped of, BUT the graph is operable in that "blind spot" (i.e. I can pan the graph). I tried to create a codepen for this, but Cytoscape worked, although without showing a thing (canvases were right there). It might be the issue with iframes though.

Safer solution to: https://github.com/cytoscape/cytoscape.js/pull/980