### PR TITLE
`arrow-scale: multiplier` to control arrow size with a multiplier #884

### DIFF
--- a/src/extensions/renderer/canvas/drawing-edges.js
+++ b/src/extensions/renderer/canvas/drawing-edges.js
@@ -233,6 +233,8 @@ CRp.drawArrowShape = function( edge, arrowType, context, fill, edgeWidth, shape,
   var translation = { x: x, y: y };
   var size = this.getArrowWidth( edgeWidth );
   var shapeImpl = r.arrowShapes[ shape ];
+  
+  size *= (edge.pstyle('arrow-scale').value || 1);
 
   if( usePaths ){
     var pathCacheKey = size + '$' + shape + '$' + angle + '$' + x + '$' + y;

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -225,6 +225,7 @@ var styfn = {};
     { name: 'segment-distances', type: t.bidirectionalSizes },
     { name: 'segment-weights', type: t.numbers },
     { name: 'edge-distances', type: t.edgeDistances },
+    { name: 'arrow-scale', type: t.number},
     { name: 'edge-pointing-direction', type: t.edgeDirections },
     { name: 'loop-direction', type: t.angle },
     { name: 'loop-sweep', type: t.angle },

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -434,7 +434,8 @@ styfn.getDefaultProperties = util.memoize( function(){
     'edge-distances': 'intersection',
     'edge-pointing-direction': 'inside',
     'curve-style': 'bezier',
-    'haystack-radius': 0
+    'haystack-radius': 0,
+    'arrow-scale': 1
   }, [
     { name: 'arrow-shape', value: 'none' },
     { name: 'arrow-color', value: '#999' },


### PR DESCRIPTION
Please see #884