### PR TITLE
Fixed bug which prevents layouts from taking initial positions

### DIFF
--- a/src/core/layout.js
+++ b/src/core/layout.js
@@ -38,6 +38,8 @@ var corefn = ({
       eles: eles
     } ) );
 
+    layout.run();
+
     return layout;
   }
 


### PR DESCRIPTION
Try to run the automove extension using cytoscape 3.x to see the problem. All nodes are piled on top of each other.