### PR TITLE
Fix unwanted empty() call on boundingBox

### DIFF
--- a/src/core/viewport.js
+++ b/src/core/viewport.js
@@ -247,7 +247,7 @@ let corefn = ({
       elements = this.mutableElements();
     }
 
-    if( elements.empty() ){ return; } // can't fit to nothing
+    if( is.elementOrCollection( elements ) && elements.empty() ){ return; } // can't fit to nothing
 
     bb = bb || elements.boundingBox();
 


### PR DESCRIPTION
Fixes issue #1965 

Other alternatives could replace the `is.elementOrCollection( elements ) && ...` by `is.fn( elements.empty ) && ...` or `typeof elements.empty === 'function' && ...`.