### PR TITLE
Fix checkInEllipse signature

### DIFF
--- a/src/extensions/renderer/base/node-shapes.js
+++ b/src/extensions/renderer/base/node-shapes.js
@@ -54,7 +54,7 @@ BRp.generateEllipse = function(){
     },
 
     checkPoint: function( x, y, padding, width, height, centerX, centerY ){
-      return math.checkInEllipse( x, y, padding, width, height, centerX, centerY );
+      return math.checkInEllipse( x, y, centerX, centerY, width, height, padding );
     }
   } );
 };

--- a/src/math.js
+++ b/src/math.js
@@ -753,7 +753,7 @@ math.intersectLineEllipse = function(
 };
 
 math.checkInEllipse = function(
-  x, y, padding, width, height, centerX, centerY ){
+  x, y, centerX, centerY, width, height, padding ){
   x -= centerX;
   y -= centerY;
 


### PR DESCRIPTION
The `checkInEllipse` function was refactored into the math util but the signature was changed. Updated signature to be consistent with the other functions and then fixed a call in `ellipse.checkPoint`.

Fixes issue with disappearing bezier edges (https://github.com/cytoscape/cytoscape.js/issues/2005), and a more minimal example: http://jsbin.com/rohebeqivi/2/edit?js,output
