### PR TITLE
3.3.0-unstable does not position bg images properly if two nodes share dims #2049

### DIFF
--- a/src/extensions/renderer/canvas/drawing-nodes.js
+++ b/src/extensions/renderer/canvas/drawing-nodes.js
@@ -107,6 +107,7 @@ CRp.drawNode = function( context, node, shiftToOriginWithBb, drawLabel ){
     if( cachedPath != null ){
       path = cachedPath;
       pathCacheHit = true;
+      rs.pathCache = path;
     } else {
       path = new Path2D();
       pathCache[ key ] = rs.pathCache = path;


### PR DESCRIPTION
Max and Dylan : Fixing cytoscape issue that is reproducible within pc/app-ui.

This affects svg background images that are drawn by Dylan's sbgn-stylesheet lib.

With this change, app-ui can use cytoscape@#unstable to run the latest code.

See  #2049 for more info