### PR TITLE
Add support for `box-shadow` and `text-shadow`

### DIFF
--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -194,6 +194,12 @@ A padding defines an addition to a node's dimension.  For example, `padding` add
   * **`min`** : calculate padding as a percentage of the minimum of the node width and height.
   * **`max`** : calculate padding as a percentage of the maximum of the node width and height.
 
+Shadow:
+
+ * **`box-shadow`** : The offset of the shadow and blur (`<h-offset> <v-offset> <blur>`).
+ * **`box-shadow-color`** : The colour of the node's shadow.
+ * **`box-shadow-opacity`** : The opacity of the node's shadow.
+
 Compound parent sizing:
 
  * **`compound-sizing-wrt-labels`** : Whether to include labels of descendants in sizing a compound node; may be `include` or `exclude`.
@@ -461,6 +467,12 @@ Border:
  * **`text-border-width`** : The width of the border around the label.
  * **`text-border-style`** : The style of the border around the label; may be `solid`, `dotted`, `dashed`, or `double`.
  * **`text-border-color`** : The colour of the border around the label.
+
+Shadow:
+
+ * **`text-shadow`** : The offset of the shadow and blur (`<h-offset> <v-offset> <blur>`).
+ * **`text-shadow-color`** : The colour of the label's shadow.
+ * **`text-shadow-opacity`** : The opacity of the label's shadow.
 
 Interactivity:
 

--- a/src/collection/dimensions/bounds.js
+++ b/src/collection/dimensions/bounds.js
@@ -403,6 +403,15 @@ let boundingBoxImpl = function( ele, options ){
       wHalf = w / 2;
     }
 
+    const boxShadow = ele.pstyle( 'box-shadow' );
+    if( boxShadow ){
+      let shadow = boxShadow.value;
+      let hOffset = shadow[0],
+        vOffset = (shadow[1] || 0),
+        blur = (shadow[2] || 0);
+      overlayPadding += Math.max(blur, 0) + Math.abs(hOffset)+ Math.abs(vOffset);
+    }
+
     if( isNode && options.includeNodes ){
       let pos = ele.position();
       x = pos.x;

--- a/src/extensions/renderer/canvas/drawing-label-text.js
+++ b/src/extensions/renderer/canvas/drawing-label-text.js
@@ -116,6 +116,9 @@ CRp.setupTextStyle = function( context, ele ){
   var outlineOpacity = ele.pstyle( 'text-outline-opacity' ).value * opacity;
   var color = ele.pstyle( 'color' ).value;
   var outlineColor = ele.pstyle( 'text-outline-color' ).value;
+  var textShadow = ele.pstyle( 'text-shadow' );
+  var textShadowColor = ele.pstyle( 'text-shadow-color' ).value;
+  var textShadowOpacity = ele.pstyle( 'text-shadow-opacity' ).value * parentOpacity;
 
   var fontCacheKey = ele._private.fontKey;
   var cache = this.getFontCache( context );
@@ -134,6 +137,20 @@ CRp.setupTextStyle = function( context, ele ){
   this.fillStyle( context, color[ 0 ], color[ 1 ], color[ 2 ], opacity );
 
   this.strokeStyle( context, outlineColor[ 0 ], outlineColor[ 1 ], outlineColor[ 2 ], outlineOpacity );
+
+  if ( textShadow ) {
+    let shadow = textShadow.pfValue;
+    context.shadowOffsetX = shadow[0];
+    context.shadowOffsetY = (shadow[1] || 0);
+    context.shadowBlur = (shadow[2] || 0);
+    this.shadowColor(context, textShadowColor[0], textShadowColor[1], textShadowColor[2], textShadowOpacity);
+  }
+  else { // reset shadow
+    context.shadowOffsetX = 0;
+    context.shadowOffsetY = 0;
+    context.shadowBlur = 0;
+    context.shadowColor = null;
+  }
 };
 
 function roundRect( ctx, x, y, width, height, radius ){

--- a/src/extensions/renderer/canvas/drawing-nodes.js
+++ b/src/extensions/renderer/canvas/drawing-nodes.js
@@ -79,15 +79,11 @@ CRp.drawNode = function( context, node, shiftToOriginWithBb, drawLabel ){
   context.lineJoin = 'miter'; // so borders are square with the node shape
 
   const setupShadow = ( shadow, shadowColor, shadowOpacity ) => {
-    if ( shadow.length > 0 ) {
-      context.shadowOffsetX = shadow[0];
-      context.shadowOffsetY = (shadow[1] || 0);
-      context.shadowBlur = (shadow[2] || 0);
-      context.shadowColor = null;
-    }
-    if ( shadowColor ) {
-      r.shadowColor(context, shadowColor[0], shadowColor[1], shadowColor[2], shadowOpacity );
-    }
+    context.shadowOffsetX = shadow[0];
+    context.shadowOffsetY = (shadow[1] || 0);
+    context.shadowBlur = (shadow[2] || 0);
+    context.shadowColor = null;
+    r.shadowColor(context, shadowColor[0], shadowColor[1], shadowColor[2], shadowOpacity );
   };
 
   const resetShadow = () => {

--- a/src/extensions/renderer/canvas/drawing-nodes.js
+++ b/src/extensions/renderer/canvas/drawing-nodes.js
@@ -72,8 +72,30 @@ CRp.drawNode = function( context, node, shiftToOriginWithBb, drawLabel ){
   let borderColor = node.pstyle('border-color').value;
   let borderStyle = node.pstyle('border-style').value;
   let borderOpacity = node.pstyle('border-opacity').value * parentOpacity;
+  let boxShadow = node.pstyle('box-shadow');
+  let boxShadowColor = node.pstyle('box-shadow-color').value;
+  let boxShadowOpacity = node.pstyle('box-shadow-opacity').value * parentOpacity;
 
   context.lineJoin = 'miter'; // so borders are square with the node shape
+
+  const setupShadow = ( shadow, shadowColor, shadowOpacity ) => {
+    if ( shadow.length > 0 ) {
+      context.shadowOffsetX = shadow[0];
+      context.shadowOffsetY = (shadow[1] || 0);
+      context.shadowBlur = (shadow[2] || 0);
+      context.shadowColor = null;
+    }
+    if ( shadowColor ) {
+      r.shadowColor(context, shadowColor[0], shadowColor[1], shadowColor[2], shadowOpacity );
+    }
+  };
+
+  const resetShadow = () => {
+    context.shadowOffsetX = 0;
+    context.shadowOffsetY = 0;
+    context.shadowBlur = 0;
+    context.shadowColor = null;
+  };
 
   let setupShapeColor = ( bgOpy = bgOpacity ) => {
     r.fillStyle( context, bgColor[0], bgColor[1], bgColor[2], bgOpy );
@@ -269,8 +291,12 @@ CRp.drawNode = function( context, node, shiftToOriginWithBb, drawLabel ){
 
     context.translate( gx, gy );
 
+    if ( boxShadow ) {
+      setupShadow(boxShadow.pfValue, boxShadowColor, boxShadowOpacity);
+    }
     setupShapeColor( ghostOpacity * bgOpacity );
     drawShape();
+    resetShadow();
     drawImages( effGhostOpacity );
     drawPie( darkness !== 0 || borderWidth !== 0 );
     darken( effGhostOpacity );
@@ -280,8 +306,12 @@ CRp.drawNode = function( context, node, shiftToOriginWithBb, drawLabel ){
     context.translate( -gx, -gy );
   }
 
+  if ( boxShadow ) {
+    setupShadow(boxShadow.pfValue, boxShadowColor, boxShadowOpacity);
+  }
   setupShapeColor();
   drawShape();
+  resetShadow();
   drawImages();
   drawPie( darkness !== 0 || borderWidth !== 0 );
   darken();

--- a/src/extensions/renderer/canvas/drawing-redraw.js
+++ b/src/extensions/renderer/canvas/drawing-redraw.js
@@ -75,6 +75,20 @@ CRp.strokeStyle = function( context, r, g, b, a ){
   // }
 };
 
+CRp.shadowColor = function( context, r, g, b, a ){
+  context.shadowColor = 'rgba(' + r + ',' + g + ',' + b + ',' + a + ')';
+
+  // turn off for now, seems context does its own caching
+
+  // var cache = this.paintCache(context);
+
+  // var shadowColor = 'rgba(' + r + ',' + g + ',' + b + ',' + a + ')';
+
+  // if( cache.shadowColor !== shadowColor ){
+  //   context.shadowColor = cache.shadowColor = shadowColor;
+  // }
+};
+
 // Resize canvas
 CRp.matchCanvasSize = function( container ){
   var r = this;

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -173,6 +173,9 @@ let styfn = {};
     { name: 'text-border-style', type: t.borderStyle },
     { name: 'text-background-shape', type: t.textBackgroundShape},
     // { name: 'text-decoration', type: t.textDecoration }, // not supported in canvas
+    { name: 'text-shadow', type: t.bidirectionalSizes },
+    { name: 'text-shadow-color', type: t.color },
+    { name: 'text-shadow-opacity', type: t.zeroOneNumber },
     { name: 'text-transform', type: t.textTransform },
     { name: 'text-wrap', type: t.textWrap },
     { name: 'text-max-width', type: t.size },
@@ -216,6 +219,11 @@ let styfn = {};
     { name: 'background-blacken', type: t.nOneOneNumber },
     { name: 'padding', type: t.sizeMaybePercent },
     { name: 'padding-relative-to', type: t.paddingRelativeTo },
+
+    // node shadow
+    { name: 'box-shadow', type: t.bidirectionalSizes },
+    { name: 'box-shadow-color', type: t.color },
+    { name: 'box-shadow-opacity', type: t.zeroOneNumber },
 
     // node border
     { name: 'border-color', type: t.color },
@@ -364,6 +372,8 @@ styfn.getDefaultProperties = util.memoize( function(){
     'text-outline-opacity': 1,
     'text-opacity': 1,
     'text-decoration': 'none',
+    'text-shadow-color': '#000',
+    'text-shadow-opacity': 1,
     'text-transform': 'none',
     'text-wrap': 'none',
     'text-max-width': 9999,
@@ -433,6 +443,10 @@ styfn.getDefaultProperties = util.memoize( function(){
     'width': 30,
     'shape': 'ellipse',
     'shape-polygon-points': '-1, -1,   1, -1,   1, 1,   -1, 1',
+
+    // node shadow
+    'box-shadow-color': '#000',
+    'box-shadow-opacity': 1,
 
     // ghost props
     'ghost': 'no',


### PR DESCRIPTION
Add support for node shadows and label shadows.

Adds:
 * **`box-shadow`** : The offset of the shadow and blur (`<h-offset> <v-offset> <blur>`).
 * **`box-shadow-color`** : The colour of the node's shadow.
 * **`box-shadow-opacity`** : The opacity of the node's shadow.
 * **`text-shadow`** : The offset of the shadow and blur (`<h-offset> <v-offset> <blur>`).
 * **`text-shadow-color`** : The colour of the label's shadow.
 * **`text-shadow-opacity`** : The opacity of the label's shadow.

Example:

```
node:selected {
  box-shadow: 5px 5px 30px;
  box-shadow-color: red;
  text-shadow: 2px 2px 2px;
  text-shadow-color: red;
  text-shadow-opacity: 0.5;
}
```

![shadows](https://user-images.githubusercontent.com/1045347/35380575-57c2e6f6-01c2-11e8-9f63-0edc109ff728.png)
