### PR TITLE
add required function to falseThread that is called if a layout.run()…

### DIFF
--- a/src/extensions/layout/cose.js
+++ b/src/extensions/layout/cose.js
@@ -157,7 +157,10 @@ CoseLayout.prototype.run = function(){
     },
     stop: function(){
       return this;
-    }
+    },
+    stopped: function(){
+      return true;
+    },
   };
 
   function broadcast( message ){ // for false thread


### PR DESCRIPTION
… is called more than once in non-weaver set-up.