### PR TITLE
Add support for `line-color: linear-gradient(auto, ...colors)`

### DIFF
--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -122,6 +122,7 @@ cytoscape({
 ## Property types
 
  * Colours may be specified by name (e.g. `red`), hex (e.g. `#ff0000` or `#f00`), RGB (e.g. `rgb(255, 0, 0)`), or HSL (e.g. `hsl(0, 100%, 50%)`).
+     * Edge's `line-color` also accepts `linear-gradient(auto, ...<colors>)` as a linear gradient between the edge points.
  * Values requiring a number, such as a length, can be specified in pixel values (e.g. `24px`), unitless values that are implicitly in pixels (`24`), or em values (e.g. `2em`).  Sizes are specified in [model co-ordinates](#notation/position), so on-screen (rendered) sizes are as specified at zoom 1.
  * Opacity values are specified as numbers ranging on `0 <= opacity <= 1`.
  * Time is measured in units of ms or s.

--- a/src/extensions/renderer/canvas/drawing-edges.js
+++ b/src/extensions/renderer/canvas/drawing-edges.js
@@ -32,8 +32,18 @@ CRp.drawEdge = function( context, edge, shiftToOriginWithBb, drawLabel ){
     context.lineWidth = edgeWidth;
     context.lineCap = 'butt';
 
-    r.strokeStyle( context, lineColor[0], lineColor[1], lineColor[2], strokeOpacity );
-
+    if (Array.isArray(lineColor[0])) { //check if gradient
+      let grd = context.createLinearGradient(rs.allpts[0], rs.allpts[1], rs.allpts[rs.allpts.length-2], rs.allpts[rs.allpts.length-1]);
+      let length = lineColor.length;
+      for (let i = 0; i < length ; i++) {
+        grd.addColorStop(i / (length - 1), 'rgba(' + lineColor[i][0] + ',' + lineColor[i][1] + ',' + lineColor[i][2] + ',' + strokeOpacity + ')');
+      }
+      context.strokeStyle = grd;
+    }
+    else {
+      r.strokeStyle(context, lineColor[0], lineColor[1], lineColor[2], strokeOpacity);
+    }
+    
     r.drawEdgePath(
       edge,
       context,

--- a/src/style/parse.js
+++ b/src/style/parse.js
@@ -374,6 +374,19 @@ styfn.parseImpl = function( name, value, propIsBypass, propIsFlat ){
       bypass: propIsBypass
     };
 
+  } else if( type.colorOrGradient ) {
+    let tuple = util.colorOrGradient2tuple( value );
+    
+    if ( !tuple ){ return null; }
+
+    return {
+      name: name,
+      value: tuple,
+      pfValue: tuple,
+      strValue: '' + value,
+      bypass: propIsBypass
+    };
+    
   } else if( type.regex || type.regexes ){
 
     // first check enums

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -46,6 +46,7 @@ let styfn = {};
     bgCrossOrigin: { enums: [ 'anonymous', 'use-credentials' ], multiple: true },
     bgClip: { enums: [ 'none', 'node' ] },
     color: { color: true },
+    colorOrGradient: { colorOrGradient: true },
     bool: { enums: [ 'yes', 'no' ] },
     lineStyle: { enums: [ 'solid', 'dotted', 'dashed' ] },
     borderStyle: { enums: [ 'solid', 'dotted', 'dashed', 'double' ] },
@@ -249,7 +250,7 @@ let styfn = {};
 
     // edge line
     { name: 'line-style', type: t.lineStyle },
-    { name: 'line-color', type: t.color },
+    { name: 'line-color', type: t.colorOrGradient },
     { name: 'curve-style', type: t.curveStyle },
     { name: 'haystack-radius', type: t.zeroOneNumber },
     { name: 'source-endpoint', type: t.edgeEndpoint },

--- a/src/util/colors.js
+++ b/src/util/colors.js
@@ -135,6 +135,25 @@ module.exports = {
       || this.hsl2tuple( color );
   },
 
+  gradient2tuple: function( gradient ){
+    let m = new RegExp( '^' + this.regex.gradient + '$' ).exec( gradient );
+    if( !m ){
+      return null; //unsupported
+    }
+    let argRegexp = new RegExp(this.regex.gradientArguemnts, 'g');
+    let tuples = [];
+    while (m = argRegexp.exec( gradient )) {
+      let tuple = this.color2tuple(m[1]);
+      if (tuple) tuples.push(tuple);
+    }
+    return tuples;
+  },
+
+  colorOrGradient2tuple: function( color ){
+    return this.color2tuple(color)
+      || this.gradient2tuple(color);
+  },
+
   colors: {
     // special colour names
     transparent: [0, 0, 0, 0], // NB alpha === 0

--- a/src/util/regex.js
+++ b/src/util/regex.js
@@ -9,6 +9,11 @@ let hslaNoBackRefs = 'hsl[a]?\\((?:' + number + ')\\s*,\\s*(?:' + number + '[%])
 let hex3 = '\\#[0-9a-fA-F]{3}';
 let hex6 = '\\#[0-9a-fA-F]{6}';
 
+let colorName = '[a-zA-Z]+';
+let colorNameRgbaHslaOrHex = '(' + colorName + '|' + rgba + '|' + hsla + '|' + hex3 + '|' + hex6 + ')';
+let gradientArguemnts = ',\\s*' + colorNameRgbaHslaOrHex + '\\s*';
+let gradient = 'linear-gradient\\(\\s*auto\\s*(' + gradientArguemnts + '){2,}\\)';
+
 module.exports = {
   regex: {
     number: number,
@@ -17,6 +22,8 @@ module.exports = {
     hsla: hsla,
     hslaNoBackRefs: hslaNoBackRefs,
     hex3: hex3,
-    hex6: hex6
+    hex6: hex6,
+    gradient: gradient,
+    gradientArguemnts: gradientArguemnts
   }
 };


### PR DESCRIPTION
Add support for linear gradients on edges as color.

The syntax is:
`line-color: linear-gradient(auto, color1, color2, ...)`

- `auto` - currently is the only direction supported, between source and target points.
- At least 2 colors are required.
- Color can be: Color Name, RGBA, HSLA, Hex3 or Hex6

Example:
![cytoscape-gradient-pr](https://user-images.githubusercontent.com/1045347/35194014-65ab4940-feb4-11e7-8a26-239b71d38773.png)
