### PR TITLE
Fix for Thread fnAs breaking minified functions

### DIFF
--- a/src/thread.js
+++ b/src/thread.js
@@ -422,7 +422,7 @@ util.extend(thdfn, {
 // turns a stringified function into a (re)named function
 var fnAs = function( fn, name ){
   var fnStr = fn.toString();
-  fnStr = fnStr.replace(/function\s*\S*\s*\(/, 'function ' + name + '(');
+  fnStr = fnStr.replace(/function[\s\S]+?\(/, 'function ' + name + '(');
 
   return fnStr;
 };


### PR DESCRIPTION
Changed regex to cover the minified functions case.

https://github.com/cytoscape/cytoscape.js/blob/e75a707415564d5a20928b6ae480cfb616a2e29b/src/thread.js#L425

Consider the case where:
```
fn === "function cellCentroid(e){for(var n,t,o,i=e.halfedges,a=0,r=0,s=0,c=0;c<i.length;++c)n=i[c].getEndpoint(),t=i[c].getStartpoint(),a+=n.x*t.y,a-=n.y*t.x,o=n.x*t.y-t.x*n.y,r+=(n.x+t.x)*o,s+=(n.y+t.y)*o;return a/=2,o=6*a,{x:r/o,y:s/o}}"

name === "cellCentroid"
```
( Code from spread layout )

The result is a broken with syntax error code:
```
"function cellCentroid(var n,t,o,i=e.halfedges,a=0,r=0,s=0,c=0;c<i.length;++c)n=i[c].getEndpoint(),t=i[c].getStartpoint(),a+=n.x*t.y,a-=n.y*t.x,o=n.x*t.y-t.x*n.y,r+=(n.x+t.x)*o,s+=(n.y+t.y)*o;return a/=2,o=6*a,{x:r/o,y:s/o}}"
```

Because what matched on the regular expression is 'function cellCentroid(e){for('

Maybe change the regex to something like:
``/function[\s\S]+?\(/`` - match at least one space/no-space char in a non-greedy way?

It fixes it for that case and some others I've tested.