### PR TITLE
Handle nested undefined properties in styles

### DIFF
--- a/src/style/apply.js
+++ b/src/style/apply.js
@@ -431,10 +431,10 @@ styfn.applyParsedProperty = function( ele, parsedProp ){
     let fields = prop.field.split( '.' );
     let fieldVal = _p.data;
 
-    if( fieldVal ){ for( let i = 0; i < fields.length; i++ ){
+    for( let i = 0; i < fields.length && fieldVal; i++ ){
       let field = fields[ i ];
       fieldVal = fieldVal[ field ];
-    } }
+    }
 
     flatProp = this.parse( prop.name, fieldVal, prop.bypass, flatPropMapping );
 


### PR DESCRIPTION
Currently, if you use a data property in a style with a nested pattern, like `label: data(foo.bar)`, and `foo.bar` is not set, then we crash trying to look up `bar` on the undefined `data.foo`.

The code in fact tries to check whether the values it is indexing into are defined, but it only does so for the very first one (i.e. `data` itself). Probably the check should be the same as the one on line 366, which checks at each iteration of the loop, so I changed it to match.