### PR TITLE
`min-width`, `min-height` properties for updating compound bounds. #1614

### DIFF
--- a/debug/init.js
+++ b/debug/init.js
@@ -148,6 +148,19 @@ $(function(){
         .css({
           'curve-style': 'bezier'
         })
+      .selector('node#n1')
+        .css({
+          // 'min-width': 400,
+          // 'min-width-bias-left': 30,
+          // 'min-width-bias-right': 60,
+          // 'padding-left': 0,
+          // 'padding-right': 0,
+          // 'padding-bottom': 0,
+          // 'padding-top': 0,
+          // 'min-height': 400,
+          // 'min-height-bias-top': 20,
+          // 'min-height-bias-bottom': 40
+        })
   ;
 
   window.options = {

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -232,6 +232,12 @@ var styfn = {};
     // compound props
     { name: 'position', type: t.position },
     { name: 'compound-sizing-wrt-labels', type: t.compoundIncludeLabels },
+    { name: 'min-width', type: t.size },
+    { name: 'min-width-bias-left', type: t.percent },
+    { name: 'min-width-bias-right', type: t.percent },
+    { name: 'min-height', type: t.size },
+    { name: 'min-height-bias-top', type: t.percent },
+    { name: 'min-height-bias-bottom', type: t.percent },
 
     // edge line
     { name: 'line-style', type: t.lineStyle },
@@ -425,7 +431,13 @@ styfn.getDefaultProperties = util.memoize( function(){
     'padding-left': 0,
     'padding-right': 0,
     'position': 'origin',
-    'compound-sizing-wrt-labels': 'include'
+    'compound-sizing-wrt-labels': 'include',
+    'min-width': 0,
+    'min-width-bias-left': 0,
+    'min-width-bias-right': 0,
+    'min-height': 0,
+    'min-height-bias-top': 0,
+    'min-height-bias-bottom': 0
   }, {
     // node pie bg
     'pie-size': '100%'


### PR DESCRIPTION
- adds optional min-width, min-height properties for compound nodes
- computes autoWidth based on maximum of the boundingBox and min-width/height values
- adds commented out properties to the init script in the debug app

@maxkfranz @metincansiper @ugurdogrusoz 
Related issues: 
https://github.com/cytoscape/cytoscape.js/issues/1614
https://github.com/iVis-at-Bilkent/chise.js/issues/66

**Testing**

I have tested the following cases on the debug app:

width:
* left-bias > right-bias
* right-bias > left-bias
* left-bias = right-bias
* the above cases applied with left-bias+right-bias > 100
* the above cases applied with left-bias+right-bias < 100
* case when padding is not 0
* case when left-bias + right-bias = 0

height:
* the same cases applied mentioned above applied to height and its associated properties

events:
* clicking outside of the compound bound does not select the compound
* clicking inside or on the compound boundary selects the compound
* selecting edges and child nodes in the compound selects the child/edge
* creating nodes inside the compound adjusts the compound correctly

**Demo**

You can view a demo of the changes here:

https://www.youtube.com/watch?v=1wwLdkjLlsU



