### PR TITLE
Allow classes to be specified as arrays #1644

### DIFF
--- a/src/collection/class.js
+++ b/src/collection/class.js
@@ -1,8 +1,15 @@
 let Set = require('../set');
+let is = require('../is');
 
 let elesfn = ({
   classes: function( classes ){
-    classes = ( classes || '' ).match( /\S+/g ) || [];
+    if( is.array( classes ) ){
+      // use a copy of the array
+      classes = classes.slice(0);
+    } else {
+      // extract classes from string
+      classes = ( classes || '' ).match( /\S+/g ) || [];
+    }
     let self = this;
     let changed = [];
     let classesSet = new Set( classes );
@@ -57,8 +64,14 @@ let elesfn = ({
     return ( ele != null && ele._private.classes.has(className) );
   },
 
-  toggleClass: function( classesStr, toggle ){
-    let classes = classesStr.match( /\S+/g ) || [];
+  toggleClass: function( classes, toggle ){
+    if( is.array( classes ) ){
+      // use a copy of the array
+      classes = classes.slice(0);
+    } else {
+      // extract classes from string
+      classes = classes.match( /\S+/g ) || [];
+    }
     let self = this;
     let toggleUndefd = toggle === undefined;
     let changed = []; // eles who had classes changed

--- a/src/collection/class.js
+++ b/src/collection/class.js
@@ -3,10 +3,7 @@ let is = require('../is');
 
 let elesfn = ({
   classes: function( classes ){
-    if( is.array( classes ) ){
-      // use a copy of the array
-      classes = classes.slice(0);
-    } else {
+    if( !is.array( classes ) ){
       // extract classes from string
       classes = ( classes || '' ).match( /\S+/g ) || [];
     }
@@ -65,10 +62,7 @@ let elesfn = ({
   },
 
   toggleClass: function( classes, toggle ){
-    if( is.array( classes ) ){
-      // use a copy of the array
-      classes = classes.slice(0);
-    } else {
+    if( !is.array( classes ) ){
       // extract classes from string
       classes = classes.match( /\S+/g ) || [];
     }

--- a/src/collection/element.js
+++ b/src/collection/element.js
@@ -88,8 +88,7 @@ let Element = function( cy, params, restore ){
       _p.classes.add(cls);
     }
   } else if( is.array( params.classes ) ){
-    // use a copy of the array
-    let classes = params.classes.slice(0);
+    let classes = params.classes;
     for( let i = 0, l = classes.length; i < l; i++ ){
       let cls = classes[ i ];
       if( !cls || cls === '' ){ continue; }

--- a/src/collection/element.js
+++ b/src/collection/element.js
@@ -87,6 +87,15 @@ let Element = function( cy, params, restore ){
 
       _p.classes.add(cls);
     }
+  } else if( is.array( params.classes ) ){
+    // use a copy of the array
+    let classes = params.classes.slice(0);
+    for( let i = 0, l = classes.length; i < l; i++ ){
+      let cls = classes[ i ];
+      if( !cls || cls === '' ){ continue; }
+
+      _p.classes.add(cls);
+    }
   }
 
   if( params.style || params.css ){

--- a/src/collection/element.js
+++ b/src/collection/element.js
@@ -79,22 +79,17 @@ let Element = function( cy, params, restore ){
     };
   }
 
-  if( is.string( params.classes ) ){
-    let classes = params.classes.split( /\s+/ );
-    for( let i = 0, l = classes.length; i < l; i++ ){
-      let cls = classes[ i ];
-      if( !cls || cls === '' ){ continue; }
+  let classes = [];
+  if( is.array( params.classes ) ){
+    classes = params.classes;
+  } else if( is.string( params.classes ) ){
+    classes = params.classes.split( /\s+/ );
+  }
+  for( let i = 0, l = classes.length; i < l; i++ ){
+    let cls = classes[ i ];
+    if( !cls || cls === '' ){ continue; }
 
-      _p.classes.add(cls);
-    }
-  } else if( is.array( params.classes ) ){
-    let classes = params.classes;
-    for( let i = 0, l = classes.length; i < l; i++ ){
-      let cls = classes[ i ];
-      if( !cls || cls === '' ){ continue; }
-
-      _p.classes.add(cls);
-    }
+    _p.classes.add(cls);
   }
 
   if( params.style || params.css ){

--- a/test/collection-style.js
+++ b/test/collection-style.js
@@ -537,6 +537,13 @@ describe('Collection style', function(){
       expect( n1.hasClass('bar') ).to.be.true;
     });
 
+    it('eles.addClass() adds classes with an array', function(){
+      n1.addClass(['foo', 'bar']);
+
+      expect( n1.hasClass('foo') ).to.be.true;
+      expect( n1.hasClass('bar') ).to.be.true;
+    });
+
     it('eles.removeClass() removes class', function(){
       n1.addClass('foo');
       n1.removeClass('foo');
@@ -552,6 +559,14 @@ describe('Collection style', function(){
       expect( n1.hasClass('bar') ).to.be.false;
     });
 
+    it('eles.removeClass() removes classes with an array', function(){
+      n1.addClass(['foo', 'bar']);
+      n1.removeClass(['foo', 'bar']);
+
+      expect( n1.hasClass('foo') ).to.be.false;
+      expect( n1.hasClass('bar') ).to.be.false;
+    });
+
     it('eles.toggleClass() toggles class', function(){
       n1.addClass('foo');
       n1.toggleClass('foo');
@@ -562,6 +577,14 @@ describe('Collection style', function(){
     it('eles.toggleClass() toggles classes', function(){
       n1.addClass('foo bar');
       n1.toggleClass('foo bar');
+
+      expect( n1.hasClass('foo') ).to.be.false;
+      expect( n1.hasClass('bar') ).to.be.false;
+    });
+
+    it('eles.toggleClass() toggles with an array of classes', function(){
+      n1.addClass(['foo', 'bar']);
+      n1.toggleClass(['foo', 'bar']);
 
       expect( n1.hasClass('foo') ).to.be.false;
       expect( n1.hasClass('bar') ).to.be.false;
@@ -592,12 +615,34 @@ describe('Collection style', function(){
       expect( n1.hasClass('baz') ).to.be.false;
     });
 
+    it('eles.classes() replaces with an array of classes (subset)', function(){
+      ['foo', 'bar', 'baz'].forEach(function( c ){ n1.addClass(c); });
+
+      n1.classes(['foo', 'bar']);
+
+      expect( n1.hasClass('foo') ).to.be.true;
+      expect( n1.hasClass('bar') ).to.be.true;
+      expect( n1.hasClass('baz') ).to.be.false;
+    });
+
     it('eles.classes() replaces classes (all different)', function(){
       ['foo', 'bar', 'baz'].forEach(function( c ){ n1.addClass(c); });
 
       n1.classes('bat');
 
       expect( n1.hasClass('bat') ).to.be.true;
+      expect( n1.hasClass('foo') ).to.be.false;
+      expect( n1.hasClass('bar') ).to.be.false;
+      expect( n1.hasClass('baz') ).to.be.false;
+    });
+
+    it('eles.classes() replaces with an array of classes (all different)', function(){
+      ['foo', 'bar', 'baz'].forEach(function( c ){ n1.addClass(c); });
+
+      n1.classes(['bat', 'bot']);
+
+      expect( n1.hasClass('bat') ).to.be.true;
+      expect( n1.hasClass('bot') ).to.be.true;
       expect( n1.hasClass('foo') ).to.be.false;
       expect( n1.hasClass('bar') ).to.be.false;
       expect( n1.hasClass('baz') ).to.be.false;
@@ -614,6 +659,44 @@ describe('Collection style', function(){
       n1.removeClass('foo');
 
       expect( n1.json().classes ).to.be.empty;
+    });
+
+    it('initializes classes with a string', function(){
+      cytoscape({
+        headless: true,
+
+        elements: {
+          nodes: [{
+            data: { id: 'n1' },
+            classes: 'foo bar'
+          }]
+        },
+        ready: function(){
+          var cy = this;
+          var n1 = cy.$('#n1');
+          expect( n1.hasClass('foo') ).to.be.true;
+          expect( n1.hasClass('bar') ).to.be.true;
+        }
+      });
+    });
+
+    it('initializes classes with an array', function(){
+      cytoscape({
+        headless: true,
+
+        elements: {
+          nodes: [{
+            data: { id: 'n1' },
+            classes: [ 'foo', 'bar' ]
+          }]
+        },
+        ready: function(){
+          var cy = this;
+          var n1 = cy.$('#n1');
+          expect( n1.hasClass('foo') ).to.be.true;
+          expect( n1.hasClass('bar') ).to.be.true;
+        }
+      });
     });
 
   });


### PR DESCRIPTION
This implements #1644. I think this is just about ready, but I wanted to open it up for maintainer input before going any farther.

Do you have any opinions on what to do with arrays of strings with spaces in them - e.g.
```
[ 'foo', 'bar baz' ]
```

This PR takes care of classes at initialization, `eles.classes()`, `eles.addClass()`, `eles.removeClass()`, and `eles.toggleClass()`. Is there anything else that needs to support arrays of classes?