### PR TITLE
Fix taphold and cxttap problems under Chrome for Windows.

### DIFF
--- a/src/extensions/renderer/base/load-listeners.js
+++ b/src/extensions/renderer/base/load-listeners.js
@@ -480,7 +480,11 @@ BRp.load = function() {
 
     var multSelKeyDown = isMultSelKeyDown( e );
 
-    r.hoverData.tapholdCancelled = true;
+    var isOverThresholdDrag = rdist2 >= r.desktopTapThreshold2;
+
+    if (isOverThresholdDrag) {
+      r.hoverData.tapholdCancelled = true;
+    }
 
     var updateDragDelta = function(){
       var dragDelta = r.hoverData.dragDelta = r.hoverData.dragDelta || [];
@@ -503,37 +507,40 @@ BRp.load = function() {
 
     // trigger context drag if rmouse down
     if( r.hoverData.which === 3 ){
-      var cxtEvt = Event(e, {
-        type: 'cxtdrag',
-        cyPosition: { x: pos[0], y: pos[1] }
-      });
+      // but only if over threshold
+      if( isOverThresholdDrag ){
+        var cxtEvt = Event( e, {
+          type: 'cxtdrag',
+          cyPosition: { x: pos[0], y: pos[1] }
+        } );
 
-      if( down ){
-        down.trigger( cxtEvt );
-      } else {
-        cy.trigger( cxtEvt );
-      }
-
-      r.hoverData.cxtDragged = true;
-
-      if( !r.hoverData.cxtOver || near !== r.hoverData.cxtOver ){
-
-        if( r.hoverData.cxtOver ){
-          r.hoverData.cxtOver.trigger( Event(e, {
-            type: 'cxtdragout',
-            cyPosition: { x: pos[0], y: pos[1] }
-          }) );
+        if( down ){
+          down.trigger( cxtEvt );
+        } else{
+          cy.trigger( cxtEvt );
         }
 
-        r.hoverData.cxtOver = near;
+        r.hoverData.cxtDragged = true;
 
-        if( near ){
-          near.trigger( Event(e, {
-            type: 'cxtdragover',
-            cyPosition: { x: pos[0], y: pos[1] }
-          }) );
+        if( !r.hoverData.cxtOver || near !== r.hoverData.cxtOver ){
+
+          if( r.hoverData.cxtOver ){
+            r.hoverData.cxtOver.trigger( Event( e, {
+              type: 'cxtdragout',
+              cyPosition: { x: pos[0], y: pos[1] }
+            } ) );
+          }
+
+          r.hoverData.cxtOver = near;
+
+          if( near ){
+            near.trigger( Event( e, {
+              type: 'cxtdragover',
+              cyPosition: { x: pos[0], y: pos[1] }
+            } ) );
+          }
+
         }
-
       }
 
     // Check if we are drag panning the entire graph
@@ -619,7 +626,7 @@ BRp.load = function() {
 
       if( down && down.isNode() && r.nodeIsDraggable(down) ){
 
-        if( rdist2 >= r.desktopTapThreshold2 ){ // then drag
+        if( isOverThresholdDrag ){ // then drag
 
           var justStartedDrag = !r.dragData.didDrag;
 


### PR DESCRIPTION
# Changes
Use desktopTapThreshold for all mouse drag functionality.

# Details
Related external bug: https://bugs.chromium.org/p/chromium/issues/detail?id=161464

Because of the aforementioned bug in Chromium (which apparently only affects Windows users), all events that rely on there not being a `mousemove` event, such as `taphold` and `cxttap` (these were the only 2 I tested), fail to trigger.

As pointed out in the external bug report, a simple solution and good practice when dealing with these click + move interactions is to only consider a drag after a certain movement threshold. Such a threshold already exists (`desktopTapThreshold`) but is only applied when testing dragging of nodes. Because cancellation of holds and right taps occurs outside of this test, the problem manifests.

# Comments
 For the fix, testing against a threshold of 0 (`mousemove` event with no actual movement) would be sufficient but, in my opinion, the `desktopTapThreshold` should be applied to any type of mouse drag movement. Most importantly, doing so, also applies `desktopTapThreshold` to right-click taps.

I haven't tested the touch-related events so perhaps they suffer from the same problem.