### PR TITLE
implements cutrectangle node shape

### DIFF
--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -148,7 +148,7 @@ Shape:
 
  * **`width`** : The width of the node's body.  This property can take on the special value `label` so the width is automatically based on the node's label.
  * **`height`** : The height of the node's body.  This property can take on the special value `label` so the height is automatically based on the node's label.
- * **`shape`** : The shape of the node's body; may be `rectangle`, `roundrectangle`, `ellipse`, `triangle`, `pentagon`, `hexagon`, `heptagon`, `octagon`, `star`, `diamond`, `vee`, `rhomboid`, or `polygon` (custom polygon specified via `shape-polygon-points`).  Note that each shape fits within the specified `width` and `height`, and so you may have to adjust `width` and `height` if you desire an equilateral shape (i.e. `width !== height` for several equilateral shapes).
+ * **`shape`** : The shape of the node's body; may be `rectangle`, `roundrectangle`, `cutrectangle`, `ellipse`, `triangle`, `pentagon`, `hexagon`, `heptagon`, `octagon`, `star`, `diamond`, `vee`, `rhomboid`, or `polygon` (custom polygon specified via `shape-polygon-points`).  Note that each shape fits within the specified `width` and `height`, and so you may have to adjust `width` and `height` if you desire an equilateral shape (i.e. `width !== height` for several equilateral shapes).
  * **`shape-polygon-points`** : A space-separated list of numbers ranging on [-1, 1], representing alternating x and y values (i.e. `x1 y1   x2 y2,   x3 y3 ...`).  This represents the points in the polygon for the node's shape.  The bounding box of the node is given by (-1, -1), (1, -1), (1, 1), (-1, 1).
 
 Background:

--- a/src/extensions/renderer/base/coord-ele-math.js
+++ b/src/extensions/renderer/base/coord-ele-math.js
@@ -563,7 +563,9 @@ BRp.getNodeShape = function( node ){
   var shape = node.pstyle( 'shape' ).value;
 
   if( node.isParent() ){
-    if( shape === 'rectangle' || shape === 'roundrectangle' ){
+    if( shape === 'rectangle'
+    || shape === 'roundrectangle'
+    || shape === 'cutrectangle' ){
       return shape;
     } else {
       return 'rectangle';

--- a/src/extensions/renderer/canvas/drawing-shapes.js
+++ b/src/extensions/renderer/canvas/drawing-shapes.js
@@ -49,6 +49,28 @@ CRp.drawRoundRectanglePath = function(
   context.closePath();
 };
 
+CRp.drawCutRectanglePath = function(
+  context, x, y, width, height ){
+
+    var halfWidth = width / 2;
+    var halfHeight = height / 2;
+    var cornerLength = math.getCutRectangleCornerLength();
+
+    if( context.beginPath ){ context.beginPath(); }
+
+    context.moveTo( x - halfWidth + cornerLength, y - halfHeight );
+
+    context.lineTo( x + halfWidth - cornerLength, y - halfHeight );
+    context.lineTo( x + halfWidth, y - halfHeight + cornerLength );
+    context.lineTo( x + halfWidth, y + halfHeight - cornerLength );
+    context.lineTo( x + halfWidth - cornerLength, y + halfHeight );
+    context.lineTo( x - halfWidth + cornerLength,  y + halfHeight );
+    context.lineTo( x - halfWidth, y + halfHeight - cornerLength );
+    context.lineTo( x - halfWidth, y - halfHeight + cornerLength );
+
+    context.closePath();
+};
+
 var sin0 = Math.sin( 0 );
 var cos0 = Math.cos( 0 );
 

--- a/src/extensions/renderer/canvas/node-shapes.js
+++ b/src/extensions/renderer/canvas/node-shapes.js
@@ -10,6 +10,8 @@ CRp.nodeShapeImpl = function( name, context, centerX, centerY, width, height, po
       return this.drawPolygonPath( context, centerX, centerY, width, height, points );
     case 'roundrectangle':
       return this.drawRoundRectanglePath( context, centerX, centerY, width, height );
+    case 'cutrectangle':
+      return this.drawCutRectanglePath( context, centerX, centerY, width, height );
   }
 };
 

--- a/src/math.js
+++ b/src/math.js
@@ -827,7 +827,12 @@ math.midOfThree = function( a, b, c ){
   }
 };
 
-math.finiteLinesIntersect = function( x1, y1, x2, y2, x3, y3, x4, y4, infiniteLines ){
+// (x1,y1)=>(x2,y2) intersect with (x3,y3)=>(x4,y4)
+math.finiteLinesIntersect = function(
+  x1, y1, x2, y2,
+  x3, y3, x4, y4,
+  infiniteLines
+){
 
   var dx13 = x1 - x3;
   var dx21 = x2 - x1;
@@ -888,6 +893,11 @@ math.finiteLinesIntersect = function( x1, y1, x2, y2, x3, y3, x4, y4, infiniteLi
   }
 };
 
+// math.polygonIntersectLine( x, y, basePoints, centerX, centerY, width, height, padding )
+// intersect a node polygon (pts transformed)
+//
+// math.polygonIntersectLine( x, y, basePoints, centerX, centerY )
+// intersect the points (no transform)
 math.polygonIntersectLine = function(
   x, y, basePoints, centerX, centerY, width, height, padding ){
 
@@ -896,23 +906,31 @@ math.polygonIntersectLine = function(
 
   var transformedPoints = new Array( basePoints.length );
 
-  for( var i = 0; i < transformedPoints.length / 2; i++ ){
-    transformedPoints[ i * 2] = basePoints[ i * 2] * width + centerX;
-    transformedPoints[ i * 2 + 1] = basePoints[ i * 2 + 1] * height + centerY;
+  var doTransform = true;
+  if( arguments.length === 5 ){
+    doTransform = false;
   }
 
   var points;
 
-  if( padding > 0 ){
-    var expandedLineSet = math.expandPolygon(
-      transformedPoints,
-      -padding );
+  if( doTransform ){
+    for( var i = 0; i < transformedPoints.length / 2; i++ ){
+      transformedPoints[ i * 2] = basePoints[ i * 2] * width + centerX;
+      transformedPoints[ i * 2 + 1] = basePoints[ i * 2 + 1] * height + centerY;
+    }
 
-    points = math.joinLines( expandedLineSet );
+    if( padding > 0 ){
+      var expandedLineSet = math.expandPolygon(
+        transformedPoints,
+        -padding );
+
+      points = math.joinLines( expandedLineSet );
+    } else {
+      points = transformedPoints;
+    }
   } else {
-    points = transformedPoints;
+    points = basePoints;
   }
-  // var points = transformedPoints;
 
   var currentX, currentY, nextX, nextY;
 
@@ -1028,6 +1046,10 @@ math.getRoundRectangleRadius = function( width, height ){
 
   // Set the default radius, unless half of width or height is smaller than default
   return Math.min( width / 4, height / 4, 8 );
+};
+
+math.getCutRectangleCornerLength = function(){
+  return 8;
 };
 
 module.exports = math;

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -59,7 +59,7 @@ var styfn = {};
     textTransform: { enums: [ 'none', 'uppercase', 'lowercase' ] },
     textWrap: { enums: [ 'none', 'wrap', 'ellipsis' ] },
     textBackgroundShape: { enums: [ 'rectangle', 'roundrectangle' ]},
-    nodeShape: { enums: [ 'rectangle', 'roundrectangle', 'ellipse', 'triangle', 'square', 'pentagon', 'hexagon', 'heptagon', 'octagon', 'star', 'diamond', 'vee', 'rhomboid', 'polygon' ] },
+    nodeShape: { enums: [ 'rectangle', 'roundrectangle', 'cutrectangle', 'ellipse', 'triangle', 'square', 'pentagon', 'hexagon', 'heptagon', 'octagon', 'star', 'diamond', 'vee', 'rhomboid', 'polygon' ] },
     compoundIncludeLabels: { enums: [ 'include', 'exclude' ] },
     arrowShape: { enums: [ 'tee', 'triangle', 'triangle-tee', 'triangle-cross', 'triangle-backcurve', 'half-triangle-overshot', 'vee', 'square', 'circle', 'diamond', 'none' ] },
     arrowFill: { enums: [ 'filled', 'hollow' ] },

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -120,6 +120,11 @@ util.clearArray = function( arr ){
   arr.splice( 0, arr.length );
 };
 
+util.push = function( arr ){
+  var args = Array.prototype.slice.call( arguments, 1 );
+  Array.prototype.push.apply( arr, args );
+};
+
 util.getPrefixedProperty = function( obj, propName, prefix ){
   if( prefix ){
     propName = this.prependCamel( prefix, propName ); // e.g. (labelWidth, source) => sourceLabelWidth


### PR DESCRIPTION
- cutrectangle shape can be a compound or simple node
- adds a util.push method for arrays
- refactors math.polygonIntersectLine to allow polygon intersect
  checking without transforming the base points
- adds 'cutrectangle' to nodeshape enums
- adds comments for ambiguous arguments in some math functions