### PR TITLE
Replace complicated triangle cross arrow scaling functions with a simpler one

### DIFF
--- a/src/extensions/renderer/base/arrow-shapes.js
+++ b/src/extensions/renderer/base/arrow-shapes.js
@@ -208,18 +208,6 @@ BRp.registerArrowShapes = function(){
 
     matchEdgeWidth: true,
 
-    scaleCoord: function ( constant, size, edgeWidth ){
-     return constant + ( edgeWidth * 0.012 ) + ( math.log2( size - 28.95 ) * 0.001 );
-    },
-
-   scaleCrossLineXCoord: function( size, edgeWidth ){
-      return this.scaleCoord( 0.42, size, edgeWidth );
-    },
-
-    scaleCrossLineYCoord: function( size, edgeWidth ){
-      return this.scaleCoord( -0.01, size, edgeWidth );
-    },
-
     collide: function( x, y, size, angle, translation, padding ){
       var triPts = pointsToArr( transformPoints( this.points, size + 2 * padding, angle, translation ) );
       var crossLinePts = pointsToArr( transformPoints( this.crossLinePoints, size + 2 * padding, angle, translation ) );
@@ -232,15 +220,10 @@ BRp.registerArrowShapes = function(){
     },
 
     draw: function( context, size, angle, translation, edgeWidth ){
-      var scaledCrossLine = [
-        this.crossLinePoints[0] + this.scaleCrossLineXCoord( size, edgeWidth ),
-        this.crossLinePoints[1] - this.scaleCrossLineYCoord( size, edgeWidth ),
-        this.crossLinePoints[2] - this.scaleCrossLineXCoord( size, edgeWidth ),
-        this.crossLinePoints[3] - this.scaleCrossLineYCoord( size, edgeWidth )
-      ];
+      var sz = size*0.94 + edgeWidth + 2; 
       var triPts = transformPoints( this.points, size, angle, translation );
-      var crossLinePts = transformPoints( scaledCrossLine, size, angle, translation );
-
+      var crossLinePts = transformPoints( this.crossLinePoints, sz, angle, translation );
+      
       renderer.arrowShapeImpl( this.name )( context, triPts, crossLinePts );
     }
   } );

--- a/src/extensions/renderer/base/arrow-shapes.js
+++ b/src/extensions/renderer/base/arrow-shapes.js
@@ -220,9 +220,9 @@ BRp.registerArrowShapes = function(){
     },
 
     draw: function( context, size, angle, translation, edgeWidth ){
-      var sz = size*0.94 + edgeWidth + 2; 
+      var scaledCrossLineSize = size*0.94 + edgeWidth + 2; 
       var triPts = transformPoints( this.points, size, angle, translation );
-      var crossLinePts = transformPoints( this.crossLinePoints, sz, angle, translation );
+      var crossLinePts = transformPoints( this.crossLinePoints, scaledCrossLineSize, angle, translation );
       
       renderer.arrowShapeImpl( this.name )( context, triPts, crossLinePts );
     }


### PR DESCRIPTION
- Uses size and edgewidth to determine how large the crossline should be relative to the arrow head
- Works for arrow-scale values < 1
- Remove complicated and fragile arrow cross scaling functions that used numerous magic values