### PR TITLE
Add scalingFactor for adjusting layouts post-calculation #1266

### DIFF
--- a/src/collection/layout.js
+++ b/src/collection/layout.js
@@ -22,6 +22,10 @@ var elesfn = ({
         var newPos = fn.call( node, i, node );
         var pos = node.position();
 
+        if( !is.number( pos.x ) || !is.number( pos.y ) ){
+          node.silentPosition( { x: 0, y: 0 } );
+        }
+
         if ( options.spacingFactor && options.spacingFactor !== 1){
           var spacing = Math.abs(options.spacingFactor);
           var nbb = nodes.boundingBox();
@@ -34,10 +38,6 @@ var elesfn = ({
             y: (newPos.y - center.y) * spacing
           };
           newPos = util.extend( {}, newPos, { x: center.x + spacingVector.x, y: center.y + spacingVector.y } );
-        }
-
-        if( !is.number( pos.x ) || !is.number( pos.y ) ){
-          node.silentPosition( { x: 0, y: 0 } );
         }
 
         var ani = node.animation( {

--- a/src/collection/layout.js
+++ b/src/collection/layout.js
@@ -22,9 +22,18 @@ var elesfn = ({
         var newPos = fn.call( node, i, node );
         var pos = node.position();
 
-        if ( options.scalingFactor && options.scalingFactor !== 1){
-          var scale = Math.abs(options.scalingFactor);
-          newPos = util.extend( {}, newPos, { x: newPos.x * scale, y: newPos.y * scale } );
+        if ( options.spacingFactor && options.spacingFactor !== 1){
+          var spacing = Math.abs(options.spacingFactor);
+          var nbb = nodes.boundingBox();
+          var center = {
+            x: nbb.x1 + nbb.w / 2,
+            y: nbb.y1 + nbb.h / 2
+          };
+          var spacingVector = { // scale the spacing from center of bounding box (not necessarily 0,0)
+            x: (newPos.x - center.x) * spacing,
+            y: (newPos.y - center.y) * spacing
+          };
+          newPos = util.extend( {}, newPos, { x: center.x + spacingVector.x, y: center.y + spacingVector.y } );
         }
 
         if( !is.number( pos.x ) || !is.number( pos.y ) ){
@@ -79,13 +88,22 @@ var elesfn = ({
     } else {
       nodes.positions( fn );
 
-      if ( options.scalingFactor && options.scalingFactor !== 1){
-        nodes.positions( function( i, node ){
+      if ( options.spacingFactor && options.spacingFactor !== 1){
+        var spacing = Math.abs(options.spacingFactor);
+        nodes.positions( function (i, node){
           var pos = node.position();
-          var scale = Math.abs(options.scalingFactor);
+          var nbb = nodes.boundingBox();
+          var center = {
+            x: nbb.x1 + nbb.w / 2,
+            y: nbb.y1 + nbb.h / 2
+          };
+          var scaleVector = { // scale from center of bounding box (not necessarily 0,0)
+            x: (pos.x - center.x) * spacing,
+            y: (pos.y - center.y) * spacing
+          };
           return {
-            x: pos.x * scale,
-            y: pos.y * scale
+            x: center.x + scaleVector.x,
+            y: center.y + scaleVector.y
           };
         });
       }

--- a/src/collection/layout.js
+++ b/src/collection/layout.js
@@ -93,15 +93,15 @@ var elesfn = ({
         layout.trigger( { type: 'layoutstop', layout: layout } );
       });
     } else {
-      nodes.positions( fn );
-
-      if ( options.spacingFactor && options.spacingFactor !== 1){
+      if( options.spacingFactor && options.spacingFactor !== 1){
         var spacing = Math.abs(options.spacingFactor);
         nodes.positions( function( i, node){
-          var pos = node.position();
+          var pos = fn( i, node);
           var nodesBb = nodes.boundingBox();
           return calculateSpacing(spacing, nodesBb, pos);
         });
+      } else {
+        nodes.positions(fn);
       }
 
       if( options.fit ){

--- a/src/collection/layout.js
+++ b/src/collection/layout.js
@@ -15,6 +15,22 @@ var elesfn = ({
 
     layout.animations = [];
 
+    var calculateSpacing = function( spacing, nodes, pos ){
+      var nbb = nodes.boundingBox();
+      var center = {
+        x: nbb.x1 + nbb.w / 2,
+        y: nbb.y1 + nbb.h / 2
+      };
+      var spacingVector = { // scale from center of bounding box (not necessarily 0,0)
+        x: (pos.x - center.x) * spacing,
+        y: (pos.y - center.y) * spacing
+      };
+      return {
+        x: center.x + spacingVector.x,
+        y: center.y + spacingVector.y
+      };
+    };
+
     if( options.animate ){
       for( var i = 0; i < nodes.length; i++ ){
         var node = nodes[ i ];
@@ -28,16 +44,7 @@ var elesfn = ({
 
         if ( options.spacingFactor && options.spacingFactor !== 1){
           var spacing = Math.abs(options.spacingFactor);
-          var nbb = nodes.boundingBox();
-          var center = {
-            x: nbb.x1 + nbb.w / 2,
-            y: nbb.y1 + nbb.h / 2
-          };
-          var spacingVector = { // scale the spacing from center of bounding box (not necessarily 0,0)
-            x: (newPos.x - center.x) * spacing,
-            y: (newPos.y - center.y) * spacing
-          };
-          newPos = util.extend( {}, newPos, { x: center.x + spacingVector.x, y: center.y + spacingVector.y } );
+          newPos = calculateSpacing(spacing, nodes, newPos);
         }
 
         var ani = node.animation( {
@@ -90,21 +97,9 @@ var elesfn = ({
 
       if ( options.spacingFactor && options.spacingFactor !== 1){
         var spacing = Math.abs(options.spacingFactor);
-        nodes.positions( function (i, node){
+        nodes.positions( function( i, node){
           var pos = node.position();
-          var nbb = nodes.boundingBox();
-          var center = {
-            x: nbb.x1 + nbb.w / 2,
-            y: nbb.y1 + nbb.h / 2
-          };
-          var scaleVector = { // scale from center of bounding box (not necessarily 0,0)
-            x: (pos.x - center.x) * spacing,
-            y: (pos.y - center.y) * spacing
-          };
-          return {
-            x: center.x + scaleVector.x,
-            y: center.y + scaleVector.y
-          };
+          return calculateSpacing(spacing, nodes, pos);
         });
       }
 

--- a/src/collection/layout.js
+++ b/src/collection/layout.js
@@ -22,6 +22,11 @@ var elesfn = ({
         var newPos = fn.call( node, i, node );
         var pos = node.position();
 
+        if ( options.scalingFactor && options.scalingFactor !== 1){
+          var scale = Math.abs(options.scalingFactor);
+          newPos = util.extend( {}, newPos, { x: newPos.x * scale, y: newPos.y * scale } );
+        }
+
         if( !is.number( pos.x ) || !is.number( pos.y ) ){
           node.silentPosition( { x: 0, y: 0 } );
         }
@@ -73,6 +78,17 @@ var elesfn = ({
       });
     } else {
       nodes.positions( fn );
+
+      if ( options.scalingFactor && options.scalingFactor !== 1){
+        nodes.positions( function( i, node ){
+          var pos = node.position();
+          var scale = Math.abs(options.scalingFactor);
+          return {
+            x: pos.x * scale,
+            y: pos.y * scale
+          };
+        });
+      }
 
       if( options.fit ){
         cy.fit( options.eles, options.padding );

--- a/src/collection/layout.js
+++ b/src/collection/layout.js
@@ -15,11 +15,10 @@ var elesfn = ({
 
     layout.animations = [];
 
-    var calculateSpacing = function( spacing, nodes, pos ){
-      var nbb = nodes.boundingBox();
+    var calculateSpacing = function( spacing, nodesBb, pos ){
       var center = {
-        x: nbb.x1 + nbb.w / 2,
-        y: nbb.y1 + nbb.h / 2
+        x: nodesBb.x1 + nodesBb.w / 2,
+        y: nodesBb.y1 + nodesBb.h / 2
       };
       var spacingVector = { // scale from center of bounding box (not necessarily 0,0)
         x: (pos.x - center.x) * spacing,
@@ -32,6 +31,7 @@ var elesfn = ({
     };
 
     if( options.animate ){
+      var nodesBb = nodes.boundingBox();
       for( var i = 0; i < nodes.length; i++ ){
         var node = nodes[ i ];
 
@@ -44,7 +44,7 @@ var elesfn = ({
 
         if ( options.spacingFactor && options.spacingFactor !== 1){
           var spacing = Math.abs(options.spacingFactor);
-          newPos = calculateSpacing(spacing, nodes, newPos);
+          newPos = calculateSpacing(spacing, nodesBb, newPos);
         }
 
         var ani = node.animation( {
@@ -99,7 +99,8 @@ var elesfn = ({
         var spacing = Math.abs(options.spacingFactor);
         nodes.positions( function( i, node){
           var pos = node.position();
-          return calculateSpacing(spacing, nodes, pos);
+          var nodesBb = nodes.boundingBox();
+          return calculateSpacing(spacing, nodesBb, pos);
         });
       }
 

--- a/src/collection/layout.js
+++ b/src/collection/layout.js
@@ -93,15 +93,15 @@ var elesfn = ({
         layout.trigger( { type: 'layoutstop', layout: layout } );
       });
     } else {
-      if( options.spacingFactor && options.spacingFactor !== 1){
-        var spacing = Math.abs(options.spacingFactor);
-        nodes.positions( function( i, node){
-          var pos = fn( i, node);
+      if( options.spacingFactor && options.spacingFactor !== 1 ){
+        var spacing = Math.abs( options.spacingFactor );
+        nodes.positions( function( i, node ){
+          var pos = fn( i, node );
           var nodesBb = nodes.boundingBox();
-          return calculateSpacing(spacing, nodesBb, pos);
+          return calculateSpacing( spacing, nodesBb, pos );
         });
       } else {
-        nodes.positions(fn);
+        nodes.positions( fn );
       }
 
       if( options.fit ){

--- a/src/extensions/layout/breadthfirst.js
+++ b/src/extensions/layout/breadthfirst.js
@@ -10,7 +10,6 @@ var defaults = {
   padding: 30, // padding on fit
   circle: false, // put depths in concentric circles if true, put depths top down if false
   spacingFactor: 1.75, // positive spacing factor, larger => more space between nodes (N.B. n/a if causes overlap)
-  scalingFactor: undefined, // Applies a multiplicative factor (>0) to expand or compress the overall area that the nodes take up
   boundingBox: undefined, // constrain layout bounds; { x1, y1, x2, y2 } or { x1, y1, w, h }
   avoidOverlap: true, // prevents node overlap, may overflow boundingBox if not enough space
   roots: undefined, // the roots of the trees
@@ -281,7 +280,6 @@ BreadthFirstLayout.prototype.run = function(){
 
       minDistance = Math.max( minDistance, w, h );
     }
-    minDistance *= options.spacingFactor; // just to have some nice spacing
   }
 
   // get the weighted percent for an element based on its connectivity to other levels

--- a/src/extensions/layout/breadthfirst.js
+++ b/src/extensions/layout/breadthfirst.js
@@ -10,6 +10,7 @@ var defaults = {
   padding: 30, // padding on fit
   circle: false, // put depths in concentric circles if true, put depths top down if false
   spacingFactor: 1.75, // positive spacing factor, larger => more space between nodes (N.B. n/a if causes overlap)
+  scalingFactor: undefined, // Applies a multiplicative factor (>0) to expand or compress the overall area that the nodes take up
   boundingBox: undefined, // constrain layout bounds; { x1, y1, x2, y2 } or { x1, y1, w, h }
   avoidOverlap: true, // prevents node overlap, may overflow boundingBox if not enough space
   roots: undefined, // the roots of the trees

--- a/src/extensions/layout/circle.js
+++ b/src/extensions/layout/circle.js
@@ -9,7 +9,7 @@ var defaults = {
   padding: 30, // the padding on fit
   boundingBox: undefined, // constrain layout bounds; { x1, y1, x2, y2 } or { x1, y1, w, h }
   avoidOverlap: true, // prevents node overlap, may overflow boundingBox and radius if not enough space
-  scalingFactor: undefined, // Applies a multiplicative factor (>0) to expand or compress the overall area that the nodes take up
+  spacingFactor: undefined, // Applies a multiplicative factor (>0) to expand or compress the overall area that the nodes take up
   radius: undefined, // the radius of the circle
   startAngle: 3 / 2 * Math.PI, // where nodes start in radians
   sweep: undefined, // how many radians should be between the first and last node (defaults to full circle)

--- a/src/extensions/layout/circle.js
+++ b/src/extensions/layout/circle.js
@@ -9,6 +9,7 @@ var defaults = {
   padding: 30, // the padding on fit
   boundingBox: undefined, // constrain layout bounds; { x1, y1, x2, y2 } or { x1, y1, w, h }
   avoidOverlap: true, // prevents node overlap, may overflow boundingBox and radius if not enough space
+  scalingFactor: undefined, // Applies a multiplicative factor (>0) to expand or compress the overall area that the nodes take up
   radius: undefined, // the radius of the circle
   startAngle: 3 / 2 * Math.PI, // where nodes start in radians
   sweep: undefined, // how many radians should be between the first and last node (defaults to full circle)

--- a/src/extensions/layout/concentric.js
+++ b/src/extensions/layout/concentric.js
@@ -15,7 +15,7 @@ var defaults = {
   avoidOverlap: true, // prevents node overlap, may overflow boundingBox if not enough space
   height: undefined, // height of layout area (overrides container height)
   width: undefined, // width of layout area (overrides container width)
-  scalingFactor: undefined, // Applies a multiplicative factor (>0) to expand or compress the overall area that the nodes take up  
+  spacingFactor: undefined, // Applies a multiplicative factor (>0) to expand or compress the overall area that the nodes take up  
   concentric: function( node ){ // returns numeric value for each node, placing higher nodes in levels towards the centre
     return node.degree();
   },

--- a/src/extensions/layout/concentric.js
+++ b/src/extensions/layout/concentric.js
@@ -15,6 +15,7 @@ var defaults = {
   avoidOverlap: true, // prevents node overlap, may overflow boundingBox if not enough space
   height: undefined, // height of layout area (overrides container height)
   width: undefined, // width of layout area (overrides container width)
+  scalingFactor: undefined, // Applies a multiplicative factor (>0) to expand or compress the overall area that the nodes take up  
   concentric: function( node ){ // returns numeric value for each node, placing higher nodes in levels towards the centre
     return node.degree();
   },

--- a/src/extensions/layout/cose.js
+++ b/src/extensions/layout/cose.js
@@ -87,7 +87,7 @@ var defaults = {
   useMultitasking: true,
 
   // Applies a multiplicative factor (>0) to expand or compress the overall area that the nodes take up
-  scalingFactor: undefined
+  spacingFactor: undefined
 };
 
 

--- a/src/extensions/layout/cose.js
+++ b/src/extensions/layout/cose.js
@@ -84,7 +84,10 @@ var defaults = {
   minTemp: 1.0,
 
   // Whether to use threading to speed up the layout
-  useMultitasking: true
+  useMultitasking: true,
+
+  // Applies a multiplicative factor (>0) to expand or compress the overall area that the nodes take up
+  scalingFactor: undefined
 };
 
 

--- a/src/extensions/layout/grid.js
+++ b/src/extensions/layout/grid.js
@@ -9,6 +9,7 @@ var defaults = {
   boundingBox: undefined, // constrain layout bounds; { x1, y1, x2, y2 } or { x1, y1, w, h }
   avoidOverlap: true, // prevents node overlap, may overflow boundingBox if not enough space
   avoidOverlapPadding: 10, // extra spacing around nodes when avoidOverlap: true
+  scalingFactor: undefined, // Applies a multiplicative factor (>0) to expand or compress the overall area that the nodes take up
   condense: false, // uses all available space on false, uses minimal space on true
   rows: undefined, // force num of rows in the grid
   cols: undefined, // force num of columns in the grid

--- a/src/extensions/layout/grid.js
+++ b/src/extensions/layout/grid.js
@@ -9,7 +9,7 @@ var defaults = {
   boundingBox: undefined, // constrain layout bounds; { x1, y1, x2, y2 } or { x1, y1, w, h }
   avoidOverlap: true, // prevents node overlap, may overflow boundingBox if not enough space
   avoidOverlapPadding: 10, // extra spacing around nodes when avoidOverlap: true
-  scalingFactor: undefined, // Applies a multiplicative factor (>0) to expand or compress the overall area that the nodes take up
+  spacingFactor: undefined, // Applies a multiplicative factor (>0) to expand or compress the overall area that the nodes take up
   condense: false, // uses all available space on false, uses minimal space on true
   rows: undefined, // force num of rows in the grid
   cols: undefined, // force num of columns in the grid


### PR DESCRIPTION
I've tentatively named the option scalingFactor rather than spacingFactor as the `breadthfirst` layout option already includes a spacingFactor option. This PR adds a `scalingFactor` option that multiplies the layout-calculated position of the node by the (absolute value of the) `scalingFactor` to produce a final position to be rendered. 

Ex: a layout which spaces nodes out by 50px will have 100px gaps between nodes when `scalingFactor` is 2.