### PR TITLE
Grid layout : condensed & padded

### DIFF
--- a/src/extensions/layout.grid.js
+++ b/src/extensions/layout.grid.js
@@ -118,15 +118,30 @@
       var cellWidth = bb.w / cols;
       var cellHeight = bb.h / rows;
 
-      // cellHeight fits the tallest node
-      if (options.autoCellHeight) {
-        var maxHeight = 0;
+      // option to set all cell sizes to the size of the biggest cell
+      if (options.autoCellSize) {
+        cellWidth = 0;
+        cellHeight = 0;
+        var cellPaddingX = 20;
+        var cellPaddingY = 20;
+
         for (var i = 0; i < nodes.length; i++) {
           var node = nodes[i];
-          var h = node.boundingBox({ includeNodes: true, includeLabels: true }).h;
-          maxHeight = Math.max(maxHeight, h);
+
+          // During position calculation, requesting for bouding box will fail when node does not have position, fix 0, 0
+          if (!node._private.position.x) {
+            node._private.position.x = 0;
+          }
+
+          if (!node._private.position.y) {
+            node._private.position.y = 0;
+          }
+
+          var nodeBb = node.boundingBox({ includeNodes: true, includeLabels: true });
+
+          cellWidth = Math.max(cellWidth, nodeBb.w + cellPaddingX);
+          cellHeight = Math.max(cellHeight, nodeBb.h + cellPaddingY);
         }
-        var cellHeight = maxHeight;
       }
 
       if( options.avoidOverlap ){

--- a/src/extensions/layout.grid.js
+++ b/src/extensions/layout.grid.js
@@ -118,6 +118,17 @@
       var cellWidth = bb.w / cols;
       var cellHeight = bb.h / rows;
 
+      // cellHeight fits the tallest node
+      if (options.autoCellHeight) {
+        var maxHeight = 0;
+        for (var i = 0; i < nodes.length; i++) {
+          var node = nodes[i];
+          var h = node.boundingBox({ includeNodes: true, includeLabels: true }).h;
+          maxHeight = Math.max(maxHeight, h);
+        }
+        var cellHeight = maxHeight;
+      }
+
       if( options.avoidOverlap ){
         for( var i = 0; i < nodes.length; i++ ){
           var node = nodes[i];


### PR DESCRIPTION
I have an issue with the grid mode. I use it with `columns : 1, fit: true`. If I only have 2-3 nodes and the canvas is 700px height then I get too much spacing between the nodes and the graph become hard to read. This PR adds a feature to compute the height of the highest cell and then use this value as the *row* height.

What do you think of the idea? 
Should I do the same for columns  (using `autoCellWidth`)?
Do you like the name of the option? Can you think of a better name?

