### PR TITLE
Remove image caching

### DIFF
--- a/src/extensions/renderer/base/images.js
+++ b/src/extensions/renderer/base/images.js
@@ -3,26 +3,12 @@
 var BRp = {};
 
 BRp.getCachedImage = function( url, onLoad ){
-  var r = this;
-  var imageCache = r.imageCache = r.imageCache || {};
-  var cache = imageCache[ url ];
+  var image = new Image(); // eslint-disable-line no-undef
+  image.addEventListener('load', onLoad);
+  image.crossOrigin = 'Anonymous'; // prevent tainted canvas
+  image.src = url;
 
-  if( cache ){
-    if( !cache.image.complete ){
-      cache.image.addEventListener('load', onLoad);
-    }
-
-    return cache.image;
-  } else {
-    cache = imageCache[ url ] = imageCache[ url ] || {};
-
-    var image = cache.image = new Image(); // eslint-disable-line no-undef
-    image.addEventListener('load', onLoad);
-    image.crossOrigin = 'Anonymous'; // prevent tainted canvas
-    image.src = url;
-
-    return image;
-  }
+  return image;
 };
 
 module.exports = BRp;


### PR DESCRIPTION
This will prevent cross site origin weirdness that we've seen trying to fetch images for the nodes.