### PR TITLE
Barrel shape: set max values for curve width/height offsets

### DIFF
--- a/src/extensions/renderer/canvas/drawing-shapes.js
+++ b/src/extensions/renderer/canvas/drawing-shapes.js
@@ -106,7 +106,7 @@ CRp.drawBarrelPath = function(
     var barrelCurveConstants = math.getBarrelCurveConstants( width, height );
     var wOffset = barrelCurveConstants.widthOffset;
     var hOffset = barrelCurveConstants.heightOffset;
-    var ctrlPtXOffset = barrelCurveConstants.ctrlPtOffsetPct * width;
+    var ctrlPtXOffset = barrelCurveConstants.ctrlPtOffsetPct * wOffset;
 
     if( context.beginPath ){ context.beginPath(); }
 
@@ -116,7 +116,7 @@ CRp.drawBarrelPath = function(
     context.quadraticCurveTo( xBegin + ctrlPtXOffset, yEnd, xBegin + wOffset, yEnd );
 
     context.lineTo( xEnd - wOffset, yEnd );
-    context.quadraticCurveTo( xEnd - ctrlPtXOffset, yEnd, xEnd, yEnd - hOffset )
+    context.quadraticCurveTo( xEnd - ctrlPtXOffset, yEnd, xEnd, yEnd - hOffset );
 
     context.lineTo( xEnd, yBegin + hOffset );
     context.quadraticCurveTo( xEnd - ctrlPtXOffset, yBegin, xEnd -  wOffset, yBegin );

--- a/src/math.js
+++ b/src/math.js
@@ -1099,8 +1099,8 @@ math.bezierPtsToQuadCoeff = function( p0, p1, p2 ){
 math.getBarrelCurveConstants = function( width, height ){
   // get curve width, height, and control point position offsets as a percentage of node height / width
   return {
-    heightOffset: 0.05 * height,
-    widthOffset: 0.25 * width,
+    heightOffset: Math.min(15, 0.05 * height),
+    widthOffset: Math.min(100, 0.25 * width),
     ctrlPtOffsetPct: 0.05
   };
 };


### PR DESCRIPTION
Related: https://github.com/cytoscape/cytoscape.js/issues/1884

Fixes child nodes going outside of the parent shape.

Before:
![screen shot 2017-07-13 at 1 24 14 pm](https://user-images.githubusercontent.com/2328291/28179027-af280f9a-67ce-11e7-8abf-3ddac4803658.png)
![screen shot 2017-07-13 at 1 24 51 pm](https://user-images.githubusercontent.com/2328291/28179028-af2cbefa-67ce-11e7-914d-95e2e01e75f9.png)
