### PR TITLE
fix min-height bottom/top properties working in reverse; fix ellipse check point bug introduced in earlier commit

### DIFF
--- a/src/collection/dimensions.js
+++ b/src/collection/dimensions.js
@@ -394,7 +394,7 @@ fn = elesfn = ({
       pos.x = (- diffLeft + bb.x1 + bb.x2 + diffRight) / 2;
 
       _p.autoHeight = Math.max(bb.h, min.height.val);
-      pos.y = (- diffBottom + bb.y1 + bb.y2 + diffTop) / 2;
+      pos.y = (- diffTop + bb.y1 + bb.y2 + diffBottom) / 2;
 
       updated.push( parent );
     }

--- a/src/extensions/renderer/base/node-shapes.js
+++ b/src/extensions/renderer/base/node-shapes.js
@@ -56,7 +56,7 @@ BRp.generateEllipse = function(){
     },
 
     checkPoint: function( x, y, padding, width, height, centerX, centerY ){
-      math.checkInEllipse( x, y, padding, width, height, centerX, centerY );
+      return math.checkInEllipse( x, y, padding, width, height, centerX, centerY );
     }
   } );
 };


### PR DESCRIPTION
## min-height -- bias top / bias bottom had the opposite intended effect https://github.com/cytoscape/cytoscape.js/issues/1861
Changed the height computation to add the bias bottom and subtract the bias top instead of the other way around.

## ellipse check point bug
Ellipse check point method was broken because I was just calling Math.checkInEllipse instead of returning the result.
