### PR TITLE
Add property edge-cap

### DIFF
--- a/src/extensions/renderer/canvas/drawing-edges.js
+++ b/src/extensions/renderer/canvas/drawing-edges.js
@@ -27,10 +27,11 @@ CRp.drawEdge = function( context, edge, shiftToOriginWithBb, drawLabel ){
   let opacity = edge.pstyle('opacity').value;
   let lineStyle = edge.pstyle('line-style').value;
   let edgeWidth = edge.pstyle('width').pfValue;
+  let edgeCap = edge.pstyle('edge-cap').value;
 
   let drawLine = ( strokeOpacity = opacity ) => {
     context.lineWidth = edgeWidth;
-    context.lineCap = 'butt';
+    context.lineCap = edgeCap;
 
     r.strokeStyle( context, lineColor[0], lineColor[1], lineColor[2], strokeOpacity );
 

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -48,6 +48,7 @@ let styfn = {};
     color: { color: true },
     bool: { enums: [ 'yes', 'no' ] },
     lineStyle: { enums: [ 'solid', 'dotted', 'dashed' ] },
+    edgeCap: { enums: [ 'butt', 'round', 'square' ] },
     borderStyle: { enums: [ 'solid', 'dotted', 'dashed', 'double' ] },
     curveStyle: { enums: [ 'bezier', 'unbundled-bezier', 'haystack', 'segments', 'straight' ] },
     fontFamily: { regex: '^([\\w- \\"]+(?:\\s*,\\s*[\\w- \\"]+)*)$' },
@@ -250,6 +251,7 @@ let styfn = {};
     // edge line
     { name: 'line-style', type: t.lineStyle },
     { name: 'line-color', type: t.color },
+    { name: 'edge-cap', type: t.edgeCap },
     { name: 'curve-style', type: t.curveStyle },
     { name: 'haystack-radius', type: t.zeroOneNumber },
     { name: 'source-endpoint', type: t.edgeEndpoint },
@@ -471,6 +473,7 @@ styfn.getDefaultProperties = util.memoize( function(){
     // edge props
     'line-style': 'solid',
     'line-color': '#999',
+    'edge-cap': 'butt',
     'control-point-step-size': 40,
     'control-point-weights': 0.5,
     'segment-weights': 0.5,


### PR DESCRIPTION
This pull request adds the feature to specify the edge cap (shape of the edge endings) as proposed in issue #1948. This is important to avoid "cracks" between edges when nodes are smaller than the edge width or hidden. 
Since it is based on the canvas property `line-cap`, it should not have significant impact on performance.