### PR TITLE
Fix infinite loop in some JavaScript implementations

### DIFF
--- a/src/selector.js
+++ b/src/selector.js
@@ -133,8 +133,9 @@
       // - the current query is stored in self[i] --- you can use the reference to `this` in the populate function;
       // - you need to check the query objects in Selector.filter() for it actually filter properly, but that's pretty straight forward
       // - when you add something here, also add to Selector.toString()
-      var exprs = {
-        group: {
+      var exprs = [
+        {
+          name: group,
           query: true,
           regex: '(node|edge|\\*)',
           populate: function( group ){
@@ -142,7 +143,8 @@
           }
         },
 
-        state: {
+        {
+          name: state,
           query: true,
           // NB: if one colon selector is a substring of another from its start, place the longer one first
           // e.g. :foobar|:foo
@@ -152,7 +154,8 @@
           }
         },
 
-        id: {
+        {
+          name: id,
           query: true,
           regex: '\\#('+ tokens.id +')',
           populate: function( id ){
@@ -160,7 +163,8 @@
           }
         },
 
-        className: {
+        {
+          name: className,
           query: true,
           regex: '\\.('+ tokens.className +')',
           populate: function( className ){
@@ -168,7 +172,8 @@
           }
         },
 
-        dataExists: {
+        {
+          name: dataExists,
           query: true,
           regex: '\\[\\s*('+ tokens.variable +')\\s*\\]',
           populate: function( variable ){
@@ -178,7 +183,8 @@
           }
         },
 
-        dataCompare: {
+        {
+          name: dataCompare,
           query: true,
           regex: '\\[\\s*('+ tokens.variable +')\\s*('+ tokens.comparatorOp +')\\s*('+ tokens.value +')\\s*\\]',
           populate: function( variable, comparatorOp, value ){
@@ -198,7 +204,8 @@
           }
         },
 
-        dataBool: {
+        {
+          name: dataBool,
           query: true,
           regex: '\\[\\s*('+ tokens.boolOp +')\\s*('+ tokens.variable +')\\s*\\]',
           populate: function( boolOp, variable ){
@@ -209,7 +216,8 @@
           }
         },
 
-        metaCompare: {
+        {
+          name: metaCompare,
           query: true,
           regex: '\\[\\[\\s*('+ tokens.meta +')\\s*('+ tokens.comparatorOp +')\\s*('+ tokens.number +')\\s*\\]\\]',
           populate: function( meta, comparatorOp, number ){
@@ -221,7 +229,8 @@
           }
         },
 
-        nextQuery: {
+        {
+          name: nextQuery,
           separator: true,
           regex: tokens.separator,
           populate: function(){
@@ -231,7 +240,8 @@
           }
         },
 
-        child: {
+        {
+          name: child,
           separator: true,
           regex: tokens.child,
           populate: function(){
@@ -245,7 +255,8 @@
           }
         },
 
-        descendant: {
+        {
+          name: descendant,
           separator: true,
           regex: tokens.descendant,
           populate: function(){
@@ -259,7 +270,8 @@
           }
         },
 
-        subject: {
+        {
+          name: subject,
           modifier: true,
           regex: tokens.subject,
           populate: function(){
@@ -273,20 +285,12 @@
           }
 
         }
-      };
-
-      var j = 0;
-      for( var name in exprs ){
-        exprs[j] = exprs[name];
-        exprs[j].name = name;
-
-        j++;
-      }
-      exprs.length = j;
+      ];
 
       self._private.selectorText = selector;
       var remaining = selector;
       var i = 0;
+      var j = 0;
 
       // of all the expressions, find the first match in the remaining text
       var consumeExpr = function( expectation ){


### PR DESCRIPTION
Fixes infinite for...in loop that happens with some JavaScript implementations, caused by adding keys to an object while iterating over its keys.

I found two working fixes. (I went with the first.):

1. Change exprs to an array.
I went with this one since it looked like exprs was being modified to be used like an array immediately after initialization anyway.

2. Don't modify exprs, and instead, build up a temp object while iterating over exprs, and then after the iteration is complete, assign exprs to that temp object.
This solution would be fitting if there is a reason to keep exprs as an object.