### PR TITLE
New line-style 'break': creates a gap in the middle of edges

### DIFF
--- a/src/extensions/renderer/canvas/drawing-edges.js
+++ b/src/extensions/renderer/canvas/drawing-edges.js
@@ -107,6 +107,27 @@ CRp.drawEdgePath = function( edge, context, pts, type, width ){
       rs.pathCache = path;
     }
   }
+  
+  function bezierLength(x1, y1, x2, y2, x3, y3) {
+    //formula source : http://www.malczak.linuxpl.com/blog/quadratic-bezier-curve-length/
+    var a = {
+      x: x1 - 2 * x2 + x3,
+      y: y1 - 2 * y2 + y3
+    },
+    b = {
+      x: 2 * (x2 - x1),
+      y: 2 * (y2 - y1)
+    };
+    var A = 4 * (a.x * a.x + a.y * a.y);
+    var B = 4 * (a.x * b.x + a.y * b.y);
+    var C = b.x * b.x + b.y * b.y;
+    var A32 = Math.pow(A, 3/2);
+    var A12 = Math.sqrt(A);
+    var ABC12 = Math.sqrt(A+B+C);
+    var C12 = Math.sqrt(C);
+    return 1 / (8 * A32) * (4 * A32 * ABC12 + 2 * A12 * B * (ABC12 - C12) + 
+                           (4 * C * A - B * B) * Math.abs(Math.log((2 * A12 + B / A12 + 2 * ABC12) / (B / A12 + 2 * C12))));
+  }
 
   if( canvasCxt.setLineDash ){ // for very outofdate browsers
     switch( type ){
@@ -121,6 +142,27 @@ CRp.drawEdgePath = function( edge, context, pts, type, width ){
       case 'solid':
         canvasCxt.setLineDash( [ ] );
         break;
+        
+      case 'break':
+        var length = 0;
+        switch ( rs.edgeType ){
+          case 'self':
+          case 'bezier':
+          case 'compound':
+          case 'multibezier':
+            for ( var i = 2; i + 3 < pts.length; i += 4 ) {
+              length += bezierLength( pts[i - 2], pts[i - 1], pts[i], pts[i + 1], pts[i+2],pts[i + 3] );
+            }
+            break;
+          case 'straight':
+          case 'haystack':
+            for( var i = 0; i + 3 < pts.length; i += 2 ){
+              length += Math.sqrt(Math.pow(pts[i] - pts[i+2],2) + Math.pow(pts[i+1] - pts[i+3],2));
+            }
+            break;
+        }
+        var fontsize = edge.pstyle( 'font-size' ) * 1.2;
+        canvasCxt.setLineDash( [ (length - fontsize) / 2 ,  fontsize ] );
     }
   }
 

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -38,7 +38,7 @@ var styfn = {};
     bgClip: { enums: [ 'none', 'node' ] },
     color: { color: true },
     bool: { enums: [ 'yes', 'no' ] },
-    lineStyle: { enums: [ 'solid', 'dotted', 'dashed' ] },
+    lineStyle: { enums: [ 'solid', 'dotted', 'dashed', 'break' ] },
     borderStyle: { enums: [ 'solid', 'dotted', 'dashed', 'double' ] },
     curveStyle: { enums: [ 'bezier', 'unbundled-bezier', 'haystack', 'segments' ] },
     fontFamily: { regex: '^([\\w- \\"]+(?:\\s*,\\s*[\\w- \\"]+)*)$' },


### PR DESCRIPTION
![capture1](https://cloud.githubusercontent.com/assets/20598703/17438712/4507547a-5af2-11e6-8e70-1c809efcd17a.PNG)
![capture2](https://cloud.githubusercontent.com/assets/20598703/17438713/450aff58-5af2-11e6-9bcd-f8a8009c1d99.PNG)

The gap in the middle of edges allow the user to read the labels more easily.
I tried this property with segment edge style, but it only works great when the zigzag section is symmetrical.