### PR TITLE
Add contributor guides to accompany blog post

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,11 +1,20 @@
 ## **I'm submitting a:**
-- [] Feature request
-- [] Bug report
-- [] *Requests for help should be directed to [Stack Overflow](http://stackoverflow.com/questions/tagged/cytoscape.js) or [Gitter](https://gitter.im/cytoscape/cytoscape.js)
+- [ ] Bug report
+- [ ] Feature request
+- [ ] *Requests for help should be directed to [Stack Overflow](http://stackoverflow.com/questions/tagged/cytoscape.js) or [Gitter](https://gitter.im/cytoscape/cytoscape.js)*
+
+--------------------
 
 ## Bug reports
-[] Descriptive title
-[] Bug still exists in most recent Cy.js version
+
+When submitting a bug report, check the following:
+- [ ] Report has a descriptive title
+- [ ] Bug still exists in most recent Cy.js version
+
+### Environment info
+- [ ] Browser and version:
+  - [ ] Node version (if running headless):
+- [ ] Cytoscape.js version:
 
 ### Current behavior
 <!-- What does the bug do? -->
@@ -16,11 +25,11 @@
 ### Minimum steps to reproduce
 <!-- Repos that can be cloned to reproduce bug or a link to a JSBin/ CodePen/ JSFiddle are appreciated! -->
 
-### Environment info
-- [] Browser and version:
-  - [] If running headless: Node version
-
+--------------------
 
 ## Feature requests
 
-### **If this is a feature request: what's the motivation for the new feature?**
+### Description of new feature
+
+### Motivation for new feature
+<!-- Describe your use case for this new feature -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,26 @@
+## **I'm submitting a:**
+- [] Feature request
+- [] Bug report
+- [] *Requests for help should be directed to [Stack Overflow](http://stackoverflow.com/questions/tagged/cytoscape.js) or [Gitter](https://gitter.im/cytoscape/cytoscape.js)
+
+## Bug reports
+[] Descriptive title
+[] Bug still exists in most recent Cy.js version
+
+### Current behavior
+<!-- What does the bug do? -->
+
+### Desired behavior
+<!-- What do you expect Cytoscape.js to do instead? -->
+
+### Minimum steps to reproduce
+<!-- Repos that can be cloned to reproduce bug or a link to a JSBin/ CodePen/ JSFiddle are appreciated! -->
+
+### Environment info
+- [] Browser and version:
+  - [] If running headless: Node version
+
+
+## Feature requests
+
+### **If this is a feature request: what's the motivation for the new feature?**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,9 +35,6 @@ The source is organised in relatively the same as the documentation, under `./sr
 
 Use two spaces for indentation, and single-quoted strings are preferred.  The main thing is to  try to keep your code neat and similarly formatted as the rest of the code.  There isn't a strict styleguide.
 
-You can run `gulp format` to automatically format the code to more or less match the style we use.  Please do `gulp format` in a separate commit just in case it touches files or lines you didn't change.  Alternatively, you can manually run `jscs --fix <files you changed>`.
-
-
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ If you'd like to contribute code to Cytoscape.js but you're not sure exactly wha
 
 Our goal is to make Cytoscape.js as comprehensive as possible.  Thank you for taking the time and effort to contribute to help make that happen!
 
+A blog post is available [on blog.js.cytoscape.org](http://blog.js.cytoscape.org/2017/05/09/contributing/) geared towards first-time contributors with more in-depth instructions on the project's structure, the process of creating and merging changes to the code, and more.
+
 
 
 ## Submitting issues
@@ -14,10 +16,9 @@ Submit issues or feature requests to the [issue tracker](https://github.com/cyto
 
 Before submitting an issue, please ensure that the issue still exists in the latest version of the library.  Because we follow semver, you can safely upgrade patch releases (x.y.**z**) and feature releases (x.**y**) without worry of breaking API changes.
 
-Clearly describe your issue.  List the steps necessary to reproduce your issue along with the corresponding code (preferably a JSBin, as that makes the issue less ambiguous and much faster to fix).
+Clearly describe your issue.  List the steps necessary to reproduce your issue along with the corresponding code (preferably a JSBin, as that makes the issue less ambiguous and much faster to fix). Refer to the `ISSUE_TEMPLATE.md` file in this repository for guidance on formatting and submitting an issue.
 
 Make certain to mention the version of the library you are using and version of the browser/environment you are using.
-
 
 
 ## Where to put changes


### PR DESCRIPTION
Adds a template for new issues and changes to the `contributing.md` file to point to the blog post (not yet published).