### PR TITLE
add 'destroy' event & provide info if already destroyed

### DIFF
--- a/documentation/md/events.md
+++ b/documentation/md/events.md
@@ -88,5 +88,6 @@ These events are custom to Cytoscape.js, and they occur on the core.
  * `layoutready` : when a layout has set initial positions for all the nodes (but perhaps not final positions)
  * `layoutstop` : when a layout has finished running completely or otherwise stopped running
  * `ready` : when a new instance of Cytoscape.js is ready to be interacted with
+ * `destroy` : when the instance of Cytoscape.js was explicitly destroyed by calling `.destroy()`.
  * `pan` : when the viewport is panned
  * `zoom` : when the viewport is zoomed

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -60,6 +60,7 @@ var Core = function( opts ){
     scratch: {}, // scratch object for core
     layout: null,
     renderer: null,
+    destroyed: false, // whether destroy was called
     notificationsEnabled: true, // whether notifications are sent to the renderer
     minZoom: 1e-50,
     maxZoom: 1e50,
@@ -177,6 +178,10 @@ util.extend( corefn, {
     return this._private.ready;
   },
 
+  isDestroyed: function(){
+    return this._private.destroyed;
+  },
+
   ready: function( fn ){
     if( this.isReady() ){
       this.trigger( 'ready', [], fn ); // just calls fn as though triggered via ready event
@@ -193,10 +198,15 @@ util.extend( corefn, {
 
   destroy: function(){
     var cy = this;
+    if( cy.isDestroyed() ) return;
 
     cy.stopAnimationLoop();
 
     cy.destroyRenderer();
+
+    this.trigger( 'destroy' );
+
+    cy._private.destroyed = true;
 
     return cy;
   },

--- a/test/events.js
+++ b/test/events.js
@@ -214,6 +214,14 @@ describe('Events', function(){
       expect( triggers ).to.equal(1);
     });
 
+    it('`destroy`', function(){
+      cy.on('destroy', handler);
+
+      cy.destroy();
+
+      expect( triggers ).to.equal(1);
+    });
+
   });
 
 


### PR DESCRIPTION
Adds a `destroy` event which is triggered right **after** the instance was destroyed.
Allows external loops (like animated layouts) to listen to calls of `.destroy()`. Should provide the basis for future fixes for #1499 and related issues.

In addition to the event this PR also adds an `isDestroyed()` method (similar to `isReady()`) to check the state. This also allows for `.destroy()` to get called multiple times, as they can be safely ignored.
