### PR TITLE
Update gap calculation for triangle-backcurve and vee

### DIFF
--- a/src/extensions/renderer/base/arrow-shapes.js
+++ b/src/extensions/renderer/base/arrow-shapes.js
@@ -76,6 +76,10 @@ BRp.registerArrowShapes = function(){
     return ret;
   };
 
+  var standardGap = function( edge ) {
+    return edge.pstyle( 'width' ).pfValue * edge.pstyle( 'arrow-scale' ).pfValue * 2;
+  };
+
   var defineArrowShape = function( name, defn ){
     if( is.string( defn ) ){
       defn = arrowShapes[ defn ];
@@ -110,9 +114,7 @@ BRp.registerArrowShapes = function(){
         return 0;
       },
 
-      gap: function( edge ){
-        return edge.pstyle( 'width' ).pfValue * 2 * edge.pstyle( 'arrow-scale' ).pfValue;
-      }
+      gap: standardGap
     }, defn );
   };
 
@@ -153,8 +155,8 @@ BRp.registerArrowShapes = function(){
       renderer.arrowShapeImpl( this.name )( context, ptsTrans, ctrlPtTrans );
     },
 
-    gap: function( edge ){
-      return edge.pstyle( 'width' ).pfValue * edge.pstyle( 'arrow-scale' ).pfValue;
+    gap: function( edge ) {
+      return standardGap(edge) * 0.985;
     }
   } );
 

--- a/src/extensions/renderer/base/arrow-shapes.js
+++ b/src/extensions/renderer/base/arrow-shapes.js
@@ -202,7 +202,7 @@ BRp.registerArrowShapes = function(){
     ],
 
     gap: function( edge ){
-      return edge.pstyle( 'width' ).pfValue * edge.pstyle( 'arrow-scale' ).pfValue;
+      return standardGap(edge) * 0.985;
     }
   } );
 


### PR DESCRIPTION
Update to #1672. Produces good results for `arrow-scale` > 0.5. Below 0.5 scaling, the edges of the edge will protrude from the side of the `triangle-backcurve` shape (as well as the `vee` shape). The scaling value of 0.985 (times the standard scaling value) is a trade-off made for all shapes with concave bases.

As scaling values approach 0, the shape becomes significantly smaller than its edge, so it becomes impossible to fully hide the edge behind the arrow (and placing the shape at the tip of the edge, as is done for other shapes, leaves empty space in the concave region of the shapes). 

Demo of new changes: http://jsfiddle.net/josephst18/rkd4bLs4/8/