### PR TITLE
Fixed redundant typo (appplication -> application) in demos

### DIFF
--- a/documentation/demos/6000-elements/index.html
+++ b/documentation/demos/6000-elements/index.html
@@ -14,7 +14,7 @@
   <body>
     <h1>Cytoscape.js (6,000 elements)</h1>
     <div id="cy"></div>
-    <!-- Load appplication code at the end to ensure DOM is loaded -->
+    <!-- Load application code at the end to ensure DOM is loaded -->
     <script src="code.js"></script>
   </body>
 </html>

--- a/documentation/demos/animated-bfs/index.html
+++ b/documentation/demos/animated-bfs/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div id="cy"></div>
-<!-- Load appplication code at the end to ensure DOM is loaded -->
+<!-- Load application code at the end to ensure DOM is loaded -->
 <script src="code.js"></script>
 </body>
 </html>

--- a/documentation/demos/architecture/index.html
+++ b/documentation/demos/architecture/index.html
@@ -8,7 +8,7 @@
 </head>
 <body>
 <div id="cy"></div>
-<!-- Load appplication code at the end to ensure DOM is loaded -->
+<!-- Load application code at the end to ensure DOM is loaded -->
 <script src="code.js"></script>
 </body>
 </html>

--- a/documentation/demos/circle-layout/index.html
+++ b/documentation/demos/circle-layout/index.html
@@ -17,7 +17,7 @@
   <body>
     <h1>Circle demo</h1>
     <div id="cy"></div>
-    <!-- Load appplication code at the end to ensure DOM is loaded -->
+    <!-- Load application code at the end to ensure DOM is loaded -->
     <script src="code.js"></script>
   </body>
 </html>

--- a/documentation/demos/cola-compound/index.html
+++ b/documentation/demos/cola-compound/index.html
@@ -17,7 +17,7 @@
 <body>
   <h1>cytoscape-cola demo</h1>
   <div id="cy"></div>
-  <!-- Load appplication code at the end to ensure DOM is loaded -->
+  <!-- Load application code at the end to ensure DOM is loaded -->
   <script src="code.js"></script>
 </body>
 </html>

--- a/documentation/demos/compound-nodes/index.html
+++ b/documentation/demos/compound-nodes/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div id="cy"></div>
-<!-- Load appplication code at the end to ensure DOM is loaded -->
+<!-- Load application code at the end to ensure DOM is loaded -->
 <script src="code.js"></script>
 </body>
 </html>

--- a/documentation/demos/concentric-layout/index.html
+++ b/documentation/demos/concentric-layout/index.html
@@ -18,7 +18,7 @@
   <body>
     <h1>Concentric demo</h1>
     <div id="cy"></div>
-    <!-- Load appplication code at the end to ensure DOM is loaded -->
+    <!-- Load application code at the end to ensure DOM is loaded -->
     <script src="code.js"></script>
   </body>
 </html>

--- a/documentation/demos/cose-bilkent-layout-compound/index.html
+++ b/documentation/demos/cose-bilkent-layout-compound/index.html
@@ -20,7 +20,7 @@
   <body>
     <h1>cytoscape-cose-bilkent demo (compound)</h1>
     <div id="cy"></div>
-    <!-- Load appplication code at the end to ensure DOM is loaded -->
+    <!-- Load application code at the end to ensure DOM is loaded -->
     <script src="code.js"></script>
   </body>
 </html>

--- a/documentation/demos/cose-bilkent-layout/index.html
+++ b/documentation/demos/cose-bilkent-layout/index.html
@@ -20,7 +20,7 @@
   <body>
     <h1>cytoscape-cose-bilkent demo</h1>
     <div id="cy"></div>
-    <!-- Load appplication code at the end to ensure DOM is loaded -->
+    <!-- Load application code at the end to ensure DOM is loaded -->
     <script src="code.js"></script>
   </body>
 </html>

--- a/documentation/demos/cose-layout/index.html
+++ b/documentation/demos/cose-layout/index.html
@@ -17,7 +17,7 @@
   <body>
     <h1>cose demo</h1>
     <div id="cy"></div>
-    <!-- Load appplication code at the end to ensure DOM is loaded -->
+    <!-- Load application code at the end to ensure DOM is loaded -->
     <script src="code.js"></script>
   </body>
 </html>

--- a/documentation/demos/dagre-layout/index.html
+++ b/documentation/demos/dagre-layout/index.html
@@ -17,7 +17,7 @@
   <body>
     <h1>cytoscape-dagre demo</h1>
     <div id="cy"></div>
-    <!-- Load appplication code at the end to ensure DOM is loaded -->
+    <!-- Load application code at the end to ensure DOM is loaded -->
     <script src="code.js"></script>
   </body>
 </html>

--- a/documentation/demos/edge-types/index.html
+++ b/documentation/demos/edge-types/index.html
@@ -17,7 +17,7 @@
   <body>
     <h1>Edge types demo</h1>
     <div id="cy"></div>
-    <!-- Load appplication code at the end to ensure DOM is loaded -->
+    <!-- Load application code at the end to ensure DOM is loaded -->
     <script src="code.js"></script>
   </body>
 </html>

--- a/documentation/demos/genemania-export/index.html
+++ b/documentation/demos/genemania-export/index.html
@@ -13,7 +13,7 @@
 </head>
 <body>
 <div id="cy"></div>
-<!-- Load appplication code at the end to ensure DOM is loaded -->
+<!-- Load application code at the end to ensure DOM is loaded -->
 <script src="code.js"></script>
 </body>
 </html>

--- a/documentation/demos/grid-layout/index.html
+++ b/documentation/demos/grid-layout/index.html
@@ -17,7 +17,7 @@
   <body>
     <h1>Grid demo</h1>
     <div id="cy"></div>
-    <!-- Load appplication code at the end to ensure DOM is loaded -->
+    <!-- Load application code at the end to ensure DOM is loaded -->
     <script src="code.js"></script>
   </body>
 </html>

--- a/documentation/demos/images-breadthfirst-layout/index.html
+++ b/documentation/demos/images-breadthfirst-layout/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div id="cy"></div>
-<!-- Load appplication code at the end to ensure DOM is loaded -->
+<!-- Load application code at the end to ensure DOM is loaded -->
 <script src="code.js"></script>
 </body>
 </html>

--- a/documentation/demos/initialisation/index.html
+++ b/documentation/demos/initialisation/index.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     <div id="cy"></div>
-    <!-- Load appplication code at the end to ensure DOM is loaded -->
+    <!-- Load application code at the end to ensure DOM is loaded -->
     <script src="code.js"></script>
   </body>
 </html>

--- a/documentation/demos/labels/index.html
+++ b/documentation/demos/labels/index.html
@@ -17,7 +17,7 @@
   <body>
     <h1>Labels demo</h1>
     <div id="cy"></div>
-    <!-- Load appplication code at the end to ensure DOM is loaded -->
+    <!-- Load application code at the end to ensure DOM is loaded -->
     <script src="code.js"></script>
   </body>
 </html>

--- a/documentation/demos/linkout-example/index.html
+++ b/documentation/demos/linkout-example/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div id="cy"></div>
-<!-- Load appplication code at the end to ensure DOM is loaded -->
+<!-- Load application code at the end to ensure DOM is loaded -->
 <script src="code.js"></script>
 </body>
 </html>

--- a/documentation/demos/multiple-instances/index.html
+++ b/documentation/demos/multiple-instances/index.html
@@ -11,7 +11,7 @@
 <body>
 <div id="cy"></div>
 <div id="cy2"></div>
-<!-- Load appplication code at the end to ensure DOM is loaded -->
+<!-- Load application code at the end to ensure DOM is loaded -->
 <script src="code.js"></script>
 </body>
 </html>

--- a/documentation/demos/performance-tuning/index.html
+++ b/documentation/demos/performance-tuning/index.html
@@ -13,7 +13,7 @@
 </head>
 <body>
 <div id="cy"></div>
-<!-- Load appplication code at the end to ensure DOM is loaded -->
+<!-- Load application code at the end to ensure DOM is loaded -->
 <script src="code.js"></script>
 </body>
 </html>

--- a/documentation/demos/pie-style/index.html
+++ b/documentation/demos/pie-style/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div id="cy"></div>
-<!-- Load appplication code at the end to ensure DOM is loaded -->
+<!-- Load application code at the end to ensure DOM is loaded -->
 <script src="code.js"></script>
 </body>
 </html>

--- a/documentation/demos/spread-layout/index.html
+++ b/documentation/demos/spread-layout/index.html
@@ -20,7 +20,7 @@
   <body>
     <h1>cytoscape-spread demo</h1>
     <div id="cy"></div>
-    <!-- Load appplication code at the end to ensure DOM is loaded -->
+    <!-- Load application code at the end to ensure DOM is loaded -->
     <script src="code.js"></script>
   </body>
 </html>

--- a/documentation/demos/visual-style/index.html
+++ b/documentation/demos/visual-style/index.html
@@ -11,7 +11,7 @@
   
 <body>
   <div id="cy"></div>
-  <!-- Load appplication code at the end to ensure DOM is loaded -->
+  <!-- Load application code at the end to ensure DOM is loaded -->
   <script src="code.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The same comment , where present, has the word 'application' misspelled in the demos directory. Fixed by applying the following search & replace pattern: s/appplication/application/