### PR TITLE
Changes the require of the version file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ var cytoscape = function( options ){ // jshint ignore:line
 };
 
 // replaced by build system
-cytoscape.version = require('./version');
+cytoscape.version = require('./version.json');
 
 // try to register w/ jquery
 if( window && window.jQuery ){


### PR DESCRIPTION
Some build steps error out when trying to require the version file, this adds .json to the end of the file to be more specific in the require call.

For issue: https://github.com/cytoscape/cytoscape.js/issues/1394