### PR TITLE
add px support for compound bias properties

### DIFF
--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -23,6 +23,7 @@ var styfn = {};
     zeroOneNumber: { number: true, min: 0, max: 1, unitless: true },
     nOneOneNumber: { number: true, min: -1, max: 1, unitless: true },
     nonNegativeInt: { number: true, min: 0, integer: true, unitless: true },
+    pxPercentSize: { number: true, min: 0, allowPercent: true },
     position: { enums: [ 'parent', 'origin' ] },
     nodeSize: { number: true, min: 0, enums: [ 'label' ] },
     number: { number: true, unitless: true },
@@ -230,11 +231,11 @@ var styfn = {};
     { name: 'position', type: t.position },
     { name: 'compound-sizing-wrt-labels', type: t.compoundIncludeLabels },
     { name: 'min-width', type: t.size },
-    { name: 'min-width-bias-left', type: t.percent },
-    { name: 'min-width-bias-right', type: t.percent },
+    { name: 'min-width-bias-left', type: t.pxPercentSize },
+    { name: 'min-width-bias-right', type: t.pxPercentSize },
     { name: 'min-height', type: t.size },
-    { name: 'min-height-bias-top', type: t.percent },
-    { name: 'min-height-bias-bottom', type: t.percent },
+    { name: 'min-height-bias-top', type: t.pxPercentSize },
+    { name: 'min-height-bias-bottom', type: t.pxPercentSize },
 
     // edge line
     { name: 'line-style', type: t.lineStyle },


### PR DESCRIPTION
## Functional Changes
* Adds px support for the min-\*-bias-\* property values for compound nodes

## Summary of Code Changes 
* Refactors the code in compoundBounds calculation to reduce the amount of repeated code
* Adds a new pxPercentSize property type -- a size type that also supports percentages 
* Px values for the bias fields are converted to percentages before the compoundBound calculation

## Testing

The following cases have been tested on the cytoscape.js debug app:

* min-width/min-height set to 0
  - bias values set to 0
  - bias values set > 0
* min-width set to > 0
  - left bias px + right bias % > min-width
  - left bias px + right bias % < min-width
  - left bias px + right bias % = min-width
  - left bias px + right bias px > min-width
  - left bias px + right bias px < min-width
  - left bias px + right bias px = min-width
  - left bias % + right bias % > 100%
  - left bias % + right bias % < 100%
  - left bias % + right bias % = 100%
* min-height set to > 0
  - top bias px + bottom bias % > min-height
  - top bias px + bottom bias % < min-height
  - top bias px + bottom bias % = min-height
  - top bias px + bottom bias px > min-height
  - top bias px + bottom bias px < min-height
  - top bias px + bottom bias px = min-height
  - top bias % + bottom bias % > 100%
  - top bias % + bottom bias % < 100%
  - top bias % + bottom bias % = 100%