### PR TITLE
document the includeOverlays option

### DIFF
--- a/documentation/docmaker.json
+++ b/documentation/docmaker.json
@@ -1509,7 +1509,8 @@
                       "fields": [
                         { "name": "includeNodes", "descr": "A boolean indicating whether to include nodes in the bounding box (default `true`)." },
                         { "name": "includeEdges", "descr": "A boolean indicating whether to include edges in the bounding box (default `true`)." },
-                        { "name": "includeLabels", "descr": "A boolean indicating whether to include labels in the bounding box (default `true`)." }
+                        { "name": "includeLabels", "descr": "A boolean indicating whether to include labels in the bounding box (default `true`)." },
+                        { "name": "includeOverlays", "descr": "A boolean indicating whether to include overlays (such as the one which appears when a node is clicked) in the bounding box (default `true`)." }
                       ]
                     }
                   ]
@@ -1533,7 +1534,8 @@
                       "fields": [
                         { "name": "includeNodes", "descr": "A boolean indicating whether to include nodes in the bounding box (default `true`)." },
                         { "name": "includeEdges", "descr": "A boolean indicating whether to include edges in the bounding box (default `true`)." },
-                        { "name": "includeLabels", "descr": "A boolean indicating whether to include labels in the bounding box (default `true`)." }
+                        { "name": "includeLabels", "descr": "A boolean indicating whether to include labels in the bounding box (default `true`)." },
+                        { "name": "includeOverlays", "descr": "A boolean indicating whether to include overlays (such as the one which appears when a node is clicked) in the bounding box (default `true`)." }                        
                       ]
                     }
                   ]


### PR DESCRIPTION
I ran into an issue while working on the Popper plugin; I eventually tracked it down to unknowingly leaving `includeOverlay` in it's default (true) value. I think the option should be documented, since it's a (relatively) user-facing option. There's also a `useCache` option, but since I can't think of any (non-development) use of it, I'm not documenting it.