### PR TITLE
Fix depth adjustment in breadthfirst layout

### DIFF
--- a/src/extensions/layout/breadthfirst.js
+++ b/src/extensions/layout/breadthfirst.js
@@ -263,6 +263,10 @@ BreadthFirstLayout.prototype.run = function(){
       }
       depths[ newDepth ].push( ele );
 
+      for ( let j = info.index; j < depths[info.depth].length; j++ ){
+        depths[info.depth][j]._private.scratch.breadthfirst.index--;
+      }
+
       info.depth = newDepth;
       info.index = depths[ newDepth ].length - 1;
     }


### PR DESCRIPTION
Indexes were not updated after splicing; this could cause wrongful move to higher depths after 1st iteration.