### PR TITLE
Make sure raf is defined to fix IE9 issue.

### DIFF
--- a/src/util/timing.js
+++ b/src/util/timing.js
@@ -9,7 +9,7 @@ var util = {};
 var pnow = performance && performance.now ? function(){ return performance.now(); } : function(){ return Date.now(); };
 
 var raf = (function(){
-  if(window) {
+  if( window ) {
     if( window.requestAnimationFrame ){
       return function( fn ){ window.requestAnimationFrame( fn ); };
     } else if( window.mozRequestAnimationFrame ){

--- a/src/util/timing.js
+++ b/src/util/timing.js
@@ -6,29 +6,33 @@ var performance = window ? window.performance : null;
 
 var util = {};
 
-var raf = !window ? function( fn ){
-  if( fn ){
-    setTimeout( function(){
-      fn( pnow() );
-    }, 1000 / 60 );
+var pnow = performance && performance.now ? function(){ return performance.now(); } : function(){ return Date.now(); };
+
+var raf = (function(){
+  if(window) {
+    if( window.requestAnimationFrame ){
+      return function( fn ){ window.requestAnimationFrame( fn ); };
+    } else if( window.mozRequestAnimationFrame ){
+      return function( fn ){ window.mozRequestAnimationFrame( fn ); };
+    } else if( window.webkitRequestAnimationFrame ){
+      return function( fn ){ window.webkitRequestAnimationFrame( fn ); };
+    } else if( window.msRequestAnimationFrame ){
+      return function( fn ){ window.msRequestAnimationFrame( fn ); };
+    }
   }
-} : (function(){
-  if( window.requestAnimationFrame ){
-    return function( fn ){ window.requestAnimationFrame( fn ); };
-  } else if( window.mozRequestAnimationFrame ){
-    return function( fn ){ window.mozRequestAnimationFrame( fn ); };
-  } else if( window.webkitRequestAnimationFrame ){
-    return function( fn ){ window.webkitRequestAnimationFrame( fn ); };
-  } else if( window.msRequestAnimationFrame ){
-    return function( fn ){ window.msRequestAnimationFrame( fn ); };
+  
+  return function( fn ){
+    if( fn ){
+      setTimeout( function(){
+        fn( pnow() );
+      }, 1000 / 60 );
+    }
   }
 })();
 
 util.requestAnimationFrame = function( fn ){
   raf( fn );
 };
-
-var pnow = performance && performance.now ? function(){ return performance.now(); } : function(){ return Date.now(); };
 
 util.performanceNow = pnow;
 


### PR DESCRIPTION
IE9 has `window` defined but none of the `requestAnimationFrame` properties so we end up with an `undefined` `raf` variable and cytoscape breaks whenever `util.requestAnimationFrame` is called.

I reordered the variable assignment a bit to use the "no window" value as a default value whenever all the `requestAnimationFrame` properties don't exist.