### PR TITLE
add documentation for the render event

### DIFF
--- a/documentation/md/events.md
+++ b/documentation/md/events.md
@@ -88,5 +88,6 @@ These events are custom to Cytoscape.js, and they occur on the core.
  * `layoutready` : when a layout has set initial positions for all the nodes (but perhaps not final positions)
  * `layoutstop` : when a layout has finished running completely or otherwise stopped running
  * `ready` : when a new instance of Cytoscape.js is ready to be interacted with
+ * `render` : when the viewport is (re)rendered
  * `pan` : when the viewport is panned
  * `zoom` : when the viewport is zoomed


### PR DESCRIPTION
`onRender()` and `offRender()` are being replaced by using the `render` event #1541 

In Cytoscape.js v3, `onRender(fn)` should be `cy.on('render', fn)`.