### PR TITLE
Triangle-cross arrowhead

### DIFF
--- a/src/extensions/renderer/base/arrow-shapes.js
+++ b/src/extensions/renderer/base/arrow-shapes.js
@@ -191,6 +191,60 @@ BRp.registerArrowShapes = function(){
     }
   } );
 
+  defineArrowShape( 'triangle-cross', {
+    points: [
+      -0.15, -0.3,
+      0, 0,
+      0.15, -0.3,
+      -0.15, -0.3
+    ],
+
+    crossLinePoints: [
+      -0.24175, -0.4,
+      0.24175, -0.4,
+    ],
+
+    forceStroke: true,
+
+    matchEdgeWidth: true,
+
+    scaleCoord: function ( constant, size, edgeWidth ){
+     return constant + ( edgeWidth * 0.012 ) + ( math.log2( size - 28.95 ) * 0.001 );
+    },
+
+   scaleCrossLineXCoord: function( size, edgeWidth ){
+      return this.scaleCoord( 0.42, size, edgeWidth );
+    },
+
+    scaleCrossLineYCoord: function( size, edgeWidth ){
+      return this.scaleCoord( -0.01, size, edgeWidth );
+    },
+
+    collide: function( x, y, size, angle, translation, padding ){
+      var triPts = pointsToArr( transformPoints( this.points, size + 2 * padding, angle, translation ) );
+      var crossLinePts = pointsToArr( transformPoints( this.crossLinePoints, size + 2 * padding, angle, translation ) );
+
+      var inside = math.pointInsidePolygonPoints( x, y, triPts )
+      || math.inLineVicinity( x, y,
+        crossLinePts[0], crossLinePts[1], crossLinePts[2], crossLinePts[3], padding );
+
+      return inside;
+    },
+
+    draw: function( context, size, angle, translation, edgeWidth ){
+      var scaledCrossLine = [
+        this.crossLinePoints[0] + this.scaleCrossLineXCoord( size, edgeWidth ),
+        this.crossLinePoints[1] - this.scaleCrossLineYCoord( size, edgeWidth ),
+        this.crossLinePoints[2] - this.scaleCrossLineXCoord( size, edgeWidth ),
+        this.crossLinePoints[3] - this.scaleCrossLineYCoord( size, edgeWidth )
+      ];
+      var triPts = transformPoints( this.points, size, angle, translation );
+      var crossLinePts = transformPoints( scaledCrossLine, size, angle, translation );
+
+      renderer.arrowShapeImpl( this.name )( context, triPts, crossLinePts );
+    }
+  } );
+
   defineArrowShape( 'vee', {
     points: [
       -0.15, -0.3,

--- a/src/extensions/renderer/canvas/arrow-shapes.js
+++ b/src/extensions/renderer/canvas/arrow-shapes.js
@@ -53,7 +53,33 @@ CRp.arrowShapeImpl = function( name ){
 
           context.lineTo( pt.x, pt.y );
         }
+      if( context.closePath ){ context.closePath(); }
+    },
 
+    'triangle-cross': function( context, trianglePoints, crossLinePoints ){
+      if( context.beginPath ){ context.beginPath(); }
+
+        var triPts = trianglePoints;
+        for( var i = 0; i < triPts.length; i++ ){
+          var pt = triPts[ i ];
+
+          context.lineTo( pt.x, pt.y );
+        }
+
+      if( context.closePath ){ context.closePath(); }
+
+
+      if( context.beginPath ){ context.beginPath(); }
+
+      var crossLinePts = crossLinePoints;
+      var firstTeePt = crossLinePoints[0];
+      context.moveTo( firstTeePt.x, firstTeePt.y );
+
+      for( var i = 0; i < crossLinePts.length; i++ ){
+        var pt = crossLinePts[ i ];
+
+        context.lineTo( pt.x, pt.y );
+      }
       if( context.closePath ){ context.closePath(); }
     },
 

--- a/src/extensions/renderer/canvas/drawing-edges.js
+++ b/src/extensions/renderer/canvas/drawing-edges.js
@@ -183,20 +183,20 @@ CRp.drawArrowhead = function( context, edge, prefix, x, y, angle ){
 
   var self = this;
   var arrowShape = edge.pstyle( prefix + '-arrow-shape' ).value;
-
-  if( arrowShape === 'none' ){
-    return;
-  }
-
-  var gco = context.globalCompositeOperation;
+  if( arrowShape === 'none' ) { return; }
 
   var arrowClearFill = edge.pstyle( prefix + '-arrow-fill' ).value === 'hollow' ? 'both' : 'filled';
   var arrowFill = edge.pstyle( prefix + '-arrow-fill' ).value;
+  var edgeWidth = edge.pstyle( 'width' ).pfValue;
   var opacity = edge.pstyle( 'opacity' ).value;
 
-  if( arrowShape === 'half-triangle-overshot' ){
-    arrowFill = 'hollow';
-    arrowClearFill = 'hollow';
+  var gco = context.globalCompositeOperation;
+
+  var shapeImpl = self.arrowShapes[ arrowShape ];
+
+  // check if the shape needs both fill and stroke operations to be drawn
+  if( shapeImpl.forceStroke && arrowFill === 'filled' ){
+    arrowFill = 'both';
   }
 
   if( opacity !== 1 || arrowFill === 'hollow' ){ // then extra clear is needed
@@ -206,8 +206,7 @@ CRp.drawArrowhead = function( context, edge, prefix, x, y, angle ){
     self.strokeStyle( context, 255, 255, 255, 1 );
 
     self.drawArrowShape( edge, prefix, context,
-      arrowClearFill, edge.pstyle( 'width' ).pfValue, edge.pstyle( prefix + '-arrow-shape' ).value,
-      x, y, angle
+      arrowClearFill, edgeWidth, arrowShape, x, y, angle
     );
 
     context.globalCompositeOperation = gco;
@@ -218,8 +217,7 @@ CRp.drawArrowhead = function( context, edge, prefix, x, y, angle ){
   self.strokeStyle( context, color[0], color[1], color[2], opacity );
 
   self.drawArrowShape( edge, prefix, context,
-    arrowFill, edge.pstyle( 'width' ).pfValue, edge.pstyle( prefix + '-arrow-shape' ).value,
-    x, y, angle
+    arrowFill, edgeWidth, arrowShape, x, y, angle
   );
 };
 
@@ -254,7 +252,7 @@ CRp.drawArrowShape = function( edge, arrowType, context, fill, edgeWidth, shape,
   if( context.beginPath ){ context.beginPath(); }
 
   if( !pathCacheHit ){
-    shapeImpl.draw( context, size, angle, translation );
+    shapeImpl.draw( context, size, angle, translation, edgeWidth );
   }
 
   if( !shapeImpl.leavePathOpen && context.closePath ){
@@ -280,7 +278,6 @@ CRp.drawArrowShape = function( edge, arrowType, context, fill, edgeWidth, shape,
     } else {
       context.stroke();
     }
-
   }
 };
 

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -54,7 +54,7 @@ var styfn = {};
     textBackgroundShape: { enums: [ 'rectangle', 'roundrectangle' ]},
     nodeShape: { enums: [ 'rectangle', 'roundrectangle', 'ellipse', 'triangle', 'square', 'pentagon', 'hexagon', 'heptagon', 'octagon', 'star', 'diamond', 'vee', 'rhomboid', 'polygon' ] },
     compoundIncludeLabels: { enums: [ 'include', 'exclude' ] },
-    arrowShape: { enums: [ 'tee', 'triangle', 'triangle-tee', 'triangle-backcurve', 'half-triangle-overshot', 'vee', 'square', 'circle', 'diamond', 'none' ] },
+    arrowShape: { enums: [ 'tee', 'triangle', 'triangle-tee', 'triangle-cross', 'triangle-backcurve', 'half-triangle-overshot', 'vee', 'square', 'circle', 'diamond', 'none' ] },
     arrowFill: { enums: [ 'filled', 'hollow' ] },
     display: { enums: [ 'element', 'none' ] },
     visibility: { enums: [ 'hidden', 'visible' ] },


### PR DESCRIPTION
## High Level Overview

- implements a new arrow head shape called 'triangle-cross'
- collision detection using inline vicinity
- scales arrow size based on edge width and size


## Miscellaneous Changes

- removes explicit arrowShape check for 'half-triangle-overshot' in the drawArrowHead function
- reuses arrowWidth and arrowShape variables that were already computed at the beginning of the drawArrowHead function
- shapeImpl.draw takes edgeWidth as a parameter for arrow scaling

See https://github.com/cytoscape/cytoscape.js/issues/1656