### PR TITLE
Remove useless minified bundle size snapshot

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -4,11 +4,6 @@
     "minified": 317897,
     "gzipped": 98067
   },
-  "build/cytoscape.min.js": {
-    "bundled": 854989,
-    "minified": 317897,
-    "gzipped": 98067
-  },
   "build/cytoscape.cjs.js": {
     "bundled": 787562,
     "minified": 331520,

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
       "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
       "dev": true,
       "requires": {
-        "acorn": "5.3.0"
+        "acorn": "^5.0.0"
       }
     },
     "acorn-jsx": {
@@ -50,7 +50,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -67,10 +67,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ajv-keywords": {
@@ -85,9 +85,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -201,33 +201,33 @@
       "integrity": "sha1-csMd4qDZoszQysMMyYI+6y9kNLU=",
       "dev": true,
       "requires": {
-        "ansi-bgblack": "0.1.1",
-        "ansi-bgblue": "0.1.1",
-        "ansi-bgcyan": "0.1.1",
-        "ansi-bggreen": "0.1.1",
-        "ansi-bgmagenta": "0.1.1",
-        "ansi-bgred": "0.1.1",
-        "ansi-bgwhite": "0.1.1",
-        "ansi-bgyellow": "0.1.1",
-        "ansi-black": "0.1.1",
-        "ansi-blue": "0.1.1",
-        "ansi-bold": "0.1.1",
-        "ansi-cyan": "0.1.1",
-        "ansi-dim": "0.1.1",
-        "ansi-gray": "0.1.1",
-        "ansi-green": "0.1.1",
-        "ansi-grey": "0.1.1",
-        "ansi-hidden": "0.1.1",
-        "ansi-inverse": "0.1.1",
-        "ansi-italic": "0.1.1",
-        "ansi-magenta": "0.1.1",
-        "ansi-red": "0.1.1",
-        "ansi-reset": "0.1.1",
-        "ansi-strikethrough": "0.1.1",
-        "ansi-underline": "0.1.1",
-        "ansi-white": "0.1.1",
-        "ansi-yellow": "0.1.1",
-        "lazy-cache": "2.0.2"
+        "ansi-bgblack": "^0.1.1",
+        "ansi-bgblue": "^0.1.1",
+        "ansi-bgcyan": "^0.1.1",
+        "ansi-bggreen": "^0.1.1",
+        "ansi-bgmagenta": "^0.1.1",
+        "ansi-bgred": "^0.1.1",
+        "ansi-bgwhite": "^0.1.1",
+        "ansi-bgyellow": "^0.1.1",
+        "ansi-black": "^0.1.1",
+        "ansi-blue": "^0.1.1",
+        "ansi-bold": "^0.1.1",
+        "ansi-cyan": "^0.1.1",
+        "ansi-dim": "^0.1.1",
+        "ansi-gray": "^0.1.1",
+        "ansi-green": "^0.1.1",
+        "ansi-grey": "^0.1.1",
+        "ansi-hidden": "^0.1.1",
+        "ansi-inverse": "^0.1.1",
+        "ansi-italic": "^0.1.1",
+        "ansi-magenta": "^0.1.1",
+        "ansi-red": "^0.1.1",
+        "ansi-reset": "^0.1.1",
+        "ansi-strikethrough": "^0.1.1",
+        "ansi-underline": "^0.1.1",
+        "ansi-white": "^0.1.1",
+        "ansi-yellow": "^0.1.1",
+        "lazy-cache": "^2.0.1"
       },
       "dependencies": {
         "lazy-cache": {
@@ -236,7 +236,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -405,8 +405,8 @@
       "integrity": "sha1-Cns0jFifr2unCNSiJBBp6lFii14=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "make-iterator": "0.1.1"
+        "for-own": "^0.1.2",
+        "make-iterator": "^0.1.0"
       },
       "dependencies": {
         "make-iterator": {
@@ -415,7 +415,7 @@
           "integrity": "sha1-hz0nuBmKRlqBSDtvXRbaToY+z1s=",
           "dev": true,
           "requires": {
-            "for-own": "0.1.5"
+            "for-own": "^0.1.1"
           }
         }
       }
@@ -426,8 +426,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
       }
     },
     "aproba": {
@@ -443,8 +443,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -453,7 +453,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -462,7 +462,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -477,7 +477,7 @@
       "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
       "dev": true,
       "requires": {
-        "make-iterator": "1.0.0"
+        "make-iterator": "^1.0.0"
       }
     },
     "arr-pluck": {
@@ -486,7 +486,7 @@
       "integrity": "sha1-+K1tcI+HkAiB4jr9gw1SKQp2Z3U=",
       "dev": true,
       "requires": {
-        "arr-map": "2.0.2"
+        "arr-map": "^2.0.0"
       }
     },
     "arr-union": {
@@ -525,9 +525,9 @@
       "integrity": "sha512-BNcM+RXxndPxiZ2rd76k6nyQLRZr2/B/sdi8pQ+Joafr5AH279L40dfokSUTp8O+AaqYjXWhblBWa2st2nc4fQ==",
       "dev": true,
       "requires": {
-        "default-compare": "1.0.0",
-        "get-value": "2.0.6",
-        "kind-of": "5.1.0"
+        "default-compare": "^1.0.0",
+        "get-value": "^2.0.6",
+        "kind-of": "^5.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -544,7 +544,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -565,7 +565,7 @@
       "integrity": "sha1-RZFw4VXKErtRRISDnJ1xUHyA7E0=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arrify": {
@@ -580,11 +580,11 @@
       "integrity": "sha1-EIaxDpYZM3dqnYAcoqpyZF5QYL4=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "get-value": "2.0.6",
-        "is-answer": "0.1.1",
-        "is-valid-app": "0.2.1",
-        "mixin-deep": "1.3.0"
+        "debug": "^2.2.0",
+        "get-value": "^2.0.6",
+        "is-answer": "^0.1.0",
+        "is-valid-app": "^0.2.0",
+        "mixin-deep": "^1.1.3"
       }
     },
     "asn1": {
@@ -598,9 +598,9 @@
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assemble-core": {
@@ -609,13 +609,13 @@
       "integrity": "sha1-ZZF7/K+c1rFNm5HQMaDdmar0OWQ=",
       "dev": true,
       "requires": {
-        "assemble-fs": "0.6.0",
-        "assemble-render-file": "0.7.2",
-        "assemble-streams": "0.6.0",
-        "base-task": "0.6.2",
-        "define-property": "0.2.5",
-        "lazy-cache": "2.0.2",
-        "templates": "0.24.3"
+        "assemble-fs": "^0.6.0",
+        "assemble-render-file": "^0.7.1",
+        "assemble-streams": "^0.6.0",
+        "base-task": "^0.6.1",
+        "define-property": "^0.2.5",
+        "lazy-cache": "^2.0.1",
+        "templates": "^0.24.0"
       },
       "dependencies": {
         "lazy-cache": {
@@ -624,7 +624,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -635,13 +635,13 @@
       "integrity": "sha1-uky+t0tdG97m1SipZa07fZbe8Og=",
       "dev": true,
       "requires": {
-        "assemble-handle": "0.1.4",
-        "extend-shallow": "2.0.1",
-        "is-valid-app": "0.2.1",
-        "lazy-cache": "2.0.2",
-        "stream-combiner": "0.2.2",
-        "through2": "2.0.3",
-        "vinyl-fs": "2.4.4"
+        "assemble-handle": "^0.1.2",
+        "extend-shallow": "^2.0.1",
+        "is-valid-app": "^0.2.0",
+        "lazy-cache": "^2.0.1",
+        "stream-combiner": "^0.2.2",
+        "through2": "^2.0.1",
+        "vinyl-fs": "^2.4.3"
       },
       "dependencies": {
         "lazy-cache": {
@@ -650,7 +650,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         },
         "stream-combiner": {
@@ -659,8 +659,8 @@
           "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
           "dev": true,
           "requires": {
-            "duplexer": "0.1.1",
-            "through": "2.3.8"
+            "duplexer": "~0.1.1",
+            "through": "~2.3.4"
           }
         }
       }
@@ -671,7 +671,7 @@
       "integrity": "sha1-6De1uyPnXJsFJX2AfhYvaSzOIW4=",
       "dev": true,
       "requires": {
-        "through2": "2.0.3"
+        "through2": "^2.0.3"
       }
     },
     "assemble-loader": {
@@ -680,16 +680,16 @@
       "integrity": "sha1-0GmqZBhOFzKEP+HsGAghI1dpVdg=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "file-contents": "0.2.4",
-        "fs-exists-sync": "0.1.0",
-        "has-glob": "0.1.1",
-        "is-registered": "0.1.5",
-        "is-valid-glob": "0.3.0",
-        "is-valid-instance": "0.1.0",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
-        "load-templates": "0.11.4"
+        "extend-shallow": "^2.0.1",
+        "file-contents": "^0.2.4",
+        "fs-exists-sync": "^0.1.0",
+        "has-glob": "^0.1.1",
+        "is-registered": "^0.1.5",
+        "is-valid-glob": "^0.3.0",
+        "is-valid-instance": "^0.1.0",
+        "isobject": "^2.1.0",
+        "lazy-cache": "^2.0.1",
+        "load-templates": "^0.11.3"
       },
       "dependencies": {
         "is-valid-instance": {
@@ -698,8 +698,8 @@
           "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
           "dev": true,
           "requires": {
-            "isobject": "2.1.0",
-            "pascalcase": "0.1.1"
+            "isobject": "^2.1.0",
+            "pascalcase": "^0.1.1"
           }
         },
         "lazy-cache": {
@@ -708,7 +708,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -719,11 +719,11 @@
       "integrity": "sha1-g6qV9e131ctK6oq8dPIkoVRVccY=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "is-valid-app": "0.1.2",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.0",
-        "through2": "2.0.3"
+        "debug": "^2.2.0",
+        "is-valid-app": "^0.1.2",
+        "lazy-cache": "^2.0.1",
+        "mixin-deep": "^1.1.3",
+        "through2": "^2.0.1"
       },
       "dependencies": {
         "is-valid-app": {
@@ -732,10 +732,10 @@
           "integrity": "sha1-L2fLs7r2TWWccNBD/JETm1qLlZA=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "is-registered": "0.1.5",
-            "is-valid-instance": "0.1.0",
-            "lazy-cache": "2.0.2"
+            "debug": "^2.2.0",
+            "is-registered": "^0.1.5",
+            "is-valid-instance": "^0.1.0",
+            "lazy-cache": "^2.0.1"
           }
         },
         "is-valid-instance": {
@@ -744,8 +744,8 @@
           "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
           "dev": true,
           "requires": {
-            "isobject": "2.1.0",
-            "pascalcase": "0.1.1"
+            "isobject": "^2.1.0",
+            "pascalcase": "^0.1.1"
           }
         },
         "lazy-cache": {
@@ -754,7 +754,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -765,13 +765,13 @@
       "integrity": "sha1-kOkhaoNpltJoNwvtrHG7MdjJq18=",
       "dev": true,
       "requires": {
-        "assemble-handle": "0.1.4",
-        "is-registered": "0.1.5",
-        "is-valid-instance": "0.1.0",
-        "lazy-cache": "2.0.2",
-        "match-file": "0.2.2",
-        "src-stream": "0.1.1",
-        "through2": "2.0.3"
+        "assemble-handle": "^0.1.2",
+        "is-registered": "^0.1.4",
+        "is-valid-instance": "^0.1.0",
+        "lazy-cache": "^2.0.1",
+        "match-file": "^0.2.0",
+        "src-stream": "^0.1.1",
+        "through2": "^2.0.1"
       },
       "dependencies": {
         "is-valid-instance": {
@@ -780,8 +780,8 @@
           "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
           "dev": true,
           "requires": {
-            "isobject": "2.1.0",
-            "pascalcase": "0.1.1"
+            "isobject": "^2.1.0",
+            "pascalcase": "^0.1.1"
           }
         },
         "lazy-cache": {
@@ -790,7 +790,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -821,9 +821,9 @@
       "integrity": "sha512-f+IUW5Q6mnQyQVinljOCWd5I+ltgHslVGHS9Jqlp6xIos3C+I9Bl0wvViWH++LNsjPcRSxmkWuq+g22YSF4BfA==",
       "dev": true,
       "requires": {
-        "assign-symbols": "0.1.1",
-        "is-primitive": "2.0.0",
-        "kind-of": "5.1.0"
+        "assign-symbols": "^0.1.1",
+        "is-primitive": "^2.0.0",
+        "kind-of": "^5.0.2"
       },
       "dependencies": {
         "assign-symbols": {
@@ -864,10 +864,10 @@
       "integrity": "sha512-mxc+yISkb0vjsuvG3dJCIZXzRWjKndQ9Zo9zNDJ1K2wh9eP0E0oGmOWm+4cFOvW4dA0tGFImTW5tQJHCtn1kIQ==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0",
-        "process-nextick-args": "1.0.7",
-        "stream-exhaust": "1.0.2"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.2",
+        "process-nextick-args": "^1.0.7",
+        "stream-exhaust": "^1.0.1"
       }
     },
     "async-each": {
@@ -888,8 +888,8 @@
       "integrity": "sha512-LfgCyvmK6ZiC7pyqOgli2zfkWL4HYbEb+HXvGgdmqVBgsOOtQz5rSF8Ii/H/1cNNtrfj1KsdZE/lUMeIY3Qcwg==",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "kind-of": "6.0.2"
+        "co": "^4.6.0",
+        "kind-of": "^6.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -906,7 +906,7 @@
       "integrity": "sha1-dnRi1XOACNx16sQkYiNSjyE3E5Y=",
       "dev": true,
       "requires": {
-        "async-done": "0.4.0"
+        "async-done": "^0.4.0"
       },
       "dependencies": {
         "async-done": {
@@ -915,10 +915,10 @@
           "integrity": "sha1-q4BT9fYikPi/xY83zZtzBwszB7k=",
           "dev": true,
           "requires": {
-            "end-of-stream": "0.1.5",
-            "next-tick": "0.2.2",
-            "once": "1.4.0",
-            "stream-exhaust": "1.0.2"
+            "end-of-stream": "^0.1.4",
+            "next-tick": "^0.2.2",
+            "once": "^1.3.0",
+            "stream-exhaust": "^1.0.0"
           }
         },
         "end-of-stream": {
@@ -927,7 +927,7 @@
           "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
           "dev": true,
           "requires": {
-            "once": "1.3.3"
+            "once": "~1.3.0"
           },
           "dependencies": {
             "once": {
@@ -936,7 +936,7 @@
               "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
               "dev": true,
               "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
               }
             }
           }
@@ -977,9 +977,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       }
     },
     "babel-core": {
@@ -988,25 +988,25 @@
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.0",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "debug": "^2.6.8",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.7",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.6"
       }
     },
     "babel-generator": {
@@ -1015,14 +1015,14 @@
       "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
       "dev": true,
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.6",
+        "trim-right": "^1.0.1"
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -1031,9 +1031,9 @@
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-call-delegate": {
@@ -1042,10 +1042,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-define-map": {
@@ -1054,10 +1054,10 @@
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -1066,9 +1066,9 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-function-name": {
@@ -1077,11 +1077,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -1090,8 +1090,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -1100,8 +1100,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -1110,8 +1110,8 @@
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
@@ -1120,9 +1120,9 @@
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -1131,11 +1131,11 @@
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-replace-supers": {
@@ -1144,12 +1144,12 @@
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helpers": {
@@ -1158,8 +1158,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-messages": {
@@ -1168,7 +1168,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -1177,7 +1177,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-external-helpers": {
@@ -1186,7 +1186,7 @@
       "integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -1213,9 +1213,9 @@
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -1224,7 +1224,7 @@
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1233,7 +1233,7 @@
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -1242,11 +1242,11 @@
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -1255,15 +1255,15 @@
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -1272,8 +1272,8 @@
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -1282,7 +1282,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -1291,8 +1291,8 @@
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -1301,7 +1301,7 @@
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -1310,9 +1310,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -1321,7 +1321,7 @@
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -1330,9 +1330,9 @@
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -1341,10 +1341,10 @@
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -1353,9 +1353,9 @@
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -1364,9 +1364,9 @@
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -1375,8 +1375,8 @@
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -1385,12 +1385,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -1399,8 +1399,8 @@
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -1409,7 +1409,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -1418,9 +1418,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -1429,7 +1429,7 @@
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -1438,7 +1438,7 @@
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -1447,9 +1447,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -1458,9 +1458,9 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -1469,7 +1469,7 @@
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "0.10.1"
+        "regenerator-transform": "^0.10.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -1478,8 +1478,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-preset-env": {
@@ -1488,36 +1488,36 @@
       "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.11.3",
-        "invariant": "2.2.2",
-        "semver": "5.5.0"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^2.1.2",
+        "invariant": "^2.2.2",
+        "semver": "^5.3.0"
       }
     },
     "babel-register": {
@@ -1526,13 +1526,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       }
     },
     "babel-runtime": {
@@ -1541,8 +1541,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-template": {
@@ -1551,11 +1551,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -1564,15 +1564,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       }
     },
     "babel-types": {
@@ -1581,10 +1581,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babylon": {
@@ -1599,14 +1599,14 @@
       "integrity": "sha1-P/pqN0F3PrwNJL5f2kvF6FtbHaE=",
       "dev": true,
       "requires": {
-        "async-done": "1.2.4",
-        "async-settle": "0.2.1",
-        "lodash.filter": "4.6.0",
-        "lodash.flatten": "4.4.0",
-        "lodash.foreach": "4.5.0",
-        "lodash.initial": "4.1.1",
-        "lodash.last": "3.0.0",
-        "lodash.map": "4.6.0",
+        "async-done": "^1.1.1",
+        "async-settle": "^0.2.1",
+        "lodash.filter": "^4.1.0",
+        "lodash.flatten": "^4.0.0",
+        "lodash.foreach": "^4.0.0",
+        "lodash.initial": "^4.0.1",
+        "lodash.last": "^3.0.0",
+        "lodash.map": "^4.1.0",
         "now-and-later": "0.0.6"
       }
     },
@@ -1621,13 +1621,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.0",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1636,7 +1636,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -1645,7 +1645,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -1654,7 +1654,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -1663,9 +1663,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "isobject": {
@@ -1688,13 +1688,13 @@
       "integrity": "sha1-BalXHNwnaUDeGW/8h07uuJnLED0=",
       "dev": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "arr-union": "3.1.0",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "expand-args": "0.4.3",
-        "extend-shallow": "2.0.1",
-        "lazy-cache": "1.0.4"
+        "arr-diff": "^2.0.0",
+        "arr-union": "^3.1.0",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "expand-args": "^0.4.1",
+        "extend-shallow": "^2.0.1",
+        "lazy-cache": "^1.0.3"
       }
     },
     "base-cli": {
@@ -1703,8 +1703,8 @@
       "integrity": "sha1-U+Zdjg9bKKoRBo/sjdTpXXLvPOg=",
       "dev": true,
       "requires": {
-        "base-argv": "0.4.5",
-        "base-config": "0.5.2"
+        "base-argv": "^0.4.2",
+        "base-config": "^0.5.2"
       }
     },
     "base-cli-process": {
@@ -1713,26 +1713,26 @@
       "integrity": "sha1-Mg08gVTfcQltSBgY52/m1+R5NjY=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "arrayify-compact": "0.2.0",
-        "base-cli": "0.5.0",
-        "base-cli-schema": "0.1.19",
-        "base-config-process": "0.1.9",
-        "base-cwd": "0.3.4",
-        "base-option": "0.8.4",
-        "base-pkg": "0.2.5",
-        "debug": "2.6.9",
-        "export-files": "2.1.1",
-        "fs-exists-sync": "0.1.0",
-        "is-valid-app": "0.2.1",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "log-utils": "0.2.1",
-        "merge-deep": "3.0.0",
-        "mixin-deep": "1.3.0",
-        "object.pick": "1.3.0",
-        "pad-right": "0.2.2",
-        "union-value": "1.0.0"
+        "arr-union": "^3.1.0",
+        "arrayify-compact": "^0.2.0",
+        "base-cli": "^0.5.0",
+        "base-cli-schema": "^0.1.19",
+        "base-config-process": "^0.1.9",
+        "base-cwd": "^0.3.4",
+        "base-option": "^0.8.4",
+        "base-pkg": "^0.2.4",
+        "debug": "^2.6.2",
+        "export-files": "^2.1.1",
+        "fs-exists-sync": "^0.1.0",
+        "is-valid-app": "^0.2.1",
+        "kind-of": "^3.1.0",
+        "lazy-cache": "^2.0.2",
+        "log-utils": "^0.2.1",
+        "merge-deep": "^3.0.0",
+        "mixin-deep": "^1.2.0",
+        "object.pick": "^1.2.0",
+        "pad-right": "^0.2.2",
+        "union-value": "^1.0.0"
       },
       "dependencies": {
         "lazy-cache": {
@@ -1741,7 +1741,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -1752,23 +1752,23 @@
       "integrity": "sha1-gfQYL0zwu4NnHxF2PknLBbkugkE=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-unique": "0.2.1",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "export-files": "2.1.1",
-        "extend-shallow": "2.0.1",
-        "falsey": "0.3.2",
-        "fs-exists-sync": "0.1.0",
-        "has-glob": "0.1.1",
-        "has-value": "0.3.1",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "map-schema": "0.2.4",
-        "merge-deep": "3.0.0",
-        "mixin-deep": "1.3.0",
-        "resolve": "1.5.0",
-        "tableize-object": "0.1.0"
+        "arr-flatten": "^1.0.1",
+        "array-unique": "^0.2.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "export-files": "^2.1.1",
+        "extend-shallow": "^2.0.1",
+        "falsey": "^0.3.0",
+        "fs-exists-sync": "^0.1.0",
+        "has-glob": "^0.1.1",
+        "has-value": "^0.3.1",
+        "kind-of": "^3.0.3",
+        "lazy-cache": "^2.0.1",
+        "map-schema": "^0.2.3",
+        "merge-deep": "^3.0.0",
+        "mixin-deep": "^1.1.3",
+        "resolve": "^1.1.7",
+        "tableize-object": "^0.1.0"
       },
       "dependencies": {
         "lazy-cache": {
@@ -1777,7 +1777,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -1788,9 +1788,9 @@
       "integrity": "sha1-reSal/WiRIvVa8s0C090aMb74tc=",
       "dev": true,
       "requires": {
-        "copy-task": "0.1.0",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.0"
+        "copy-task": "^0.1.0",
+        "lazy-cache": "^2.0.1",
+        "mixin-deep": "^1.1.3"
       },
       "dependencies": {
         "lazy-cache": {
@@ -1799,7 +1799,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -1810,10 +1810,10 @@
       "integrity": "sha1-q2A8AdExWL4uYux3/7Ix4o9Ijh8=",
       "dev": true,
       "requires": {
-        "isobject": "2.1.0",
-        "lazy-cache": "1.0.4",
-        "map-config": "0.5.0",
-        "resolve-dir": "0.1.1"
+        "isobject": "^2.0.0",
+        "lazy-cache": "^1.0.3",
+        "map-config": "^0.5.0",
+        "resolve-dir": "^0.1.0"
       }
     },
     "base-config-process": {
@@ -1822,16 +1822,16 @@
       "integrity": "sha1-imOmGYnuY1UMyM/cP2wCdf2gtG4=",
       "dev": true,
       "requires": {
-        "base-config": "0.5.2",
-        "base-config-schema": "0.1.24",
-        "base-cwd": "0.3.4",
-        "base-option": "0.8.4",
-        "debug": "2.6.9",
-        "export-files": "2.1.1",
-        "is-valid-app": "0.2.1",
-        "lazy-cache": "2.0.2",
-        "micromatch": "2.3.11",
-        "mixin-deep": "1.3.0"
+        "base-config": "^0.5.2",
+        "base-config-schema": "^0.1.18",
+        "base-cwd": "^0.3.4",
+        "base-option": "^0.8.4",
+        "debug": "^2.2.0",
+        "export-files": "^2.1.1",
+        "is-valid-app": "^0.2.0",
+        "lazy-cache": "^2.0.1",
+        "micromatch": "^2.3.10",
+        "mixin-deep": "^1.1.3"
       },
       "dependencies": {
         "lazy-cache": {
@@ -1840,7 +1840,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -1851,24 +1851,24 @@
       "integrity": "sha1-T74UvsVtwa7ef+3QaSjpGfhyH6k=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-unique": "0.3.2",
-        "base-pkg": "0.2.5",
-        "camel-case": "3.0.0",
-        "debug": "2.6.9",
-        "define-property": "1.0.0",
-        "export-files": "2.1.1",
-        "extend-shallow": "2.0.1",
-        "has-glob": "1.0.0",
-        "has-value": "0.3.1",
-        "inflection": "1.12.0",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "load-templates": "1.0.2",
-        "map-schema": "0.2.4",
-        "matched": "0.4.4",
-        "mixin-deep": "1.3.0",
-        "resolve": "1.5.0"
+        "arr-flatten": "^1.0.3",
+        "array-unique": "^0.3.2",
+        "base-pkg": "^0.2.4",
+        "camel-case": "^3.0.0",
+        "debug": "^2.6.6",
+        "define-property": "^1.0.0",
+        "export-files": "^2.1.1",
+        "extend-shallow": "^2.0.1",
+        "has-glob": "^1.0.0",
+        "has-value": "^0.3.1",
+        "inflection": "^1.12.0",
+        "kind-of": "^3.2.0",
+        "lazy-cache": "^2.0.2",
+        "load-templates": "^1.0.2",
+        "map-schema": "^0.2.4",
+        "matched": "^0.4.4",
+        "mixin-deep": "^1.2.0",
+        "resolve": "^1.3.3"
       },
       "dependencies": {
         "array-unique": {
@@ -1895,7 +1895,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "file-contents": {
@@ -1904,14 +1904,14 @@
           "integrity": "sha1-ryW7/T00RjhPrYBmSdiAi8/uHsg=",
           "dev": true,
           "requires": {
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "is-buffer": "1.1.6",
-            "kind-of": "3.2.2",
-            "lazy-cache": "2.0.2",
-            "strip-bom-buffer": "0.1.1",
-            "strip-bom-string": "0.1.2",
-            "through2": "2.0.3"
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "is-buffer": "^1.1.4",
+            "kind-of": "^3.1.0",
+            "lazy-cache": "^2.0.2",
+            "strip-bom-buffer": "^0.1.1",
+            "strip-bom-string": "^0.1.2",
+            "through2": "^2.0.3"
           },
           "dependencies": {
             "define-property": {
@@ -1920,7 +1920,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
@@ -1929,7 +1929,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               }
             },
             "is-data-descriptor": {
@@ -1938,7 +1938,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               }
             },
             "is-descriptor": {
@@ -1947,9 +1947,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               },
               "dependencies": {
                 "kind-of": {
@@ -1968,12 +1968,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "glob-parent": {
@@ -1982,8 +1982,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
           }
         },
         "has-glob": {
@@ -1992,7 +1992,7 @@
           "integrity": "sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=",
           "dev": true,
           "requires": {
-            "is-glob": "3.1.0"
+            "is-glob": "^3.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -2001,7 +2001,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -2018,7 +2018,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -2035,9 +2035,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -2060,7 +2060,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         },
         "lazy-cache": {
@@ -2069,7 +2069,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         },
         "load-templates": {
@@ -2078,14 +2078,14 @@
           "integrity": "sha1-CfOOlcjvS/t4W9f8qOv9MrIwvIc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "file-contents": "1.0.1",
-            "glob-parent": "3.1.0",
-            "is-glob": "3.1.0",
-            "kind-of": "3.2.2",
-            "lazy-cache": "2.0.2",
-            "matched": "0.4.4",
-            "vinyl": "2.1.0"
+            "extend-shallow": "^2.0.1",
+            "file-contents": "^1.0.0",
+            "glob-parent": "^3.1.0",
+            "is-glob": "^3.1.0",
+            "kind-of": "^3.1.0",
+            "lazy-cache": "^2.0.2",
+            "matched": "^0.4.4",
+            "vinyl": "^2.0.1"
           }
         },
         "matched": {
@@ -2094,15 +2094,15 @@
           "integrity": "sha1-Vte36xgDPwz5vFLrIJD6x9weifo=",
           "dev": true,
           "requires": {
-            "arr-union": "3.1.0",
-            "async-array-reduce": "0.2.1",
-            "extend-shallow": "2.0.1",
-            "fs-exists-sync": "0.1.0",
-            "glob": "7.1.2",
-            "has-glob": "0.1.1",
-            "is-valid-glob": "0.3.0",
-            "lazy-cache": "2.0.2",
-            "resolve-dir": "0.1.1"
+            "arr-union": "^3.1.0",
+            "async-array-reduce": "^0.2.0",
+            "extend-shallow": "^2.0.1",
+            "fs-exists-sync": "^0.1.0",
+            "glob": "^7.0.5",
+            "has-glob": "^0.1.1",
+            "is-valid-glob": "^0.3.0",
+            "lazy-cache": "^2.0.1",
+            "resolve-dir": "^0.1.0"
           },
           "dependencies": {
             "has-glob": {
@@ -2111,7 +2111,7 @@
               "integrity": "sha1-omHEwqbGZ+DHe3AKfyl8Oe86pYk=",
               "dev": true,
               "requires": {
-                "is-glob": "2.0.1"
+                "is-glob": "^2.0.1"
               }
             },
             "is-extglob": {
@@ -2126,7 +2126,7 @@
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
               "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
               }
             }
           }
@@ -2143,12 +2143,12 @@
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "dev": true,
           "requires": {
-            "clone": "2.1.1",
-            "clone-buffer": "1.0.0",
-            "clone-stats": "1.0.0",
-            "cloneable-readable": "1.0.0",
-            "remove-trailing-separator": "1.1.0",
-            "replace-ext": "1.0.0"
+            "clone": "^2.1.1",
+            "clone-buffer": "^1.0.0",
+            "clone-stats": "^1.0.0",
+            "cloneable-readable": "^1.0.0",
+            "remove-trailing-separator": "^1.0.1",
+            "replace-ext": "^1.0.0"
           }
         }
       }
@@ -2159,9 +2159,9 @@
       "integrity": "sha1-TQCrY1CgRuGtSrnCMm2heUs+TwE=",
       "dev": true,
       "requires": {
-        "empty-dir": "0.2.1",
-        "find-pkg": "0.1.2",
-        "is-valid-app": "0.2.1"
+        "empty-dir": "^0.2.0",
+        "find-pkg": "^0.1.2",
+        "is-valid-app": "^0.2.0"
       }
     },
     "base-data": {
@@ -2170,22 +2170,22 @@
       "integrity": "sha512-wH2ViG6CUO2AaeHSEt6fJTyQAk5gl0oY456DoSC5h8mnHrWUbvdctMCuF53CXgBmi0oalZQppKNH0iamG5+uqw==",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "cache-base": "1.0.1",
-        "extend-shallow": "2.0.1",
-        "get-value": "2.0.6",
-        "has-glob": "1.0.0",
-        "has-value": "1.0.0",
-        "is-registered": "0.1.5",
-        "is-valid-app": "0.3.0",
-        "kind-of": "5.1.0",
-        "lazy-cache": "2.0.2",
-        "merge-value": "1.0.0",
-        "mixin-deep": "1.3.0",
-        "read-file": "0.2.0",
-        "resolve-glob": "1.0.0",
-        "set-value": "2.0.0",
-        "union-value": "1.0.0"
+        "arr-flatten": "^1.1.0",
+        "cache-base": "^1.0.0",
+        "extend-shallow": "^2.0.1",
+        "get-value": "^2.0.6",
+        "has-glob": "^1.0.0",
+        "has-value": "^1.0.0",
+        "is-registered": "^0.1.5",
+        "is-valid-app": "^0.3.0",
+        "kind-of": "^5.0.0",
+        "lazy-cache": "^2.0.2",
+        "merge-value": "^1.0.0",
+        "mixin-deep": "^1.2.0",
+        "read-file": "^0.2.0",
+        "resolve-glob": "^1.0.0",
+        "set-value": "^2.0.0",
+        "union-value": "^1.0.0"
       },
       "dependencies": {
         "has-glob": {
@@ -2194,7 +2194,7 @@
           "integrity": "sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=",
           "dev": true,
           "requires": {
-            "is-glob": "3.1.0"
+            "is-glob": "^3.0.0"
           }
         },
         "has-value": {
@@ -2203,9 +2203,9 @@
           "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
           "dev": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "1.0.0",
-            "isobject": "3.0.1"
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
           }
         },
         "is-extglob": {
@@ -2220,7 +2220,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         },
         "is-valid-app": {
@@ -2229,10 +2229,10 @@
           "integrity": "sha1-eBBrdR88oyOF+0VJK/KUF7WZPIA=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "is-registered": "0.1.5",
-            "is-valid-instance": "0.3.0",
-            "lazy-cache": "2.0.2"
+            "debug": "^2.6.3",
+            "is-registered": "^0.1.5",
+            "is-valid-instance": "^0.3.0",
+            "lazy-cache": "^2.0.2"
           }
         },
         "is-valid-instance": {
@@ -2241,8 +2241,8 @@
           "integrity": "sha1-9KxzAjxNTYubw7PsPmZjBRbijp4=",
           "dev": true,
           "requires": {
-            "isobject": "3.0.1",
-            "pascalcase": "0.1.1"
+            "isobject": "^3.0.0",
+            "pascalcase": "^0.1.1"
           }
         },
         "isobject": {
@@ -2263,7 +2263,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         },
         "set-value": {
@@ -2272,10 +2272,10 @@
           "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "split-string": "3.1.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
           }
         }
       }
@@ -2286,11 +2286,11 @@
       "integrity": "sha1-aXgAyoq4iKM3iXONv6zLgYoqWns=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "engine-cache": "0.19.4",
-        "is-valid-app": "0.1.2",
-        "lazy-cache": "2.0.2"
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "engine-cache": "^0.19.0",
+        "is-valid-app": "^0.1.2",
+        "lazy-cache": "^2.0.1"
       },
       "dependencies": {
         "is-valid-app": {
@@ -2299,10 +2299,10 @@
           "integrity": "sha1-L2fLs7r2TWWccNBD/JETm1qLlZA=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "is-registered": "0.1.5",
-            "is-valid-instance": "0.1.0",
-            "lazy-cache": "2.0.2"
+            "debug": "^2.2.0",
+            "is-registered": "^0.1.5",
+            "is-valid-instance": "^0.1.0",
+            "lazy-cache": "^2.0.1"
           }
         },
         "is-valid-instance": {
@@ -2311,8 +2311,8 @@
           "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
           "dev": true,
           "requires": {
-            "isobject": "2.1.0",
-            "pascalcase": "0.1.1"
+            "isobject": "^2.1.0",
+            "pascalcase": "^0.1.1"
           }
         },
         "lazy-cache": {
@@ -2321,7 +2321,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -2332,18 +2332,18 @@
       "integrity": "sha1-a6t5ZzKTMm34X6YfVRaG9MLx9HI=",
       "dev": true,
       "requires": {
-        "base-namespace": "0.2.0",
-        "contains-path": "0.1.0",
-        "debug": "2.6.9",
-        "extend-shallow": "2.0.1",
-        "fs-exists-sync": "0.1.0",
-        "global-modules": "0.2.3",
-        "is-absolute": "0.2.6",
-        "is-valid-app": "0.1.2",
-        "is-valid-instance": "0.1.0",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "os-homedir": "1.0.2",
+        "base-namespace": "^0.2.0",
+        "contains-path": "^0.1.0",
+        "debug": "^2.2.0",
+        "extend-shallow": "^2.0.1",
+        "fs-exists-sync": "^0.1.0",
+        "global-modules": "^0.2.2",
+        "is-absolute": "^0.2.5",
+        "is-valid-app": "^0.1.0",
+        "is-valid-instance": "^0.1.0",
+        "kind-of": "^3.0.3",
+        "lazy-cache": "^2.0.1",
+        "os-homedir": "^1.0.1",
         "resolve-file": "github:jonschlinkert/resolve-file#261082c95a5f407c43d82797c13bae3527462842"
       },
       "dependencies": {
@@ -2353,8 +2353,8 @@
           "integrity": "sha1-FyQAaUBXwioTsM8WFix+S3p/5Wc=",
           "dev": true,
           "requires": {
-            "find-pkg": "0.1.2",
-            "fs-exists-sync": "0.1.0"
+            "find-pkg": "^0.1.2",
+            "fs-exists-sync": "^0.1.0"
           }
         },
         "expand-tilde": {
@@ -2363,7 +2363,7 @@
           "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
           "dev": true,
           "requires": {
-            "os-homedir": "1.0.2"
+            "os-homedir": "^1.0.1"
           }
         },
         "is-valid-app": {
@@ -2372,10 +2372,10 @@
           "integrity": "sha1-L2fLs7r2TWWccNBD/JETm1qLlZA=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "is-registered": "0.1.5",
-            "is-valid-instance": "0.1.0",
-            "lazy-cache": "2.0.2"
+            "debug": "^2.2.0",
+            "is-registered": "^0.1.5",
+            "is-valid-instance": "^0.1.0",
+            "lazy-cache": "^2.0.1"
           }
         },
         "is-valid-instance": {
@@ -2384,8 +2384,8 @@
           "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
           "dev": true,
           "requires": {
-            "isobject": "2.1.0",
-            "pascalcase": "0.1.1"
+            "isobject": "^2.1.0",
+            "pascalcase": "^0.1.1"
           }
         },
         "lazy-cache": {
@@ -2394,21 +2394,22 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         },
         "resolve-file": {
           "version": "github:jonschlinkert/resolve-file#261082c95a5f407c43d82797c13bae3527462842",
+          "from": "resolve-file@github:jonschlinkert/resolve-file#261082c95a5f407c43d82797c13bae3527462842",
           "dev": true,
           "requires": {
-            "cwd": "0.10.0",
-            "expand-tilde": "1.2.2",
-            "extend-shallow": "2.0.1",
-            "fs-exists-sync": "0.1.0",
-            "global-modules": "0.2.3",
-            "lazy-cache": "2.0.2",
-            "os-homedir": "1.0.2",
-            "resolve": "1.5.0"
+            "cwd": "^0.10.0",
+            "expand-tilde": "^1.2.2",
+            "extend-shallow": "^2.0.1",
+            "fs-exists-sync": "^0.1.0",
+            "global-modules": "^0.2.2",
+            "lazy-cache": "^2.0.1",
+            "os-homedir": "^1.0.1",
+            "resolve": "^1.1.7"
           }
         }
       }
@@ -2419,24 +2420,24 @@
       "integrity": "sha1-4amTYh5bRCr44MgRMVoyb5h8nqY=",
       "dev": true,
       "requires": {
-        "async-each-series": "1.1.0",
-        "base-compose": "0.2.1",
-        "base-cwd": "0.3.4",
-        "base-data": "0.6.2",
-        "base-env": "0.3.0",
-        "base-option": "0.8.4",
-        "base-pkg": "0.2.5",
-        "base-plugins": "0.4.13",
-        "base-task": "0.6.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "global-modules": "0.2.3",
-        "is-valid-app": "0.2.1",
-        "is-valid-instance": "0.2.0",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.0"
+        "async-each-series": "^1.1.0",
+        "base-compose": "^0.2.1",
+        "base-cwd": "^0.3.1",
+        "base-data": "^0.6.0",
+        "base-env": "^0.3.0",
+        "base-option": "^0.8.4",
+        "base-pkg": "^0.2.4",
+        "base-plugins": "^0.4.13",
+        "base-task": "^0.6.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "global-modules": "^0.2.2",
+        "is-valid-app": "^0.2.0",
+        "is-valid-instance": "^0.2.0",
+        "kind-of": "^3.0.3",
+        "lazy-cache": "^2.0.1",
+        "mixin-deep": "^1.1.3"
       },
       "dependencies": {
         "lazy-cache": {
@@ -2445,7 +2446,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -2456,11 +2457,11 @@
       "integrity": "sha1-2k4eKy+ACOzc6T8R79223gYzP7M=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "is-valid-app": "0.1.2",
-        "lazy-cache": "2.0.2",
-        "load-helpers": "0.2.11"
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "is-valid-app": "^0.1.0",
+        "lazy-cache": "^2.0.1",
+        "load-helpers": "^0.2.11"
       },
       "dependencies": {
         "is-valid-app": {
@@ -2469,10 +2470,10 @@
           "integrity": "sha1-L2fLs7r2TWWccNBD/JETm1qLlZA=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "is-registered": "0.1.5",
-            "is-valid-instance": "0.1.0",
-            "lazy-cache": "2.0.2"
+            "debug": "^2.2.0",
+            "is-registered": "^0.1.5",
+            "is-valid-instance": "^0.1.0",
+            "lazy-cache": "^2.0.1"
           }
         },
         "is-valid-instance": {
@@ -2481,8 +2482,8 @@
           "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
           "dev": true,
           "requires": {
-            "isobject": "2.1.0",
-            "pascalcase": "0.1.1"
+            "isobject": "^2.1.0",
+            "pascalcase": "^0.1.1"
           }
         },
         "lazy-cache": {
@@ -2491,7 +2492,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -2502,7 +2503,7 @@
       "integrity": "sha1-RLLLumZ1Y8xE5trrTv5AO7CrPaA=",
       "dev": true,
       "requires": {
-        "is-valid-app": "0.1.2"
+        "is-valid-app": "^0.1.0"
       },
       "dependencies": {
         "is-valid-app": {
@@ -2511,10 +2512,10 @@
           "integrity": "sha1-L2fLs7r2TWWccNBD/JETm1qLlZA=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "is-registered": "0.1.5",
-            "is-valid-instance": "0.1.0",
-            "lazy-cache": "2.0.2"
+            "debug": "^2.2.0",
+            "is-registered": "^0.1.5",
+            "is-valid-instance": "^0.1.0",
+            "lazy-cache": "^2.0.1"
           }
         },
         "is-valid-instance": {
@@ -2523,8 +2524,8 @@
           "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
           "dev": true,
           "requires": {
-            "isobject": "2.1.0",
-            "pascalcase": "0.1.1"
+            "isobject": "^2.1.0",
+            "pascalcase": "^0.1.1"
           }
         },
         "lazy-cache": {
@@ -2533,7 +2534,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -2544,14 +2545,14 @@
       "integrity": "sha1-EUF/qSRPInpNU3tNKRcjRieH1cc=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "get-value": "2.0.6",
-        "is-valid-app": "0.2.1",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.0",
-        "option-cache": "3.5.0",
-        "set-value": "0.3.3"
+        "define-property": "^0.2.5",
+        "get-value": "^2.0.6",
+        "is-valid-app": "^0.2.0",
+        "isobject": "^2.1.0",
+        "lazy-cache": "^2.0.1",
+        "mixin-deep": "^1.1.3",
+        "option-cache": "^3.4.0",
+        "set-value": "^0.3.3"
       },
       "dependencies": {
         "lazy-cache": {
@@ -2560,7 +2561,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -2571,14 +2572,14 @@
       "integrity": "sha512-/POxajlgBhVsknwLXnqnbp//bAMh7SkDgHF+z/uoYnFqk46e05c3MxSEmn5vFCB8g4rHHKxAPLKrU/4Yb3vUdA==",
       "dev": true,
       "requires": {
-        "cache-base": "1.0.1",
-        "debug": "2.6.9",
-        "define-property": "1.0.0",
-        "expand-pkg": "0.1.8",
-        "extend-shallow": "2.0.1",
-        "is-valid-app": "0.3.0",
-        "log-utils": "0.2.1",
-        "pkg-store": "0.2.2"
+        "cache-base": "^1.0.0",
+        "debug": "^2.6.8",
+        "define-property": "^1.0.0",
+        "expand-pkg": "^0.1.8",
+        "extend-shallow": "^2.0.1",
+        "is-valid-app": "^0.3.0",
+        "log-utils": "^0.2.1",
+        "pkg-store": "^0.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -2587,7 +2588,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -2596,7 +2597,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -2605,7 +2606,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -2614,9 +2615,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "is-valid-app": {
@@ -2625,10 +2626,10 @@
           "integrity": "sha1-eBBrdR88oyOF+0VJK/KUF7WZPIA=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "is-registered": "0.1.5",
-            "is-valid-instance": "0.3.0",
-            "lazy-cache": "2.0.2"
+            "debug": "^2.6.3",
+            "is-registered": "^0.1.5",
+            "is-valid-instance": "^0.3.0",
+            "lazy-cache": "^2.0.2"
           }
         },
         "is-valid-instance": {
@@ -2637,8 +2638,8 @@
           "integrity": "sha1-9KxzAjxNTYubw7PsPmZjBRbijp4=",
           "dev": true,
           "requires": {
-            "isobject": "3.0.1",
-            "pascalcase": "0.1.1"
+            "isobject": "^3.0.0",
+            "pascalcase": "^0.1.1"
           }
         },
         "isobject": {
@@ -2659,7 +2660,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -2670,9 +2671,9 @@
       "integrity": "sha1-kd8XjcN/hoQt6ihteeSPuGtarD0=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "is-registered": "0.1.5",
-        "isobject": "2.1.0"
+        "define-property": "^0.2.5",
+        "is-registered": "^0.1.5",
+        "isobject": "^2.1.0"
       }
     },
     "base-project": {
@@ -2681,9 +2682,9 @@
       "integrity": "sha1-hpRKpHwD2ShM561b7NBUPvy57Uo=",
       "dev": true,
       "requires": {
-        "is-registered": "0.1.5",
-        "is-valid-instance": "0.1.0",
-        "project-name": "0.2.6"
+        "is-registered": "^0.1.3",
+        "is-valid-instance": "^0.1.0",
+        "project-name": "^0.2.5"
       },
       "dependencies": {
         "is-valid-instance": {
@@ -2692,8 +2693,8 @@
           "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
           "dev": true,
           "requires": {
-            "isobject": "2.1.0",
-            "pascalcase": "0.1.1"
+            "isobject": "^2.1.0",
+            "pascalcase": "^0.1.1"
           }
         }
       }
@@ -2704,15 +2705,15 @@
       "integrity": "sha1-9k+EgmHtbIKPSYPXgS9A0wN4IUY=",
       "dev": true,
       "requires": {
-        "base-store": "0.4.4",
-        "clone-deep": "0.2.4",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "is-valid-app": "0.2.1",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.0",
-        "question-store": "0.11.1"
+        "base-store": "^0.4.4",
+        "clone-deep": "^0.2.4",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "is-valid-app": "^0.2.0",
+        "isobject": "^2.1.0",
+        "lazy-cache": "^2.0.1",
+        "mixin-deep": "^1.1.3",
+        "question-store": "^0.11.0"
       },
       "dependencies": {
         "lazy-cache": {
@@ -2721,7 +2722,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -2732,11 +2733,11 @@
       "integrity": "sha1-CmFNFy1JBF2Mk4dxP4YN88QFNB4=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "en-route": "0.7.5",
-        "is-valid-app": "0.2.1",
-        "lazy-cache": "2.0.2",
-        "template-error": "0.1.2"
+        "debug": "^2.2.0",
+        "en-route": "^0.7.5",
+        "is-valid-app": "^0.2.0",
+        "lazy-cache": "^2.0.1",
+        "template-error": "^0.1.2"
       },
       "dependencies": {
         "lazy-cache": {
@@ -2745,7 +2746,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -2756,12 +2757,12 @@
       "integrity": "sha1-GI4+ZoJMyxWYsyh7TqW5NaG4UEU=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-valid-app": "0.2.1",
-        "lazy-cache": "2.0.2",
-        "log-utils": "0.1.5",
-        "micromatch": "2.3.11",
-        "time-diff": "0.3.1"
+        "extend-shallow": "^2.0.1",
+        "is-valid-app": "^0.2.0",
+        "lazy-cache": "^2.0.1",
+        "log-utils": "^0.1.4",
+        "micromatch": "^2.3.10",
+        "time-diff": "^0.3.1"
       },
       "dependencies": {
         "ansi-colors": {
@@ -2770,33 +2771,33 @@
           "integrity": "sha1-M0rDbNPq1wjeXGnhmpjRhkImtD8=",
           "dev": true,
           "requires": {
-            "ansi-bgblack": "0.1.1",
-            "ansi-bgblue": "0.1.1",
-            "ansi-bgcyan": "0.1.1",
-            "ansi-bggreen": "0.1.1",
-            "ansi-bgmagenta": "0.1.1",
-            "ansi-bgred": "0.1.1",
-            "ansi-bgwhite": "0.1.1",
-            "ansi-bgyellow": "0.1.1",
-            "ansi-black": "0.1.1",
-            "ansi-blue": "0.1.1",
-            "ansi-bold": "0.1.1",
-            "ansi-cyan": "0.1.1",
-            "ansi-dim": "0.1.1",
-            "ansi-gray": "0.1.1",
-            "ansi-green": "0.1.1",
-            "ansi-grey": "0.1.1",
-            "ansi-hidden": "0.1.1",
-            "ansi-inverse": "0.1.1",
-            "ansi-italic": "0.1.1",
-            "ansi-magenta": "0.1.1",
-            "ansi-red": "0.1.1",
-            "ansi-reset": "0.1.1",
-            "ansi-strikethrough": "0.1.1",
-            "ansi-underline": "0.1.1",
-            "ansi-white": "0.1.1",
-            "ansi-yellow": "0.1.1",
-            "lazy-cache": "0.2.7"
+            "ansi-bgblack": "^0.1.1",
+            "ansi-bgblue": "^0.1.1",
+            "ansi-bgcyan": "^0.1.1",
+            "ansi-bggreen": "^0.1.1",
+            "ansi-bgmagenta": "^0.1.1",
+            "ansi-bgred": "^0.1.1",
+            "ansi-bgwhite": "^0.1.1",
+            "ansi-bgyellow": "^0.1.1",
+            "ansi-black": "^0.1.1",
+            "ansi-blue": "^0.1.1",
+            "ansi-bold": "^0.1.1",
+            "ansi-cyan": "^0.1.1",
+            "ansi-dim": "^0.1.1",
+            "ansi-gray": "^0.1.1",
+            "ansi-green": "^0.1.1",
+            "ansi-grey": "^0.1.1",
+            "ansi-hidden": "^0.1.1",
+            "ansi-inverse": "^0.1.1",
+            "ansi-italic": "^0.1.1",
+            "ansi-magenta": "^0.1.1",
+            "ansi-red": "^0.1.1",
+            "ansi-reset": "^0.1.1",
+            "ansi-strikethrough": "^0.1.1",
+            "ansi-underline": "^0.1.1",
+            "ansi-white": "^0.1.1",
+            "ansi-yellow": "^0.1.1",
+            "lazy-cache": "^0.2.4"
           },
           "dependencies": {
             "lazy-cache": {
@@ -2813,7 +2814,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         },
         "log-utils": {
@@ -2822,13 +2823,13 @@
           "integrity": "sha1-3g84+Vf0zW69Xctoddijua4HT3c=",
           "dev": true,
           "requires": {
-            "ansi-colors": "0.1.0",
-            "error-symbol": "0.1.0",
-            "info-symbol": "0.1.0",
-            "log-ok": "0.1.1",
-            "success-symbol": "0.1.0",
-            "time-stamp": "1.1.0",
-            "warning-symbol": "0.1.0"
+            "ansi-colors": "^0.1.0",
+            "error-symbol": "^0.1.0",
+            "info-symbol": "^0.1.0",
+            "log-ok": "^0.1.1",
+            "success-symbol": "^0.1.0",
+            "time-stamp": "^1.0.1",
+            "warning-symbol": "^0.1.0"
           }
         }
       }
@@ -2839,13 +2840,13 @@
       "integrity": "sha1-JY32uKYu4G/xUADJSdD9fCi68mY=",
       "dev": true,
       "requires": {
-        "data-store": "0.16.1",
-        "debug": "2.6.9",
-        "extend-shallow": "2.0.1",
-        "is-registered": "0.1.5",
-        "is-valid-instance": "0.1.0",
-        "lazy-cache": "2.0.2",
-        "project-name": "0.2.6"
+        "data-store": "^0.16.0",
+        "debug": "^2.2.0",
+        "extend-shallow": "^2.0.1",
+        "is-registered": "^0.1.4",
+        "is-valid-instance": "^0.1.0",
+        "lazy-cache": "^2.0.1",
+        "project-name": "^0.2.5"
       },
       "dependencies": {
         "is-valid-instance": {
@@ -2854,8 +2855,8 @@
           "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
           "dev": true,
           "requires": {
-            "isobject": "2.1.0",
-            "pascalcase": "0.1.1"
+            "isobject": "^2.1.0",
+            "pascalcase": "^0.1.1"
           }
         },
         "lazy-cache": {
@@ -2864,7 +2865,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -2875,8 +2876,8 @@
       "integrity": "sha1-Rn1guuBzezuJab/1f6RElJiZgcA=",
       "dev": true,
       "requires": {
-        "composer": "0.13.0",
-        "is-valid-app": "0.1.2"
+        "composer": "^0.13.0",
+        "is-valid-app": "^0.1.0"
       },
       "dependencies": {
         "is-valid-app": {
@@ -2885,10 +2886,10 @@
           "integrity": "sha1-L2fLs7r2TWWccNBD/JETm1qLlZA=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "is-registered": "0.1.5",
-            "is-valid-instance": "0.1.0",
-            "lazy-cache": "2.0.2"
+            "debug": "^2.2.0",
+            "is-registered": "^0.1.5",
+            "is-valid-instance": "^0.1.0",
+            "lazy-cache": "^2.0.1"
           }
         },
         "is-valid-instance": {
@@ -2897,8 +2898,8 @@
           "integrity": "sha1-etXGo4ht/ffZzHgEnO/yFxqZB7M=",
           "dev": true,
           "requires": {
-            "isobject": "2.1.0",
-            "pascalcase": "0.1.1"
+            "isobject": "^2.1.0",
+            "pascalcase": "^0.1.1"
           }
         },
         "lazy-cache": {
@@ -2907,7 +2908,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -2924,7 +2925,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "benchmark": {
@@ -2933,8 +2934,8 @@
       "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4",
-        "platform": "1.3.5"
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
       }
     },
     "big.js": {
@@ -2955,10 +2956,10 @@
       "integrity": "sha1-YJjb/L9Fy1xjcCRUgmu+z4mIkCc=",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.1",
-        "minilog": "2.1.0",
-        "request": "2.83.0",
-        "underscore": "1.8.3"
+        "bluebird": "^3.2.2",
+        "minilog": "^2.0.6",
+        "request": "^2.52.0",
+        "underscore": "^1.7.0"
       },
       "dependencies": {
         "underscore": {
@@ -2975,7 +2976,7 @@
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.5"
       }
     },
     "block-stream": {
@@ -2984,7 +2985,7 @@
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "~2.0.0"
       }
     },
     "bluebird": {
@@ -3005,7 +3006,7 @@
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "dev": true,
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.x.x"
       }
     },
     "brace-expansion": {
@@ -3013,7 +3014,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -3023,9 +3024,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "brorand": {
@@ -3040,12 +3041,12 @@
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "browserify-cipher": {
@@ -3054,9 +3055,9 @@
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.2.0",
-        "browserify-des": "1.0.1",
-        "evp_bytestokey": "1.0.3"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -3065,9 +3066,9 @@
       "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "browserify-rsa": {
@@ -3076,8 +3077,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       }
     },
     "browserify-sign": {
@@ -3086,13 +3087,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "elliptic": "6.4.0",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.1.1"
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
       }
     },
     "browserify-zlib": {
@@ -3101,7 +3102,7 @@
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "1.0.6"
+        "pako": "~1.0.5"
       }
     },
     "browserslist": {
@@ -3110,8 +3111,8 @@
       "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000792",
-        "electron-to-chromium": "1.3.31"
+        "caniuse-lite": "^1.0.30000792",
+        "electron-to-chromium": "^1.3.30"
       }
     },
     "buffer": {
@@ -3121,8 +3122,8 @@
       "dev": true,
       "requires": {
         "base64-js": "0.0.8",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-crc32": {
@@ -3161,19 +3162,19 @@
       "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.1",
-        "chownr": "1.0.1",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "lru-cache": "4.1.1",
-        "mississippi": "2.0.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "promise-inflight": "1.0.1",
-        "rimraf": "2.6.2",
-        "ssri": "5.3.0",
-        "unique-filename": "1.1.0",
-        "y18n": "4.0.0"
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.1",
+        "mississippi": "^2.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^5.2.4",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
       },
       "dependencies": {
         "glob": {
@@ -3182,12 +3183,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -3198,15 +3199,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -3215,9 +3216,9 @@
           "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
           "dev": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "1.0.0",
-            "isobject": "3.0.1"
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
           }
         },
         "isobject": {
@@ -3232,10 +3233,10 @@
           "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "split-string": "3.1.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
           }
         }
       }
@@ -3246,7 +3247,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -3261,8 +3262,8 @@
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2",
-        "upper-case": "1.1.3"
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
       }
     },
     "camelcase": {
@@ -3277,8 +3278,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       }
     },
     "caniuse-lite": {
@@ -3298,10 +3299,10 @@
       "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
       "dev": true,
       "requires": {
-        "get-proxy": "2.1.0",
-        "isurl": "1.0.0",
-        "tunnel-agent": "0.6.0",
-        "url-to-options": "1.0.1"
+        "get-proxy": "^2.0.0",
+        "isurl": "^1.0.0-alpha5",
+        "tunnel-agent": "^0.6.0",
+        "url-to-options": "^1.0.1"
       }
     },
     "center-align": {
@@ -3310,8 +3311,8 @@
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chai": {
@@ -3330,11 +3331,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "chardet": {
@@ -3349,9 +3350,9 @@
       "integrity": "sha1-3f6Wfse7dkPIWqBQJq+h0F9dcNQ=",
       "dev": true,
       "requires": {
-        "ansi-gray": "0.1.1",
-        "debug": "2.6.9",
-        "repeat-string": "1.6.1"
+        "ansi-gray": "^0.1.1",
+        "debug": "^2.2.0",
+        "repeat-string": "^1.5.4"
       }
     },
     "chokidar": {
@@ -3360,15 +3361,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.3",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
       }
     },
     "chownr": {
@@ -3389,8 +3390,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "circular-json": {
@@ -3405,10 +3406,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "isobject": {
@@ -3425,7 +3426,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-width": {
@@ -3441,8 +3442,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -3473,11 +3474,11 @@
       "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-plain-object": "2.0.4",
-        "kind-of": "3.2.2",
-        "lazy-cache": "1.0.4",
-        "shallow-clone": "0.1.2"
+        "for-own": "^0.1.3",
+        "is-plain-object": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "lazy-cache": "^1.0.3",
+        "shallow-clone": "^0.1.2"
       }
     },
     "clone-stats": {
@@ -3492,9 +3493,9 @@
       "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "process-nextick-args": "1.0.7",
-        "through2": "2.0.3"
+        "inherits": "^2.0.1",
+        "process-nextick-args": "^1.0.6",
+        "through2": "^2.0.1"
       }
     },
     "co": {
@@ -3513,8 +3514,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color-convert": {
@@ -3523,7 +3524,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -3543,7 +3544,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -3552,7 +3553,7 @@
       "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
       "dev": true,
       "requires": {
-        "graceful-readlink": "1.0.1"
+        "graceful-readlink": ">= 1.0.0"
       }
     },
     "common-config": {
@@ -3561,19 +3562,19 @@
       "integrity": "sha1-0fGnQa+gy/al7wl1K9/C5nfYtO8=",
       "dev": true,
       "requires": {
-        "composer": "0.13.0",
-        "data-store": "0.16.1",
-        "get-value": "2.0.6",
-        "lazy-cache": "2.0.2",
-        "log-utils": "0.2.1",
-        "object.pick": "1.3.0",
-        "omit-empty": "0.4.1",
-        "question-cache": "0.4.0",
-        "set-value": "0.3.3",
-        "strip-color": "0.1.0",
-        "tableize-object": "0.1.0",
-        "text-table": "0.2.0",
-        "yargs-parser": "2.4.1"
+        "composer": "^0.13.0",
+        "data-store": "^0.16.1",
+        "get-value": "^2.0.6",
+        "lazy-cache": "^2.0.1",
+        "log-utils": "^0.2.0",
+        "object.pick": "^1.1.2",
+        "omit-empty": "^0.4.1",
+        "question-cache": "^0.4.0",
+        "set-value": "^0.3.3",
+        "strip-color": "^0.1.0",
+        "tableize-object": "^0.1.0",
+        "text-table": "^0.2.0",
+        "yargs-parser": "^2.4.0"
       },
       "dependencies": {
         "has-values": {
@@ -3588,7 +3589,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         },
         "question-cache": {
@@ -3597,25 +3598,25 @@
           "integrity": "sha1-4rmTf8X7fcYPu58QXx+iVLM96n0=",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "arr-union": "3.1.0",
+            "arr-flatten": "^1.0.1",
+            "arr-union": "^3.1.0",
             "async": "1.5.2",
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "get-value": "2.0.6",
-            "has-value": "0.3.1",
-            "inquirer2": "0.1.1",
-            "is-answer": "0.1.1",
-            "isobject": "2.1.0",
-            "lazy-cache": "1.0.4",
-            "mixin-deep": "1.3.0",
-            "omit-empty": "0.3.6",
-            "option-cache": "3.5.0",
-            "os-homedir": "1.0.2",
-            "project-name": "0.2.6",
-            "set-value": "0.3.3",
-            "to-choices": "0.2.0",
-            "use": "1.1.2"
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "get-value": "^2.0.5",
+            "has-value": "^0.3.1",
+            "inquirer2": "^0.1.1",
+            "is-answer": "^0.1.0",
+            "isobject": "^2.0.0",
+            "lazy-cache": "^1.0.3",
+            "mixin-deep": "^1.1.3",
+            "omit-empty": "^0.3.6",
+            "option-cache": "^3.3.5",
+            "os-homedir": "^1.0.1",
+            "project-name": "^0.2.4",
+            "set-value": "^0.3.3",
+            "to-choices": "^0.2.0",
+            "use": "^1.1.2"
           },
           "dependencies": {
             "lazy-cache": {
@@ -3630,10 +3631,10 @@
               "integrity": "sha1-bThAXyqmHJEetQT+aIBcVm2FwxY=",
               "dev": true,
               "requires": {
-                "has-values": "0.1.4",
-                "is-date-object": "1.0.1",
-                "isobject": "2.1.0",
-                "reduce-object": "0.1.3"
+                "has-values": "^0.1.4",
+                "is-date-object": "^1.0.1",
+                "isobject": "^2.0.0",
+                "reduce-object": "^0.1.3"
               }
             }
           }
@@ -3646,16 +3647,16 @@
       "integrity": "sha1-Urlj64DwSYU8s/6vNvH8b+7o2ZA=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "is-valid-app": "0.2.1",
-        "isbinaryfile": "3.0.2",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
-        "middleware-rename-file": "0.1.1",
-        "middleware-utils": "0.3.1",
-        "mixin-deep": "1.3.0",
-        "parser-front-matter": "1.6.4"
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "is-valid-app": "^0.2.0",
+        "isbinaryfile": "^3.0.0",
+        "isobject": "^2.1.0",
+        "lazy-cache": "^2.0.1",
+        "middleware-rename-file": "^0.1.0",
+        "middleware-utils": "^0.3.0",
+        "mixin-deep": "^1.1.3",
+        "parser-front-matter": "^1.5.0"
       },
       "dependencies": {
         "lazy-cache": {
@@ -3664,7 +3665,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -3675,21 +3676,21 @@
       "integrity": "sha512-Qo72fpSI2mN8mGVDKHcb4ot8Ytveksh0KEgU9hoMnp8W9kw4uLJisg38/2QMSQH0wikN4vcdBHf/zLdVYBNyuQ==",
       "dev": true,
       "requires": {
-        "base-pkg": "0.2.5",
-        "base-project": "0.2.1",
-        "base-questions": "0.7.4",
-        "camel-case": "3.0.0",
-        "common-config": "0.1.0",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "get-value": "2.0.6",
-        "is-valid-app": "0.2.1",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.0",
-        "omit-empty": "0.4.1",
-        "set-getter": "0.1.0",
-        "set-value": "2.0.0"
+        "base-pkg": "^0.2.4",
+        "base-project": "^0.2.1",
+        "base-questions": "^0.7.4",
+        "camel-case": "^3.0.0",
+        "common-config": "^0.1.0",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "get-value": "^2.0.6",
+        "is-valid-app": "^0.2.0",
+        "lazy-cache": "^2.0.1",
+        "mixin-deep": "^1.2.0",
+        "omit-empty": "^0.4.1",
+        "set-getter": "^0.1.0",
+        "set-value": "^2.0.0"
       },
       "dependencies": {
         "lazy-cache": {
@@ -3698,7 +3699,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         },
         "set-value": {
@@ -3707,10 +3708,10 @@
           "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "split-string": "3.1.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
           }
         }
       }
@@ -3733,18 +3734,18 @@
       "integrity": "sha1-HbyxXxmpBt7uSanD0TfmVLvG0OI=",
       "dev": true,
       "requires": {
-        "array-unique": "0.2.1",
-        "bach": "0.5.0",
-        "co": "4.6.0",
-        "component-emitter": "1.2.1",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "is-generator": "1.0.3",
-        "is-glob": "2.0.1",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
-        "micromatch": "2.3.11",
-        "nanoseconds": "0.1.0"
+        "array-unique": "^0.2.1",
+        "bach": "^0.5.0",
+        "co": "^4.6.0",
+        "component-emitter": "^1.2.1",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "is-generator": "^1.0.3",
+        "is-glob": "^2.0.1",
+        "isobject": "^2.1.0",
+        "lazy-cache": "^2.0.1",
+        "micromatch": "^2.3.8",
+        "nanoseconds": "^0.1.0"
       },
       "dependencies": {
         "lazy-cache": {
@@ -3753,7 +3754,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -3769,9 +3770,9 @@
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "config-chain": {
@@ -3780,8 +3781,8 @@
       "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
       "dev": true,
       "requires": {
-        "ini": "1.3.5",
-        "proto-list": "1.2.4"
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
       }
     },
     "console-browserify": {
@@ -3790,7 +3791,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "console-control-strings": {
@@ -3829,12 +3830,12 @@
       "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "dev": true,
       "requires": {
-        "aproba": "1.1.1",
-        "fs-write-stream-atomic": "1.0.10",
-        "iferr": "0.1.5",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "run-queue": "1.0.3"
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
       }
     },
     "copy-descriptor": {
@@ -3878,13 +3879,13 @@
       "integrity": "sha1-b4NhYlRiTwrViqSqjQdvAmvn4Yg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "nested-error-stacks": "1.0.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "readable-stream": "2.3.3"
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "nested-error-stacks": "^1.0.1",
+        "object-assign": "^4.0.1",
+        "pify": "^2.3.0",
+        "pinkie-promise": "^2.0.0",
+        "readable-stream": "^2.1.4"
       },
       "dependencies": {
         "pify": {
@@ -3901,12 +3902,12 @@
       "integrity": "sha1-tnJn66LzlgugalphrJQDNCKDNCQ=",
       "dev": true,
       "requires": {
-        "cp-file": "3.2.0",
-        "globby": "4.1.0",
-        "meow": "3.7.0",
-        "nested-error-stacks": "1.0.2",
-        "object-assign": "4.1.1",
-        "pinkie-promise": "2.0.1"
+        "cp-file": "^3.1.0",
+        "globby": "^4.0.0",
+        "meow": "^3.6.0",
+        "nested-error-stacks": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "cpy-cli": {
@@ -3915,8 +3916,8 @@
       "integrity": "sha1-Z/taSi3sKMqKv/N13kuecfanVhw=",
       "dev": true,
       "requires": {
-        "cpy": "4.0.1",
-        "meow": "3.7.0"
+        "cpy": "^4.0.0",
+        "meow": "^3.6.0"
       }
     },
     "create-ecdh": {
@@ -3925,8 +3926,8 @@
       "integrity": "sha512-iZvCCg8XqHQZ1ioNBTzXS/cQSkqkqcPs8xSX4upNB+DAk9Ht3uzQf2J32uAHNCne8LDmKr29AgZrEs4oIrwLuQ==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       }
     },
     "create-hash": {
@@ -3935,11 +3936,11 @@
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "md5.js": "1.3.4",
-        "ripemd160": "2.0.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -3948,12 +3949,12 @@
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "cross-env": {
@@ -3962,8 +3963,8 @@
       "integrity": "sha512-UOokgwvDzCT0mqRSLEkJzUhYXB1vK3E5UgDrD41QiXsm9UetcW2rCGHYz/O3p873lMJ1VZbFCF9Izkwh7nYR5A==",
       "dev": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "is-windows": "1.0.1"
+        "cross-spawn": "^5.1.0",
+        "is-windows": "^1.0.0"
       }
     },
     "cross-spawn": {
@@ -3972,9 +3973,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "cryptiles": {
@@ -3983,7 +3984,7 @@
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "dev": true,
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -3992,7 +3993,7 @@
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "dev": true,
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.x.x"
           }
         }
       }
@@ -4003,17 +4004,17 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "1.0.1",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.1",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "diffie-hellman": "5.0.3",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.16",
-        "public-encrypt": "4.0.2",
-        "randombytes": "2.0.6",
-        "randomfill": "1.0.4"
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
       }
     },
     "currently-unhandled": {
@@ -4022,7 +4023,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "cwd": {
@@ -4031,7 +4032,7 @@
       "integrity": "sha1-QeEKfhq4M9xZwuyoOBTH3ne1pP0=",
       "dev": true,
       "requires": {
-        "find-pkg": "0.1.2"
+        "find-pkg": "^0.1.0"
       }
     },
     "cyclist": {
@@ -4045,7 +4046,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "data-store": {
@@ -4054,19 +4055,19 @@
       "integrity": "sha1-5pwDpcrBXR/zPwJUyWeDZT5ogwQ=",
       "dev": true,
       "requires": {
-        "cache-base": "0.8.5",
-        "clone-deep": "0.2.4",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "graceful-fs": "4.1.11",
-        "has-own-deep": "0.1.4",
-        "lazy-cache": "2.0.2",
-        "mkdirp": "0.5.1",
-        "project-name": "0.2.6",
-        "resolve-dir": "0.1.1",
-        "rimraf": "2.6.2",
-        "union-value": "0.2.4"
+        "cache-base": "^0.8.4",
+        "clone-deep": "^0.2.4",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "graceful-fs": "^4.1.4",
+        "has-own-deep": "^0.1.4",
+        "lazy-cache": "^2.0.1",
+        "mkdirp": "^0.5.1",
+        "project-name": "^0.2.5",
+        "resolve-dir": "^0.1.0",
+        "rimraf": "^2.5.3",
+        "union-value": "^0.2.3"
       },
       "dependencies": {
         "cache-base": {
@@ -4075,16 +4076,16 @@
           "integrity": "sha1-YM6zUEAh7O7HAR/TOEt/TpVym/o=",
           "dev": true,
           "requires": {
-            "collection-visit": "0.2.3",
-            "component-emitter": "1.2.1",
-            "get-value": "2.0.6",
-            "has-value": "0.3.1",
-            "isobject": "3.0.1",
-            "lazy-cache": "2.0.2",
-            "set-value": "0.4.3",
-            "to-object-path": "0.3.0",
-            "union-value": "0.2.4",
-            "unset-value": "0.1.2"
+            "collection-visit": "^0.2.1",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.5",
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0",
+            "lazy-cache": "^2.0.1",
+            "set-value": "^0.4.2",
+            "to-object-path": "^0.3.0",
+            "union-value": "^0.2.3",
+            "unset-value": "^0.1.1"
           }
         },
         "collection-visit": {
@@ -4093,9 +4094,9 @@
           "integrity": "sha1-L2JIPK7MlfCDuaRUo+6eYTmteVc=",
           "dev": true,
           "requires": {
-            "lazy-cache": "2.0.2",
-            "map-visit": "0.1.5",
-            "object-visit": "0.3.4"
+            "lazy-cache": "^2.0.1",
+            "map-visit": "^0.1.5",
+            "object-visit": "^0.3.4"
           }
         },
         "isobject": {
@@ -4110,7 +4111,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         },
         "map-visit": {
@@ -4119,8 +4120,8 @@
           "integrity": "sha1-2+Q5J85VJbgN/BVzpE1oxR8mgWs=",
           "dev": true,
           "requires": {
-            "lazy-cache": "2.0.2",
-            "object-visit": "0.3.4"
+            "lazy-cache": "^2.0.1",
+            "object-visit": "^0.3.4"
           }
         },
         "object-visit": {
@@ -4129,7 +4130,7 @@
           "integrity": "sha1-rhXPhvCy/dVRdxY2RIRSxUw9qCk=",
           "dev": true,
           "requires": {
-            "isobject": "2.1.0"
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -4149,10 +4150,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         },
         "union-value": {
@@ -4161,10 +4162,10 @@
           "integrity": "sha1-c3UVJ4ZnkFfns3qmdug0aPwCdPA=",
           "dev": true,
           "requires": {
-            "arr-union": "3.1.0",
-            "get-value": "2.0.6",
-            "is-extendable": "0.1.1",
-            "set-value": "0.4.3"
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
           }
         },
         "unset-value": {
@@ -4173,8 +4174,8 @@
           "integrity": "sha1-UGgQuGfyfCpabpsEgzYx9t5Y0xA=",
           "dev": true,
           "requires": {
-            "has-value": "0.3.1",
-            "isobject": "3.0.1"
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
           }
         }
       }
@@ -4212,14 +4213,14 @@
       "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
       "dev": true,
       "requires": {
-        "decompress-tar": "4.1.1",
-        "decompress-tarbz2": "4.1.1",
-        "decompress-targz": "4.1.1",
-        "decompress-unzip": "4.0.1",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.1.0",
-        "pify": "2.3.0",
-        "strip-dirs": "2.1.0"
+        "decompress-tar": "^4.0.0",
+        "decompress-tarbz2": "^4.0.0",
+        "decompress-targz": "^4.0.0",
+        "decompress-unzip": "^4.0.1",
+        "graceful-fs": "^4.1.10",
+        "make-dir": "^1.0.0",
+        "pify": "^2.3.0",
+        "strip-dirs": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -4236,7 +4237,7 @@
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
       "requires": {
-        "mimic-response": "1.0.0"
+        "mimic-response": "^1.0.0"
       }
     },
     "decompress-tar": {
@@ -4245,9 +4246,9 @@
       "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
       "dev": true,
       "requires": {
-        "file-type": "5.2.0",
-        "is-stream": "1.1.0",
-        "tar-stream": "1.5.5"
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0",
+        "tar-stream": "^1.5.2"
       }
     },
     "decompress-tarbz2": {
@@ -4256,11 +4257,11 @@
       "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
       "dev": true,
       "requires": {
-        "decompress-tar": "4.1.1",
-        "file-type": "6.2.0",
-        "is-stream": "1.1.0",
-        "seek-bzip": "1.0.5",
-        "unbzip2-stream": "1.2.5"
+        "decompress-tar": "^4.1.0",
+        "file-type": "^6.1.0",
+        "is-stream": "^1.1.0",
+        "seek-bzip": "^1.0.5",
+        "unbzip2-stream": "^1.0.9"
       },
       "dependencies": {
         "file-type": {
@@ -4277,9 +4278,9 @@
       "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
       "dev": true,
       "requires": {
-        "decompress-tar": "4.1.1",
-        "file-type": "5.2.0",
-        "is-stream": "1.1.0"
+        "decompress-tar": "^4.1.1",
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0"
       }
     },
     "decompress-unzip": {
@@ -4288,10 +4289,10 @@
       "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
       "dev": true,
       "requires": {
-        "file-type": "3.9.0",
-        "get-stream": "2.3.1",
-        "pify": "2.3.0",
-        "yauzl": "2.9.1"
+        "file-type": "^3.8.0",
+        "get-stream": "^2.2.0",
+        "pify": "^2.3.0",
+        "yauzl": "^2.4.2"
       },
       "dependencies": {
         "file-type": {
@@ -4306,8 +4307,8 @@
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "requires": {
-            "object-assign": "4.1.1",
-            "pinkie-promise": "2.0.1"
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -4324,7 +4325,7 @@
       "integrity": "sha1-lcMd2Eoc0bOBEZosQu25DbSFvDM=",
       "dev": true,
       "requires": {
-        "mixin-deep": "1.3.0"
+        "mixin-deep": "^1.1.3"
       }
     },
     "deep-eql": {
@@ -4361,7 +4362,7 @@
       "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
       "dev": true,
       "requires": {
-        "kind-of": "5.1.0"
+        "kind-of": "^5.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -4378,8 +4379,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "define-property": {
@@ -4388,7 +4389,7 @@
       "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
       "dev": true,
       "requires": {
-        "is-descriptor": "0.1.6"
+        "is-descriptor": "^0.1.0"
       }
     },
     "del": {
@@ -4397,13 +4398,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       },
       "dependencies": {
         "glob": {
@@ -4412,12 +4413,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "globby": {
@@ -4426,12 +4427,12 @@
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -4460,10 +4461,10 @@
       "integrity": "sha512-bdhJatRNYsJnOhSRx9Eej3ABBtxQQw/uz2RprpYL5R3jCC2XMYVBcQWwvQLl+iNDk4LCLEKhdIP3uZSqRWi/tw==",
       "dev": true,
       "requires": {
-        "async-each": "1.0.1",
-        "extend-shallow": "2.0.1",
-        "matched": "1.0.2",
-        "rimraf": "2.6.2"
+        "async-each": "^1.0.1",
+        "extend-shallow": "^2.0.1",
+        "matched": "^1.0.2",
+        "rimraf": "^2.6.1"
       }
     },
     "delimiter-regex": {
@@ -4472,8 +4473,8 @@
       "integrity": "sha1-DQ9vYdmRVZH9Qwh6jpWF0+IRWnU=",
       "dev": true,
       "requires": {
-        "extend-shallow": "1.1.4",
-        "isobject": "2.1.0"
+        "extend-shallow": "^1.1.2",
+        "isobject": "^2.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -4482,7 +4483,7 @@
           "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
           "dev": true,
           "requires": {
-            "kind-of": "1.1.0"
+            "kind-of": "^1.1.0"
           }
         },
         "kind-of": {
@@ -4499,8 +4500,8 @@
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "detect-indent": {
@@ -4509,7 +4510,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "detect-libc": {
@@ -4531,9 +4532,9 @@
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "director": {
@@ -4548,7 +4549,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "^2.0.2"
       }
     },
     "domain-browser": {
@@ -4563,17 +4564,17 @@
       "integrity": "sha512-DpO9K1sXAST8Cpzb7kmEhogJxymyVUd5qz/vCOSyvwtp2Klj2XcDt5YUuasgxka44SxF0q5RriKIwJmQHG2AuA==",
       "dev": true,
       "requires": {
-        "caw": "2.0.1",
-        "content-disposition": "0.5.2",
-        "decompress": "4.2.0",
-        "ext-name": "5.0.0",
+        "caw": "^2.0.0",
+        "content-disposition": "^0.5.2",
+        "decompress": "^4.0.0",
+        "ext-name": "^5.0.0",
         "file-type": "5.2.0",
-        "filenamify": "2.0.0",
-        "get-stream": "3.0.0",
-        "got": "7.1.0",
-        "make-dir": "1.1.0",
-        "p-event": "1.3.0",
-        "pify": "3.0.0"
+        "filenamify": "^2.0.0",
+        "get-stream": "^3.0.0",
+        "got": "^7.0.0",
+        "make-dir": "^1.0.0",
+        "p-event": "^1.0.0",
+        "pify": "^3.0.0"
       }
     },
     "download-cli": {
@@ -4582,8 +4583,8 @@
       "integrity": "sha512-CsQlwf9XFpwjKOChGXTa+h01Bs1L37wRvhR5FIL+X/Exv15pf7QtiB11Sqf7p9j2kRycL/q2R9v3QPRtF+sg8w==",
       "dev": true,
       "requires": {
-        "download": "6.2.5",
-        "meow": "3.7.0"
+        "download": "^6.2.1",
+        "meow": "^3.3.0"
       }
     },
     "duplexer": {
@@ -4604,10 +4605,10 @@
       "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -4616,7 +4617,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "ecstatic": {
@@ -4625,10 +4626,10 @@
       "integrity": "sha512-D9UcjcxDMMqjaQxC0mSsFh/IjJSdiZVPnHrhjHuKXlhLByk5QGGPX1GUIDIjRzhTq4UDCPYwWblw79VBEh3r1w==",
       "dev": true,
       "requires": {
-        "he": "1.1.1",
-        "mime": "1.6.0",
-        "minimist": "1.2.0",
-        "url-join": "2.0.5"
+        "he": "^1.1.1",
+        "mime": "^1.4.1",
+        "minimist": "^1.1.0",
+        "url-join": "^2.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -4651,13 +4652,13 @@
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.3",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "emojis-list": {
@@ -4672,7 +4673,7 @@
       "integrity": "sha1-gJ7kih60rRy1EMJXLWb9DthNAas=",
       "dev": true,
       "requires": {
-        "fs-exists-sync": "0.1.0"
+        "fs-exists-sync": "^0.1.0"
       }
     },
     "en-route": {
@@ -4681,12 +4682,12 @@
       "integrity": "sha1-6CMOc4NsXpXGdX4EQtPBExJL3Zg=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "debug": "2.6.9",
-        "extend-shallow": "2.0.1",
-        "kind-of": "3.2.2",
-        "lazy-cache": "1.0.4",
-        "path-to-regexp": "1.7.0"
+        "arr-flatten": "^1.0.1",
+        "debug": "^2.2.0",
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "lazy-cache": "^1.0.3",
+        "path-to-regexp": "^1.2.1"
       }
     },
     "end-of-stream": {
@@ -4695,7 +4696,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "engine": {
@@ -4704,13 +4705,13 @@
       "integrity": "sha1-+H6MkLuAzT9YWXrFaVk+5G2idC0=",
       "dev": true,
       "requires": {
-        "assign-deep": "0.4.6",
-        "collection-visit": "0.2.3",
-        "get-value": "1.3.1",
-        "kind-of": "2.0.1",
-        "lazy-cache": "0.2.7",
-        "object.omit": "2.0.1",
-        "set-value": "0.2.0"
+        "assign-deep": "^0.4.3",
+        "collection-visit": "^0.2.0",
+        "get-value": "^1.2.1",
+        "kind-of": "^2.0.1",
+        "lazy-cache": "^0.2.3",
+        "object.omit": "^2.0.0",
+        "set-value": "^0.2.0"
       },
       "dependencies": {
         "collection-visit": {
@@ -4719,9 +4720,9 @@
           "integrity": "sha1-L2JIPK7MlfCDuaRUo+6eYTmteVc=",
           "dev": true,
           "requires": {
-            "lazy-cache": "2.0.2",
-            "map-visit": "0.1.5",
-            "object-visit": "0.3.4"
+            "lazy-cache": "^2.0.1",
+            "map-visit": "^0.1.5",
+            "object-visit": "^0.3.4"
           },
           "dependencies": {
             "lazy-cache": {
@@ -4730,7 +4731,7 @@
               "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
               "dev": true,
               "requires": {
-                "set-getter": "0.1.0"
+                "set-getter": "^0.1.0"
               }
             }
           }
@@ -4741,10 +4742,10 @@
           "integrity": "sha1-isfvTyA4I5KyZGVI+bmtLcbIlkI=",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "is-extendable": "0.1.1",
-            "lazy-cache": "0.2.7",
-            "noncharacters": "1.1.0"
+            "arr-flatten": "^1.0.1",
+            "is-extendable": "^0.1.1",
+            "lazy-cache": "^0.2.4",
+            "noncharacters": "^1.1.0"
           }
         },
         "kind-of": {
@@ -4753,7 +4754,7 @@
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.0.2"
           }
         },
         "lazy-cache": {
@@ -4768,8 +4769,8 @@
           "integrity": "sha1-2+Q5J85VJbgN/BVzpE1oxR8mgWs=",
           "dev": true,
           "requires": {
-            "lazy-cache": "2.0.2",
-            "object-visit": "0.3.4"
+            "lazy-cache": "^2.0.1",
+            "object-visit": "^0.3.4"
           },
           "dependencies": {
             "lazy-cache": {
@@ -4778,7 +4779,7 @@
               "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
               "dev": true,
               "requires": {
-                "set-getter": "0.1.0"
+                "set-getter": "^0.1.0"
               }
             }
           }
@@ -4789,7 +4790,7 @@
           "integrity": "sha1-rhXPhvCy/dVRdxY2RIRSxUw9qCk=",
           "dev": true,
           "requires": {
-            "isobject": "2.1.0"
+            "isobject": "^2.0.0"
           }
         },
         "set-value": {
@@ -4798,8 +4799,8 @@
           "integrity": "sha1-c7CmglwVjGoWqCu9yVd1vyqCX6s=",
           "dev": true,
           "requires": {
-            "isobject": "1.0.2",
-            "noncharacters": "1.1.0"
+            "isobject": "^1.0.0",
+            "noncharacters": "^1.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -4818,14 +4819,14 @@
       "integrity": "sha1-1ZycxS591t0rSa579ftEmU9wFqU=",
       "dev": true,
       "requires": {
-        "component-emitter": "1.2.1",
-        "delimiter-regex": "2.0.0",
-        "engine": "0.1.12",
-        "engine-utils": "0.1.1",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.0",
-        "object.omit": "2.0.1",
-        "object.pick": "1.3.0"
+        "component-emitter": "^1.2.1",
+        "delimiter-regex": "^2.0.0",
+        "engine": "^0.1.12",
+        "engine-utils": "^0.1.1",
+        "lazy-cache": "^2.0.2",
+        "mixin-deep": "^1.1.3",
+        "object.omit": "^2.0.1",
+        "object.pick": "^1.2.0"
       },
       "dependencies": {
         "lazy-cache": {
@@ -4834,7 +4835,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -4845,12 +4846,12 @@
       "integrity": "sha1-giSWb732pl54Dsed+HtrLLgjlbI=",
       "dev": true,
       "requires": {
-        "async-helpers": "0.3.17",
-        "extend-shallow": "2.0.1",
-        "helper-cache": "0.7.2",
-        "isobject": "3.0.1",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.0"
+        "async-helpers": "^0.3.9",
+        "extend-shallow": "^2.0.1",
+        "helper-cache": "^0.7.2",
+        "isobject": "^3.0.0",
+        "lazy-cache": "^2.0.2",
+        "mixin-deep": "^1.1.3"
       },
       "dependencies": {
         "isobject": {
@@ -4865,7 +4866,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -4882,9 +4883,9 @@
       "integrity": "sha512-jox/62b2GofV1qTUQTMPEJSDIGycS43evqYzD/KVtEb9OCoki9cnacUPxCrZa7JfPzZSYOCZhu9O9luaMxAX8g==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "tapable": "1.0.0"
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.4.0",
+        "tapable": "^1.0.0"
       }
     },
     "errno": {
@@ -4893,7 +4894,7 @@
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "dev": true,
       "requires": {
-        "prr": "1.0.1"
+        "prr": "~1.0.1"
       }
     },
     "error-ex": {
@@ -4902,7 +4903,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "error-symbol": {
@@ -4917,11 +4918,11 @@
       "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -4930,9 +4931,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "escape-string-regexp": {
@@ -4947,43 +4948,43 @@
       "integrity": "sha512-YVXV4bDhNoHHcv0qzU4Meof7/P26B4EuaktMi5L1Tnt52Aov85KmYA8c5D+xyZr/BkhvwUqr011jDSD/QTULxg==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.3.0",
-        "concat-stream": "1.6.0",
-        "cross-spawn": "5.1.0",
-        "debug": "3.1.0",
-        "doctrine": "2.1.0",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "1.0.0",
-        "espree": "3.5.2",
-        "esquery": "1.0.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "11.1.0",
-        "ignore": "3.3.7",
-        "imurmurhash": "0.1.4",
-        "inquirer": "3.3.0",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.10.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.5.0",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "4.0.2",
-        "text-table": "0.2.0"
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.2",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "^4.0.1",
+        "text-table": "~0.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4998,7 +4999,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -5007,9 +5008,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "debug": {
@@ -5027,12 +5028,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "globals": {
@@ -5047,7 +5048,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -5056,7 +5057,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -5067,8 +5068,8 @@
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-visitor-keys": {
@@ -5089,8 +5090,8 @@
       "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.3.0",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.2.1",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
@@ -5105,7 +5106,7 @@
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -5114,8 +5115,8 @@
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
+        "estraverse": "^4.1.0",
+        "object-assign": "^4.0.1"
       }
     },
     "estraverse": {
@@ -5148,13 +5149,13 @@
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1",
-        "from": "0.1.7",
-        "map-stream": "0.1.0",
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
         "pause-stream": "0.0.11",
-        "split": "0.3.3",
-        "stream-combiner": "0.0.4",
-        "through": "2.3.8"
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
       }
     },
     "eventemitter3": {
@@ -5175,8 +5176,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "1.3.4",
-        "safe-buffer": "5.1.1"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "exit-hook": {
@@ -5191,13 +5192,13 @@
       "integrity": "sha1-OoZiJBxYF1fIzTf7d2d6xgL/nZg=",
       "dev": true,
       "requires": {
-        "expand-object": "0.4.2",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "minimist": "1.2.0",
-        "mixin-deep": "1.3.0",
-        "omit-empty": "0.4.1",
-        "set-value": "0.3.3"
+        "expand-object": "^0.4.2",
+        "kind-of": "^3.0.3",
+        "lazy-cache": "^2.0.1",
+        "minimist": "^1.2.0",
+        "mixin-deep": "^1.1.3",
+        "omit-empty": "^0.4.1",
+        "set-value": "^0.3.3"
       },
       "dependencies": {
         "lazy-cache": {
@@ -5206,7 +5207,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         },
         "minimist": {
@@ -5223,7 +5224,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-object": {
@@ -5232,10 +5233,10 @@
       "integrity": "sha1-t/J+9pwv3MYrD5OQwMtHvAa7Buo=",
       "dev": true,
       "requires": {
-        "get-stdin": "5.0.1",
-        "is-number": "2.1.0",
-        "minimist": "1.2.0",
-        "set-value": "0.3.3"
+        "get-stdin": "^5.0.1",
+        "is-number": "^2.1.0",
+        "minimist": "^1.2.0",
+        "set-value": "^0.3.3"
       },
       "dependencies": {
         "get-stdin": {
@@ -5258,19 +5259,19 @@
       "integrity": "sha1-JhIwIzQMvABiBsujm4Kh0XbD9oc=",
       "dev": true,
       "requires": {
-        "component-emitter": "1.2.1",
-        "debug": "2.6.9",
-        "export-files": "2.1.1",
-        "get-value": "2.0.6",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "load-pkg": "3.0.1",
-        "mixin-deep": "1.3.0",
-        "normalize-pkg": "0.3.20",
-        "omit-empty": "0.4.1",
-        "parse-author": "1.0.0",
-        "parse-git-config": "1.1.1",
-        "repo-utils": "0.3.7"
+        "component-emitter": "^1.2.1",
+        "debug": "^2.4.1",
+        "export-files": "^2.1.1",
+        "get-value": "^2.0.6",
+        "kind-of": "^3.1.0",
+        "lazy-cache": "^2.0.2",
+        "load-pkg": "^3.0.1",
+        "mixin-deep": "^1.1.3",
+        "normalize-pkg": "^0.3.20",
+        "omit-empty": "^0.4.1",
+        "parse-author": "^1.0.0",
+        "parse-git-config": "^1.1.1",
+        "repo-utils": "^0.3.7"
       },
       "dependencies": {
         "lazy-cache": {
@@ -5279,7 +5280,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -5290,7 +5291,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "expand-tilde": {
@@ -5299,7 +5300,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "1.0.1"
+        "homedir-polyfill": "^1.0.1"
       }
     },
     "export-files": {
@@ -5308,7 +5309,7 @@
       "integrity": "sha1-u/ZFdAU6CeTrmOX0NQHVcrLDzn8=",
       "dev": true,
       "requires": {
-        "lazy-cache": "1.0.4"
+        "lazy-cache": "^1.0.3"
       }
     },
     "ext-list": {
@@ -5317,7 +5318,7 @@
       "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
       "dev": true,
       "requires": {
-        "mime-db": "1.32.0"
+        "mime-db": "^1.28.0"
       }
     },
     "ext-name": {
@@ -5326,8 +5327,8 @@
       "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
       "dev": true,
       "requires": {
-        "ext-list": "2.2.2",
-        "sort-keys-length": "1.0.1"
+        "ext-list": "^2.0.0",
+        "sort-keys-length": "^1.0.0"
       }
     },
     "extend": {
@@ -5341,7 +5342,7 @@
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "requires": {
-        "is-extendable": "0.1.1"
+        "is-extendable": "^0.1.0"
       }
     },
     "external-editor": {
@@ -5350,9 +5351,9 @@
       "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "dev": true,
       "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.19",
-        "tmp": "0.0.33"
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -5361,7 +5362,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "extsprintf": {
@@ -5375,7 +5376,7 @@
       "integrity": "sha512-lxEuefF5MBIVDmE6XeqCdM4BWk1+vYmGZtkbKZ/VFcg6uBBw6fXNEbWmxCjDdQlFc9hy450nkiWwM3VAW6G1qg==",
       "dev": true,
       "requires": {
-        "kind-of": "5.1.0"
+        "kind-of": "^5.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5410,7 +5411,7 @@
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "dev": true,
       "requires": {
-        "pend": "1.2.0"
+        "pend": "~1.2.0"
       }
     },
     "figures": {
@@ -5419,7 +5420,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-contents": {
@@ -5428,13 +5429,13 @@
       "integrity": "sha1-BQb3uO/2KvpFrkXaTfnp1H30U8s=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "file-stat": "0.1.3",
-        "graceful-fs": "4.1.11",
-        "is-buffer": "1.1.6",
-        "is-utf8": "0.2.1",
-        "lazy-cache": "0.2.7",
-        "through2": "2.0.3"
+        "extend-shallow": "^2.0.0",
+        "file-stat": "^0.1.0",
+        "graceful-fs": "^4.1.2",
+        "is-buffer": "^1.1.0",
+        "is-utf8": "^0.2.0",
+        "lazy-cache": "^0.2.3",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "lazy-cache": {
@@ -5451,8 +5452,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "file-is-binary": {
@@ -5461,8 +5462,8 @@
       "integrity": "sha1-XkGAbRvK5FjI/sMv484SLbu8Q1Y=",
       "dev": true,
       "requires": {
-        "is-binary-buffer": "1.0.0",
-        "isobject": "3.0.1"
+        "is-binary-buffer": "^1.0.0",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -5485,9 +5486,9 @@
       "integrity": "sha1-0PGWHX0QcykoEgpuaVVHHCpbVBE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "lazy-cache": "0.2.7",
-        "through2": "2.0.3"
+        "graceful-fs": "^4.1.2",
+        "lazy-cache": "^0.2.3",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "lazy-cache": {
@@ -5522,9 +5523,9 @@
       "integrity": "sha1-vRYiYsC26Uv7zc8Zo7uzdk94VpU=",
       "dev": true,
       "requires": {
-        "filename-reserved-regex": "2.0.0",
-        "strip-outer": "1.0.0",
-        "trim-repeated": "1.0.0"
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.0",
+        "trim-repeated": "^1.0.0"
       }
     },
     "fill-range": {
@@ -5533,11 +5534,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^1.1.3",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "find-cache-dir": {
@@ -5546,9 +5547,9 @@
       "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
       "dev": true,
       "requires": {
-        "commondir": "1.0.1",
-        "make-dir": "1.1.0",
-        "pkg-dir": "2.0.0"
+        "commondir": "^1.0.1",
+        "make-dir": "^1.0.0",
+        "pkg-dir": "^2.0.0"
       }
     },
     "find-file-up": {
@@ -5557,8 +5558,8 @@
       "integrity": "sha1-z2gJG8+fMApA2kEbN9pczlovvqA=",
       "dev": true,
       "requires": {
-        "fs-exists-sync": "0.1.0",
-        "resolve-dir": "0.1.1"
+        "fs-exists-sync": "^0.1.0",
+        "resolve-dir": "^0.1.0"
       }
     },
     "find-pkg": {
@@ -5567,7 +5568,7 @@
       "integrity": "sha1-G9wiwG42NlUy4qJIBGhUuXiNpVc=",
       "dev": true,
       "requires": {
-        "find-file-up": "0.1.3"
+        "find-file-up": "^0.1.2"
       }
     },
     "find-up": {
@@ -5576,7 +5577,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "first-chunk-stream": {
@@ -5591,10 +5592,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "flush-write-stream": {
@@ -5603,8 +5604,8 @@
       "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.4"
       }
     },
     "for-in": {
@@ -5619,7 +5620,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreach": {
@@ -5639,9 +5640,9 @@
       "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       }
     },
     "fragment-cache": {
@@ -5650,7 +5651,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "fresh": {
@@ -5671,8 +5672,8 @@
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "fs-exists-sync": {
@@ -5687,10 +5688,10 @@
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "readable-stream": "2.3.3"
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
       }
     },
     "fs.realpath": {
@@ -5705,8 +5706,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.8.0",
-        "node-pre-gyp": "0.6.39"
+        "nan": "^2.3.0",
+        "node-pre-gyp": "^0.6.39"
       },
       "dependencies": {
         "ajv": {
@@ -5714,8 +5715,8 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "assert-plus": {
@@ -5738,7 +5739,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "cryptiles": {
@@ -5746,7 +5747,7 @@
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "extsprintf": {
@@ -5759,9 +5760,9 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "glob": {
@@ -5769,12 +5770,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "har-schema": {
@@ -5787,8 +5788,8 @@
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
           }
         },
         "hawk": {
@@ -5796,10 +5797,10 @@
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
@@ -5812,9 +5813,9 @@
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -5822,7 +5823,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "mime-db": {
@@ -5845,28 +5846,28 @@
           "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
           }
         },
         "semver": {
@@ -5879,7 +5880,7 @@
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "string-width": {
@@ -5887,9 +5888,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "verror": {
@@ -5908,10 +5909,10 @@
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       }
     },
     "fstream-ignore": {
@@ -5921,9 +5922,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "fstream": "1.0.11",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4"
+        "fstream": "^1.0.0",
+        "inherits": "2",
+        "minimatch": "^3.0.0"
       }
     },
     "function-bind": {
@@ -5945,14 +5946,14 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "aproba": "1.1.1",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -5962,7 +5963,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -5972,9 +5973,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -5985,14 +5986,14 @@
       "integrity": "sha1-Rz+OXFUu7clo2/Ynth1RJmyx/G8=",
       "dev": true,
       "requires": {
-        "base-data": "0.6.2",
-        "camel-case": "3.0.0",
-        "clone-deep": "0.2.4",
-        "expand-pkg": "0.1.8",
-        "is-valid-app": "0.2.1",
-        "lazy-cache": "2.0.2",
-        "namify": "0.1.3",
-        "repo-utils": "0.3.7"
+        "base-data": "^0.6.0",
+        "camel-case": "^3.0.0",
+        "clone-deep": "^0.2.4",
+        "expand-pkg": "^0.1.8",
+        "is-valid-app": "^0.2.1",
+        "lazy-cache": "^2.0.2",
+        "namify": "^0.1.3",
+        "repo-utils": "^0.3.7"
       },
       "dependencies": {
         "lazy-cache": {
@@ -6001,7 +6002,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -6012,16 +6013,16 @@
       "integrity": "sha1-SHcGqJ7+pXAsMc9BdUTQJ2iy8IY=",
       "dev": true,
       "requires": {
-        "common-middleware": "0.4.1",
-        "common-questions": "0.5.1",
-        "empty-dir": "0.2.1",
-        "engine-base": "0.1.3",
-        "extend-shallow": "2.0.1",
-        "fs-exists-sync": "0.1.0",
-        "generate-data": "0.1.8",
-        "is-valid-app": "0.2.1",
-        "lazy-cache": "2.0.2",
-        "template-helpers": "0.6.7"
+        "common-middleware": "^0.4.1",
+        "common-questions": "^0.5.0",
+        "empty-dir": "^0.2.1",
+        "engine-base": "^0.1.2",
+        "extend-shallow": "^2.0.1",
+        "fs-exists-sync": "^0.1.0",
+        "generate-data": "^0.1.6",
+        "is-valid-app": "^0.2.1",
+        "lazy-cache": "^2.0.1",
+        "template-helpers": "^0.6.7"
       },
       "dependencies": {
         "lazy-cache": {
@@ -6030,7 +6031,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -6041,12 +6042,12 @@
       "integrity": "sha1-CjtyU7Xns2Kwc02FN5tJ7+QdMkY=",
       "dev": true,
       "requires": {
-        "generate-defaults": "0.6.6",
-        "is-valid-app": "0.2.1",
-        "lazy-cache": "2.0.2",
-        "prompt-autocompletion": "0.1.2",
-        "through2": "2.0.3",
-        "vinyl": "2.1.0"
+        "generate-defaults": "^0.6.5",
+        "is-valid-app": "^0.2.1",
+        "lazy-cache": "^2.0.1",
+        "prompt-autocompletion": "^0.1.1",
+        "through2": "^2.0.1",
+        "vinyl": "^2.0.0"
       },
       "dependencies": {
         "clone": {
@@ -6067,7 +6068,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         },
         "replace-ext": {
@@ -6082,12 +6083,12 @@
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "dev": true,
           "requires": {
-            "clone": "2.1.1",
-            "clone-buffer": "1.0.0",
-            "clone-stats": "1.0.0",
-            "cloneable-readable": "1.0.0",
-            "remove-trailing-separator": "1.1.0",
-            "replace-ext": "1.0.0"
+            "clone": "^2.1.1",
+            "clone-buffer": "^1.0.0",
+            "clone-stats": "^1.0.0",
+            "cloneable-readable": "^1.0.0",
+            "remove-trailing-separator": "^1.0.1",
+            "replace-ext": "^1.0.0"
           }
         }
       }
@@ -6098,7 +6099,7 @@
       "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
       "dev": true,
       "requires": {
-        "npm-conf": "1.1.3"
+        "npm-conf": "^1.1.0"
       }
     },
     "get-stdin": {
@@ -6125,8 +6126,8 @@
       "integrity": "sha1-NmCsBYuhPfl0nKvKpry5bUGqDqA=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1",
-        "match-file": "0.2.2"
+        "isobject": "^3.0.0",
+        "match-file": "^0.2.1"
       },
       "dependencies": {
         "isobject": {
@@ -6142,7 +6143,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "git-config-path": {
@@ -6151,9 +6152,9 @@
       "integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "fs-exists-sync": "0.1.0",
-        "homedir-polyfill": "1.0.1"
+        "extend-shallow": "^2.0.1",
+        "fs-exists-sync": "^0.1.0",
+        "homedir-polyfill": "^1.0.0"
       }
     },
     "git-repo-name": {
@@ -6162,10 +6163,10 @@
       "integrity": "sha1-rwmIRlaqU37GJccIcAgXXNYSKP8=",
       "dev": true,
       "requires": {
-        "cwd": "0.9.1",
-        "file-name": "0.1.0",
-        "lazy-cache": "1.0.4",
-        "remote-origin-url": "0.5.3"
+        "cwd": "^0.9.1",
+        "file-name": "^0.1.0",
+        "lazy-cache": "^1.0.4",
+        "remote-origin-url": "^0.5.1"
       }
     },
     "glob": {
@@ -6174,11 +6175,11 @@
       "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
       "dev": true,
       "requires": {
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -6187,8 +6188,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -6197,7 +6198,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "glob-stream": {
@@ -6206,14 +6207,14 @@
       "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
       "dev": true,
       "requires": {
-        "extend": "3.0.1",
-        "glob": "5.0.15",
-        "glob-parent": "3.1.0",
-        "micromatch": "2.3.11",
-        "ordered-read-streams": "0.3.0",
-        "through2": "0.6.5",
-        "to-absolute-glob": "0.1.1",
-        "unique-stream": "2.2.1"
+        "extend": "^3.0.0",
+        "glob": "^5.0.3",
+        "glob-parent": "^3.0.0",
+        "micromatch": "^2.3.7",
+        "ordered-read-streams": "^0.3.0",
+        "through2": "^0.6.0",
+        "to-absolute-glob": "^0.1.1",
+        "unique-stream": "^2.0.2"
       },
       "dependencies": {
         "glob": {
@@ -6222,11 +6223,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "glob-parent": {
@@ -6235,8 +6236,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
           }
         },
         "is-extglob": {
@@ -6251,7 +6252,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         },
         "isarray": {
@@ -6266,10 +6267,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -6284,8 +6285,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         }
       }
@@ -6296,8 +6297,8 @@
       "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
       "dev": true,
       "requires": {
-        "global-prefix": "0.1.5",
-        "is-windows": "0.2.0"
+        "global-prefix": "^0.1.4",
+        "is-windows": "^0.2.0"
       },
       "dependencies": {
         "global-prefix": {
@@ -6306,10 +6307,10 @@
           "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
           "dev": true,
           "requires": {
-            "homedir-polyfill": "1.0.1",
-            "ini": "1.3.5",
-            "is-windows": "0.2.0",
-            "which": "1.3.0"
+            "homedir-polyfill": "^1.0.0",
+            "ini": "^1.3.4",
+            "is-windows": "^0.2.0",
+            "which": "^1.2.12"
           }
         },
         "is-windows": {
@@ -6326,11 +6327,11 @@
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "2.0.2",
-        "homedir-polyfill": "1.0.1",
-        "ini": "1.3.5",
-        "is-windows": "1.0.1",
-        "which": "1.3.0"
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
       }
     },
     "globals": {
@@ -6345,12 +6346,12 @@
       "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "6.0.4",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^6.0.1",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -6367,20 +6368,20 @@
       "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
       "dev": true,
       "requires": {
-        "decompress-response": "3.3.0",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-plain-obj": "1.1.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "isurl": "1.0.0",
-        "lowercase-keys": "1.0.0",
-        "p-cancelable": "0.3.0",
-        "p-timeout": "1.2.1",
-        "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1",
-        "url-parse-lax": "1.0.0",
-        "url-to-options": "1.0.1"
+        "decompress-response": "^3.2.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-plain-obj": "^1.1.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "isurl": "^1.0.0-alpha5",
+        "lowercase-keys": "^1.0.0",
+        "p-cancelable": "^0.3.0",
+        "p-timeout": "^1.1.1",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "url-parse-lax": "^1.0.0",
+        "url-to-options": "^1.0.1"
       }
     },
     "graceful-fs": {
@@ -6401,10 +6402,10 @@
       "integrity": "sha512-nZ1qjLmayEv0/wt3sHig7I0s3/sJO0dkAaKYQ5YAOApUtYEOonXSFdWvL1khvnZMTvov4UufkqlFsilPnejEXA==",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "js-yaml": "3.10.0",
-        "kind-of": "5.1.0",
-        "strip-bom-string": "1.0.0"
+        "extend-shallow": "^2.0.1",
+        "js-yaml": "^3.10.0",
+        "kind-of": "^5.0.2",
+        "strip-bom-string": "^1.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -6427,12 +6428,12 @@
       "integrity": "sha1-u9nS9xjfS+M/D7kEMqrxtDYOSY8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "for-own": "0.1.5",
-        "get-value": "2.0.6",
-        "kind-of": "3.2.2",
-        "split-string": "1.0.1",
-        "union-value": "0.2.4"
+        "arr-flatten": "^1.0.1",
+        "for-own": "^0.1.4",
+        "get-value": "^2.0.6",
+        "kind-of": "^3.1.0",
+        "split-string": "^1.0.1",
+        "union-value": "^0.2.3"
       },
       "dependencies": {
         "set-value": {
@@ -6441,10 +6442,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         },
         "split-string": {
@@ -6453,7 +6454,7 @@
           "integrity": "sha1-vLqz9BUqzuOg1qskecDSh5w9s84=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1"
+            "extend-shallow": "^2.0.1"
           }
         },
         "union-value": {
@@ -6462,10 +6463,10 @@
           "integrity": "sha1-c3UVJ4ZnkFfns3qmdug0aPwCdPA=",
           "dev": true,
           "requires": {
-            "arr-union": "3.1.0",
-            "get-value": "2.0.6",
-            "is-extendable": "0.1.1",
-            "set-value": "0.4.3"
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
           }
         }
       }
@@ -6482,9 +6483,9 @@
       "integrity": "sha1-hrFfBjAHOrZz1XJb7sY+qhSFUPk=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "question-cache": "0.5.1",
-        "through2": "2.0.3"
+        "extend-shallow": "^2.0.1",
+        "question-cache": "^0.5.1",
+        "through2": "^2.0.1"
       }
     },
     "gulp-sourcemaps": {
@@ -6493,11 +6494,11 @@
       "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
       "dev": true,
       "requires": {
-        "convert-source-map": "1.5.1",
-        "graceful-fs": "4.1.11",
-        "strip-bom": "2.0.0",
-        "through2": "2.0.3",
-        "vinyl": "1.2.0"
+        "convert-source-map": "^1.1.1",
+        "graceful-fs": "^4.1.2",
+        "strip-bom": "^2.0.0",
+        "through2": "^2.0.0",
+        "vinyl": "^1.0.0"
       }
     },
     "gzip-size": {
@@ -6506,8 +6507,8 @@
       "integrity": "sha1-iuCWJX6r59acRb4rZ8RIEk/7UXw=",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1",
-        "pify": "3.0.0"
+        "duplexer": "^0.1.1",
+        "pify": "^3.0.0"
       }
     },
     "handlebars": {
@@ -6516,10 +6517,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "source-map": {
@@ -6528,7 +6529,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -6545,8 +6546,8 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
@@ -6555,7 +6556,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.0.2"
       }
     },
     "has-ansi": {
@@ -6564,7 +6565,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-color": {
@@ -6585,7 +6586,7 @@
       "integrity": "sha1-omHEwqbGZ+DHe3AKfyl8Oe86pYk=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.1"
       }
     },
     "has-own-deep": {
@@ -6606,7 +6607,7 @@
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "dev": true,
       "requires": {
-        "has-symbol-support-x": "1.4.1"
+        "has-symbol-support-x": "^1.4.1"
       }
     },
     "has-unicode": {
@@ -6622,9 +6623,9 @@
       "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
       "dev": true,
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "0.1.4",
-        "isobject": "2.1.0"
+        "get-value": "^2.0.3",
+        "has-values": "^0.1.4",
+        "isobject": "^2.0.0"
       },
       "dependencies": {
         "has-values": {
@@ -6641,8 +6642,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -6651,7 +6652,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -6660,7 +6661,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -6671,7 +6672,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -6682,8 +6683,8 @@
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "hash.js": {
@@ -6692,8 +6693,8 @@
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "hawk": {
@@ -6702,10 +6703,10 @@
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "dev": true,
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.1.0"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       }
     },
     "he": {
@@ -6725,12 +6726,12 @@
       "integrity": "sha1-5ayh6NBYf8EVm7xs9wxSJTf/z4w=",
       "dev": true,
       "requires": {
-        "ask-when": "0.1.7",
-        "debug": "2.6.9",
-        "get-value": "2.0.6",
-        "has-value": "0.3.1",
-        "isobject": "2.1.0",
-        "mixin-deep": "1.3.0"
+        "ask-when": "^0.1.7",
+        "debug": "^2.2.0",
+        "get-value": "^2.0.6",
+        "has-value": "^0.3.1",
+        "isobject": "^2.1.0",
+        "mixin-deep": "^1.1.3"
       }
     },
     "helper-cache": {
@@ -6739,9 +6740,9 @@
       "integrity": "sha1-AkVixLS4sqsqtTHQC+FuxJZRi5A=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "lazy-cache": "0.2.7",
-        "lodash.bind": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "lazy-cache": "^0.2.3",
+        "lodash.bind": "^3.1.0"
       },
       "dependencies": {
         "lazy-cache": {
@@ -6758,7 +6759,7 @@
       "integrity": "sha1-ro7NIqaf3sMeJIBHO1yo4Yxiwus=",
       "dev": true,
       "requires": {
-        "strip-color": "0.1.0"
+        "strip-color": "^0.1.0"
       }
     },
     "highlight.js": {
@@ -6773,9 +6774,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.1.3",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hoek": {
@@ -6790,8 +6791,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "homedir-polyfill": {
@@ -6800,7 +6801,7 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "1.0.0"
+        "parse-passwd": "^1.0.0"
       }
     },
     "hosted-git-info": {
@@ -6815,8 +6816,8 @@
       "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
       "dev": true,
       "requires": {
-        "eventemitter3": "1.2.0",
-        "requires-port": "1.0.0"
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
       }
     },
     "http-server": {
@@ -6826,13 +6827,13 @@
       "dev": true,
       "requires": {
         "colors": "1.0.3",
-        "corser": "2.0.1",
-        "ecstatic": "3.1.1",
-        "http-proxy": "1.16.2",
-        "opener": "1.4.3",
-        "optimist": "0.6.1",
-        "portfinder": "1.0.13",
-        "union": "0.4.6"
+        "corser": "~2.0.0",
+        "ecstatic": "^3.0.0",
+        "http-proxy": "^1.8.1",
+        "opener": "~1.4.0",
+        "optimist": "0.6.x",
+        "portfinder": "^1.0.13",
+        "union": "~0.4.3"
       }
     },
     "http-signature": {
@@ -6841,9 +6842,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-browserify": {
@@ -6888,7 +6889,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "indexof": {
@@ -6908,8 +6909,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "info-symbol": {
@@ -6935,20 +6936,20 @@
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.0.0",
-        "chalk": "2.3.0",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.1.0",
-        "figures": "2.0.0",
-        "lodash": "4.17.4",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6963,7 +6964,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -6972,9 +6973,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -6983,7 +6984,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -6992,7 +6993,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -7003,25 +7004,25 @@
       "integrity": "sha1-vFQkqBQ1fEHmXi6Vf+U2ruqb8fY=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
-        "arr-flatten": "1.1.0",
-        "arr-pluck": "0.1.0",
-        "array-unique": "0.2.1",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "1.1.1",
-        "extend-shallow": "2.0.1",
-        "figures": "1.7.0",
-        "is-number": "2.1.0",
-        "is-plain-object": "2.0.4",
-        "lazy-cache": "1.0.4",
-        "lodash.where": "3.1.0",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "4.0.8",
-        "strip-color": "0.1.0",
-        "through2": "2.0.3"
+        "ansi-escapes": "^1.1.1",
+        "ansi-regex": "^2.0.0",
+        "arr-flatten": "^1.0.1",
+        "arr-pluck": "^0.1.0",
+        "array-unique": "^0.2.1",
+        "chalk": "^1.1.1",
+        "cli-cursor": "^1.0.2",
+        "cli-width": "^1.1.0",
+        "extend-shallow": "^2.0.1",
+        "figures": "^1.4.0",
+        "is-number": "^2.1.0",
+        "is-plain-object": "^2.0.1",
+        "lazy-cache": "^1.0.3",
+        "lodash.where": "^3.1.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^4.0.7",
+        "strip-color": "^0.1.0",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -7036,7 +7037,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "1.0.1"
+            "restore-cursor": "^1.0.1"
           }
         },
         "cli-width": {
@@ -7051,8 +7052,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         },
         "onetime": {
@@ -7067,8 +7068,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
           }
         },
         "run-async": {
@@ -7077,7 +7078,7 @@
           "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
           "dev": true,
           "requires": {
-            "once": "1.4.0"
+            "once": "^1.3.0"
           }
         }
       }
@@ -7088,7 +7089,7 @@
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
       "dev": true,
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "is-absolute": {
@@ -7097,8 +7098,8 @@
       "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
       "dev": true,
       "requires": {
-        "is-relative": "0.2.1",
-        "is-windows": "0.2.0"
+        "is-relative": "^0.2.1",
+        "is-windows": "^0.2.0"
       },
       "dependencies": {
         "is-windows": {
@@ -7115,7 +7116,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-answer": {
@@ -7124,9 +7125,9 @@
       "integrity": "sha1-zBwvGG+FzyZQIgveNZ2GIYfUnLY=",
       "dev": true,
       "requires": {
-        "has-values": "0.1.4",
-        "is-primitive": "2.0.0",
-        "omit-empty": "0.4.1"
+        "has-values": "^0.1.4",
+        "is-primitive": "^2.0.0",
+        "omit-empty": "^0.4.1"
       },
       "dependencies": {
         "has-values": {
@@ -7155,7 +7156,7 @@
       "integrity": "sha1-vGAxKQtly/eZudlQK1D9U3VSQAc=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "is-binary-path": {
@@ -7164,7 +7165,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -7179,7 +7180,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-callable": {
@@ -7194,7 +7195,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-date-object": {
@@ -7209,9 +7210,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -7234,7 +7235,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -7255,7 +7256,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -7276,7 +7277,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-module": {
@@ -7297,7 +7298,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-object": {
@@ -7312,7 +7313,7 @@
       "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
       "dev": true,
       "requires": {
-        "is-number": "4.0.0"
+        "is-number": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -7335,7 +7336,7 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -7344,7 +7345,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-obj": {
@@ -7359,7 +7360,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -7394,7 +7395,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-registered": {
@@ -7403,8 +7404,8 @@
       "integrity": "sha1-HTRpd0GdZl4qxshAE1NWheb3b38=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "isobject": "2.1.0"
+        "define-property": "^0.2.5",
+        "isobject": "^2.1.0"
       }
     },
     "is-relative": {
@@ -7413,7 +7414,7 @@
       "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
       "dev": true,
       "requires": {
-        "is-unc-path": "0.1.2"
+        "is-unc-path": "^0.1.1"
       }
     },
     "is-resolvable": {
@@ -7451,7 +7452,7 @@
       "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
       "dev": true,
       "requires": {
-        "unc-path-regex": "0.1.2"
+        "unc-path-regex": "^0.1.0"
       }
     },
     "is-utf8": {
@@ -7466,10 +7467,10 @@
       "integrity": "sha1-Zc8ZW71xvXdssWGZHGhCSNZd/4k=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "is-registered": "0.1.5",
-        "is-valid-instance": "0.2.0",
-        "lazy-cache": "2.0.2"
+        "debug": "^2.2.0",
+        "is-registered": "^0.1.5",
+        "is-valid-instance": "^0.2.0",
+        "lazy-cache": "^2.0.1"
       },
       "dependencies": {
         "lazy-cache": {
@@ -7478,7 +7479,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -7495,8 +7496,8 @@
       "integrity": "sha1-4an/EQa4y64AB+pqIPidVGoqWg8=",
       "dev": true,
       "requires": {
-        "isobject": "2.1.0",
-        "pascalcase": "0.1.1"
+        "isobject": "^2.1.0",
+        "pascalcase": "^0.1.1"
       }
     },
     "is-whitespace": {
@@ -7549,8 +7550,8 @@
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "dev": true,
       "requires": {
-        "has-to-string-tag-x": "1.4.1",
-        "is-object": "1.0.1"
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
       }
     },
     "jade": {
@@ -7583,10 +7584,10 @@
       "integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "diff": "3.5.0",
-        "jest-get-type": "22.4.3",
-        "pretty-format": "22.4.3"
+        "chalk": "^2.0.1",
+        "diff": "^3.2.0",
+        "jest-get-type": "^22.4.3",
+        "pretty-format": "^22.4.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7595,7 +7596,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -7604,9 +7605,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "diff": {
@@ -7627,7 +7628,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -7650,8 +7651,8 @@
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -7688,7 +7689,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stable-stringify-without-jsonify": {
@@ -7719,8 +7720,8 @@
       "integrity": "sha1-VzcEUIX1XrRVxosf9OvAG9UOiDA=",
       "dev": true,
       "requires": {
-        "JSV": "4.0.2",
-        "nomnom": "1.8.1"
+        "JSV": ">= 4.0.x",
+        "nomnom": ">= 1.5.x"
       }
     },
     "jsprim": {
@@ -7740,7 +7741,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "layouts": {
@@ -7749,10 +7750,10 @@
       "integrity": "sha1-xiDos8uI/IxJLbRTin3VQKTffyI=",
       "dev": true,
       "requires": {
-        "delimiter-regex": "1.3.1",
-        "falsey": "0.3.2",
-        "get-view": "0.1.3",
-        "lazy-cache": "1.0.4"
+        "delimiter-regex": "^1.3.1",
+        "falsey": "^0.3.0",
+        "get-view": "^0.1.1",
+        "lazy-cache": "^1.0.3"
       },
       "dependencies": {
         "delimiter-regex": {
@@ -7761,7 +7762,7 @@
           "integrity": "sha1-Y4XK4UAE28DBzY3//+uGPVGZnv8=",
           "dev": true,
           "requires": {
-            "extend-shallow": "1.1.4"
+            "extend-shallow": "^1.1.2"
           }
         },
         "extend-shallow": {
@@ -7770,7 +7771,7 @@
           "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
           "dev": true,
           "requires": {
-            "kind-of": "1.1.0"
+            "kind-of": "^1.1.0"
           }
         },
         "kind-of": {
@@ -7793,7 +7794,7 @@
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.5"
       }
     },
     "leven": {
@@ -7808,8 +7809,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "livereload": {
@@ -7818,9 +7819,9 @@
       "integrity": "sha512-5SVeqHbKQWB69himud5GNRS8w1RgnMrYBnuIeZMiQ5ZctsIvhFfhKJclihxUS3NkOV7354rnA9rRz1IQBsgaNQ==",
       "dev": true,
       "requires": {
-        "chokidar": "1.7.0",
-        "opts": "1.2.6",
-        "ws": "1.1.5"
+        "chokidar": "^1.7.0",
+        "opts": ">= 1.2.0",
+        "ws": "^1.1.1"
       }
     },
     "load-helpers": {
@@ -7829,11 +7830,11 @@
       "integrity": "sha1-9L2LIYQ1wFLl4536dxMinVcepCM=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-valid-glob": "0.3.0",
-        "lazy-cache": "2.0.2",
-        "matched": "0.4.4",
-        "resolve-dir": "0.1.1"
+        "extend-shallow": "^2.0.1",
+        "is-valid-glob": "^0.3.0",
+        "lazy-cache": "^2.0.1",
+        "matched": "^0.4.1",
+        "resolve-dir": "^0.1.0"
       },
       "dependencies": {
         "glob": {
@@ -7842,12 +7843,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "lazy-cache": {
@@ -7856,7 +7857,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         },
         "matched": {
@@ -7865,15 +7866,15 @@
           "integrity": "sha1-Vte36xgDPwz5vFLrIJD6x9weifo=",
           "dev": true,
           "requires": {
-            "arr-union": "3.1.0",
-            "async-array-reduce": "0.2.1",
-            "extend-shallow": "2.0.1",
-            "fs-exists-sync": "0.1.0",
-            "glob": "7.1.2",
-            "has-glob": "0.1.1",
-            "is-valid-glob": "0.3.0",
-            "lazy-cache": "2.0.2",
-            "resolve-dir": "0.1.1"
+            "arr-union": "^3.1.0",
+            "async-array-reduce": "^0.2.0",
+            "extend-shallow": "^2.0.1",
+            "fs-exists-sync": "^0.1.0",
+            "glob": "^7.0.5",
+            "has-glob": "^0.1.1",
+            "is-valid-glob": "^0.3.0",
+            "lazy-cache": "^2.0.1",
+            "resolve-dir": "^0.1.0"
           }
         }
       }
@@ -7884,11 +7885,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -7905,7 +7906,7 @@
       "integrity": "sha1-kjCzfsBOVpADBgvFiVHj7VCNWU8=",
       "dev": true,
       "requires": {
-        "find-pkg": "0.1.2"
+        "find-pkg": "^0.1.0"
       }
     },
     "load-templates": {
@@ -7914,14 +7915,14 @@
       "integrity": "sha1-zyk977a1hg/1uMRJ2qHAx7tyjek=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "glob-parent": "2.0.0",
-        "has-glob": "0.1.1",
-        "is-valid-glob": "0.3.0",
-        "lazy-cache": "2.0.2",
-        "matched": "0.4.4",
-        "to-file": "0.2.0"
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "glob-parent": "^2.0.0",
+        "has-glob": "^0.1.1",
+        "is-valid-glob": "^0.3.0",
+        "lazy-cache": "^2.0.1",
+        "matched": "^0.4.1",
+        "to-file": "^0.2.0"
       },
       "dependencies": {
         "glob": {
@@ -7930,12 +7931,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "lazy-cache": {
@@ -7944,7 +7945,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         },
         "matched": {
@@ -7953,15 +7954,15 @@
           "integrity": "sha1-Vte36xgDPwz5vFLrIJD6x9weifo=",
           "dev": true,
           "requires": {
-            "arr-union": "3.1.0",
-            "async-array-reduce": "0.2.1",
-            "extend-shallow": "2.0.1",
-            "fs-exists-sync": "0.1.0",
-            "glob": "7.1.2",
-            "has-glob": "0.1.1",
-            "is-valid-glob": "0.3.0",
-            "lazy-cache": "2.0.2",
-            "resolve-dir": "0.1.1"
+            "arr-union": "^3.1.0",
+            "async-array-reduce": "^0.2.0",
+            "extend-shallow": "^2.0.1",
+            "fs-exists-sync": "^0.1.0",
+            "glob": "^7.0.5",
+            "has-glob": "^0.1.1",
+            "is-valid-glob": "^0.3.0",
+            "lazy-cache": "^2.0.1",
+            "resolve-dir": "^0.1.0"
           }
         }
       }
@@ -7978,9 +7979,9 @@
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
       "dev": true,
       "requires": {
-        "big.js": "3.2.0",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1"
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
       }
     },
     "locate-path": {
@@ -7989,8 +7990,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -8011,10 +8012,10 @@
       "integrity": "sha1-t7K7Q9whYEJKIczybFfkQ3cqjic=",
       "dev": true,
       "requires": {
-        "lodash._baseisequal": "3.0.7",
-        "lodash._bindcallback": "3.0.1",
-        "lodash.isarray": "3.0.4",
-        "lodash.pairs": "3.0.1"
+        "lodash._baseisequal": "^3.0.0",
+        "lodash._bindcallback": "^3.0.0",
+        "lodash.isarray": "^3.0.0",
+        "lodash.pairs": "^3.0.0"
       }
     },
     "lodash._baseeach": {
@@ -8023,7 +8024,7 @@
       "integrity": "sha1-z4cGVyyhROjZ11InyZDamC+TKvM=",
       "dev": true,
       "requires": {
-        "lodash.keys": "3.1.2"
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basefilter": {
@@ -8032,7 +8033,7 @@
       "integrity": "sha1-S3ZAPfDihtA9Xg9yle00QeEB0SE=",
       "dev": true,
       "requires": {
-        "lodash._baseeach": "3.0.4"
+        "lodash._baseeach": "^3.0.0"
       }
     },
     "lodash._baseisequal": {
@@ -8041,9 +8042,9 @@
       "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
       "dev": true,
       "requires": {
-        "lodash.isarray": "3.0.4",
-        "lodash.istypedarray": "3.0.6",
-        "lodash.keys": "3.1.2"
+        "lodash.isarray": "^3.0.0",
+        "lodash.istypedarray": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._baseismatch": {
@@ -8052,7 +8053,7 @@
       "integrity": "sha1-Byj8SO+hFpnT1fLXMEnyqxPED9U=",
       "dev": true,
       "requires": {
-        "lodash._baseisequal": "3.0.7"
+        "lodash._baseisequal": "^3.0.0"
       }
     },
     "lodash._basematches": {
@@ -8061,8 +8062,8 @@
       "integrity": "sha1-9H4D8H7CB4SrCWjQy2y1l+IQEVg=",
       "dev": true,
       "requires": {
-        "lodash._baseismatch": "3.1.3",
-        "lodash.pairs": "3.0.1"
+        "lodash._baseismatch": "^3.0.0",
+        "lodash.pairs": "^3.0.0"
       }
     },
     "lodash._bindcallback": {
@@ -8077,7 +8078,7 @@
       "integrity": "sha1-30U+ZkFjIXuJWkVAZa8cR6DqPE0=",
       "dev": true,
       "requires": {
-        "lodash._root": "3.0.1"
+        "lodash._root": "^3.0.0"
       }
     },
     "lodash._getnative": {
@@ -8110,9 +8111,9 @@
       "integrity": "sha1-+V9IY419i7tYVPkIJmUnmZ+/pLs=",
       "dev": true,
       "requires": {
-        "lodash._createwrapper": "3.2.0",
-        "lodash._replaceholders": "3.0.0",
-        "lodash.restparam": "3.6.1"
+        "lodash._createwrapper": "^3.0.0",
+        "lodash._replaceholders": "^3.0.0",
+        "lodash.restparam": "^3.0.0"
       }
     },
     "lodash.debounce": {
@@ -8174,9 +8175,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.last": {
@@ -8197,7 +8198,7 @@
       "integrity": "sha1-u+CNV4bu6qCaFckevw3LfSvjJqk=",
       "dev": true,
       "requires": {
-        "lodash.keys": "3.1.2"
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash.restparam": {
@@ -8212,11 +8213,11 @@
       "integrity": "sha1-LnhLnJM2jV11qu4zLOF2Ai8rlVM=",
       "dev": true,
       "requires": {
-        "lodash._arrayfilter": "3.0.0",
-        "lodash._basecallback": "3.3.1",
-        "lodash._basefilter": "3.0.0",
-        "lodash._basematches": "3.2.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._arrayfilter": "^3.0.0",
+        "lodash._basecallback": "^3.0.0",
+        "lodash._basefilter": "^3.0.0",
+        "lodash._basematches": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "log-ok": {
@@ -8225,8 +8226,8 @@
       "integrity": "sha1-vqPdNqzQuKckDXhza1uXxlREozQ=",
       "dev": true,
       "requires": {
-        "ansi-green": "0.1.1",
-        "success-symbol": "0.1.0"
+        "ansi-green": "^0.1.1",
+        "success-symbol": "^0.1.0"
       }
     },
     "log-utils": {
@@ -8235,13 +8236,13 @@
       "integrity": "sha1-pMIXoN2aUFFdm5ICBgkas9TgMc8=",
       "dev": true,
       "requires": {
-        "ansi-colors": "0.2.0",
-        "error-symbol": "0.1.0",
-        "info-symbol": "0.1.0",
-        "log-ok": "0.1.1",
-        "success-symbol": "0.1.0",
-        "time-stamp": "1.1.0",
-        "warning-symbol": "0.1.0"
+        "ansi-colors": "^0.2.0",
+        "error-symbol": "^0.1.0",
+        "info-symbol": "^0.1.0",
+        "log-ok": "^0.1.1",
+        "success-symbol": "^0.1.0",
+        "time-stamp": "^1.0.1",
+        "warning-symbol": "^0.1.0"
       }
     },
     "longest": {
@@ -8256,7 +8257,7 @@
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dev": true,
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
       }
     },
     "loud-rejection": {
@@ -8265,8 +8266,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lower-case": {
@@ -8287,8 +8288,8 @@
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "magic-string": {
@@ -8297,7 +8298,7 @@
       "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
       "dev": true,
       "requires": {
-        "vlq": "0.2.3"
+        "vlq": "^0.2.2"
       }
     },
     "make-dir": {
@@ -8306,7 +8307,7 @@
       "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       }
     },
     "make-iterator": {
@@ -8315,7 +8316,7 @@
       "integrity": "sha1-V7713IXSOSO6I3ZzJNjo+PPZaUs=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.1.0"
       }
     },
     "map-cache": {
@@ -8330,8 +8331,8 @@
       "integrity": "sha1-FwJgfiZ696NwyKnQxiumUk/rb+U=",
       "dev": true,
       "requires": {
-        "array-unique": "0.2.1",
-        "async": "1.5.2"
+        "array-unique": "^0.2.1",
+        "async": "^1.5.2"
       }
     },
     "map-obj": {
@@ -8346,26 +8347,26 @@
       "integrity": "sha1-wZVRg0/DwHoEWXt6WvtEpHWvlbQ=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "collection-visit": "0.2.3",
-        "component-emitter": "1.2.1",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "get-value": "2.0.6",
-        "is-primitive": "2.0.0",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "log-utils": "0.2.1",
-        "longest": "1.0.1",
-        "mixin-deep": "1.3.0",
-        "object.omit": "2.0.1",
-        "object.pick": "1.3.0",
-        "omit-empty": "0.4.1",
-        "pad-right": "0.2.2",
-        "set-value": "0.4.3",
-        "sort-object-arrays": "0.1.1",
-        "union-value": "0.2.4"
+        "arr-union": "^3.1.0",
+        "collection-visit": "^0.2.3",
+        "component-emitter": "^1.2.1",
+        "debug": "^2.6.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "get-value": "^2.0.6",
+        "is-primitive": "^2.0.0",
+        "kind-of": "^3.1.0",
+        "lazy-cache": "^2.0.2",
+        "log-utils": "^0.2.1",
+        "longest": "^1.0.1",
+        "mixin-deep": "^1.1.3",
+        "object.omit": "^2.0.1",
+        "object.pick": "^1.2.0",
+        "omit-empty": "^0.4.1",
+        "pad-right": "^0.2.2",
+        "set-value": "^0.4.0",
+        "sort-object-arrays": "^0.1.1",
+        "union-value": "^0.2.3"
       },
       "dependencies": {
         "collection-visit": {
@@ -8374,9 +8375,9 @@
           "integrity": "sha1-L2JIPK7MlfCDuaRUo+6eYTmteVc=",
           "dev": true,
           "requires": {
-            "lazy-cache": "2.0.2",
-            "map-visit": "0.1.5",
-            "object-visit": "0.3.4"
+            "lazy-cache": "^2.0.1",
+            "map-visit": "^0.1.5",
+            "object-visit": "^0.3.4"
           }
         },
         "lazy-cache": {
@@ -8385,7 +8386,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         },
         "map-visit": {
@@ -8394,8 +8395,8 @@
           "integrity": "sha1-2+Q5J85VJbgN/BVzpE1oxR8mgWs=",
           "dev": true,
           "requires": {
-            "lazy-cache": "2.0.2",
-            "object-visit": "0.3.4"
+            "lazy-cache": "^2.0.1",
+            "object-visit": "^0.3.4"
           }
         },
         "object-visit": {
@@ -8404,7 +8405,7 @@
           "integrity": "sha1-rhXPhvCy/dVRdxY2RIRSxUw9qCk=",
           "dev": true,
           "requires": {
-            "isobject": "2.1.0"
+            "isobject": "^2.0.0"
           }
         },
         "set-value": {
@@ -8413,10 +8414,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         },
         "union-value": {
@@ -8425,10 +8426,10 @@
           "integrity": "sha1-c3UVJ4ZnkFfns3qmdug0aPwCdPA=",
           "dev": true,
           "requires": {
-            "arr-union": "3.1.0",
-            "get-value": "2.0.6",
-            "is-extendable": "0.1.1",
-            "set-value": "0.4.3"
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
           }
         }
       }
@@ -8445,7 +8446,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "marked": {
@@ -8460,9 +8461,9 @@
       "integrity": "sha1-Jua88bOQpmH2Em+visUB4z7M+uk=",
       "dev": true,
       "requires": {
-        "is-glob": "3.1.0",
-        "isobject": "3.0.1",
-        "micromatch": "2.3.11"
+        "is-glob": "^3.1.0",
+        "isobject": "^3.0.0",
+        "micromatch": "^2.3.11"
       },
       "dependencies": {
         "is-extglob": {
@@ -8477,7 +8478,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         },
         "isobject": {
@@ -8494,12 +8495,12 @@
       "integrity": "sha512-7ivM1jFZVTOOS77QsR+TtYHH0ecdLclMkqbf5qiJdX2RorqfhsL65QHySPZgDE0ZjHoh+mQUNHTanNXIlzXd0Q==",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "async-array-reduce": "0.2.1",
-        "glob": "7.1.2",
-        "has-glob": "1.0.0",
-        "is-valid-glob": "1.0.0",
-        "resolve-dir": "1.0.1"
+        "arr-union": "^3.1.0",
+        "async-array-reduce": "^0.2.1",
+        "glob": "^7.1.2",
+        "has-glob": "^1.0.0",
+        "is-valid-glob": "^1.0.0",
+        "resolve-dir": "^1.0.0"
       },
       "dependencies": {
         "glob": {
@@ -8508,12 +8509,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "global-modules": {
@@ -8522,9 +8523,9 @@
           "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
           "dev": true,
           "requires": {
-            "global-prefix": "1.0.2",
-            "is-windows": "1.0.1",
-            "resolve-dir": "1.0.1"
+            "global-prefix": "^1.0.1",
+            "is-windows": "^1.0.1",
+            "resolve-dir": "^1.0.0"
           }
         },
         "has-glob": {
@@ -8533,7 +8534,7 @@
           "integrity": "sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=",
           "dev": true,
           "requires": {
-            "is-glob": "3.1.0"
+            "is-glob": "^3.0.0"
           }
         },
         "is-extglob": {
@@ -8548,7 +8549,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         },
         "is-valid-glob": {
@@ -8563,8 +8564,8 @@
           "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
           "dev": true,
           "requires": {
-            "expand-tilde": "2.0.2",
-            "global-modules": "1.0.0"
+            "expand-tilde": "^2.0.0",
+            "global-modules": "^1.0.0"
           }
         }
       }
@@ -8575,8 +8576,8 @@
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "memory-fs": {
@@ -8585,8 +8586,8 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "0.1.7",
-        "readable-stream": "2.3.3"
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
       }
     },
     "memorystream": {
@@ -8601,16 +8602,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -8627,10 +8628,10 @@
       "integrity": "sha1-zJEp3tedymWpUUSvPpjpTSrXoxc=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "clone-deep": "0.2.4",
-        "kind-of": "3.2.2",
-        "lazy-cache": "1.0.4"
+        "arr-union": "^3.1.0",
+        "clone-deep": "^0.2.4",
+        "kind-of": "^3.0.2",
+        "lazy-cache": "^1.0.3"
       }
     },
     "merge-stream": {
@@ -8639,7 +8640,7 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.1"
       }
     },
     "merge-value": {
@@ -8648,10 +8649,10 @@
       "integrity": "sha512-fJMmvat4NeKz63Uv9iHWcPDjCWcCkoiRoajRTEO8hlhUC6rwaHg0QCF9hBOTjZmm4JuglPckPSTtcuJL5kp0TQ==",
       "dev": true,
       "requires": {
-        "get-value": "2.0.6",
-        "is-extendable": "1.0.1",
-        "mixin-deep": "1.3.0",
-        "set-value": "2.0.0"
+        "get-value": "^2.0.6",
+        "is-extendable": "^1.0.0",
+        "mixin-deep": "^1.2.0",
+        "set-value": "^2.0.0"
       },
       "dependencies": {
         "is-extendable": {
@@ -8660,7 +8661,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         },
         "set-value": {
@@ -8669,10 +8670,10 @@
           "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "split-string": "3.1.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -8697,19 +8698,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "middleware-rename-file": {
@@ -8718,9 +8719,9 @@
       "integrity": "sha1-R4ilIS1Ja9Xbnak9U+fWHogGdj8=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-valid-app": "0.2.1",
-        "isobject": "2.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-valid-app": "^0.2.0",
+        "isobject": "^2.1.0"
       }
     },
     "middleware-utils": {
@@ -8729,8 +8730,8 @@
       "integrity": "sha1-RjoLrLGZ1H0g4xRyFoMFHw4fAxY=",
       "dev": true,
       "requires": {
-        "async-array-reduce": "0.2.1",
-        "async-each": "1.0.1"
+        "async-array-reduce": "^0.2.0",
+        "async-each": "^1.0.0"
       }
     },
     "miller-rabin": {
@@ -8739,8 +8740,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "mime": {
@@ -8760,7 +8761,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "~1.30.0"
       },
       "dependencies": {
         "mime-db": {
@@ -8808,7 +8809,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -8823,16 +8824,16 @@
       "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.0",
-        "duplexify": "3.5.3",
-        "end-of-stream": "1.4.1",
-        "flush-write-stream": "1.0.3",
-        "from2": "2.3.0",
-        "parallel-transform": "1.1.0",
-        "pump": "2.0.1",
-        "pumpify": "1.5.0",
-        "stream-each": "1.2.2",
-        "through2": "2.0.3"
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^2.0.1",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
       }
     },
     "mixin-deep": {
@@ -8841,8 +8842,8 @@
       "integrity": "sha512-dgaCvoh6i1nosAUBKb0l0pfJ78K8+S9fluyIR2YvAeUD/QuMahnFnF3xYty5eYXMjhGSsB0DsW6A0uAZyetoAg==",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -8851,7 +8852,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -8862,8 +8863,8 @@
       "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
       "dev": true,
       "requires": {
-        "for-in": "0.1.8",
-        "is-extendable": "0.1.1"
+        "for-in": "^0.1.3",
+        "is-extendable": "^0.1.1"
       },
       "dependencies": {
         "for-in": {
@@ -8928,8 +8929,8 @@
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "minimatch": "0.3.0"
+            "inherits": "2",
+            "minimatch": "0.3"
           }
         },
         "lru-cache": {
@@ -8944,8 +8945,8 @@
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         },
         "ms": {
@@ -8968,12 +8969,12 @@
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "requires": {
-        "aproba": "1.1.1",
-        "copy-concurrently": "1.0.5",
-        "fs-write-stream-atomic": "1.0.10",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "run-queue": "1.0.3"
+        "aproba": "^1.1.1",
+        "copy-concurrently": "^1.0.0",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
       }
     },
     "ms": {
@@ -8994,7 +8995,7 @@
       "integrity": "sha1-+ouxTViTRDqDppfq0MRoZP9Bvfo=",
       "dev": true,
       "requires": {
-        "reserved": "0.1.2"
+        "reserved": "^0.1.0"
       }
     },
     "nan": {
@@ -9010,18 +9011,18 @@
       "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "fragment-cache": "0.2.1",
-        "is-odd": "2.0.0",
-        "is-windows": "1.0.2",
-        "kind-of": "6.0.2",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-odd": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -9042,8 +9043,8 @@
           "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2",
-            "isobject": "3.0.1"
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
           }
         },
         "extend-shallow": {
@@ -9052,8 +9053,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           }
         },
         "is-accessor-descriptor": {
@@ -9062,7 +9063,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -9071,7 +9072,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -9080,9 +9081,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "is-extendable": {
@@ -9091,7 +9092,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         },
         "is-windows": {
@@ -9138,7 +9139,7 @@
       "integrity": "sha1-GfYZWRUZ8JZ2mlupqG5u7sgjw88=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "~2.0.1"
       }
     },
     "next-tick": {
@@ -9153,7 +9154,7 @@
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "dev": true,
       "requires": {
-        "lower-case": "1.1.4"
+        "lower-case": "^1.1.1"
       }
     },
     "node-libs-browser": {
@@ -9162,28 +9163,28 @@
       "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
       "dev": true,
       "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.2.0",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "domain-browser": "1.2.0",
-        "events": "1.1.1",
-        "https-browserify": "1.0.0",
-        "os-browserify": "0.3.0",
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
         "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.3",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.8.1",
-        "string_decoder": "1.0.3",
-        "timers-browserify": "2.0.10",
+        "process": "^0.11.10",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.3.3",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.7.2",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
         "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.3",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
@@ -9199,9 +9200,9 @@
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "dev": true,
           "requires": {
-            "base64-js": "1.3.0",
-            "ieee754": "1.1.8",
-            "isarray": "1.0.0"
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
           }
         }
       }
@@ -9213,17 +9214,17 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "detect-libc": "1.0.2",
+        "detect-libc": "^1.0.2",
         "hawk": "3.1.3",
-        "mkdirp": "0.5.1",
-        "nopt": "4.0.1",
-        "npmlog": "4.1.0",
-        "rc": "1.2.1",
+        "mkdirp": "^0.5.1",
+        "nopt": "^4.0.1",
+        "npmlog": "^4.0.2",
+        "rc": "^1.1.7",
         "request": "2.81.0",
-        "rimraf": "2.6.2",
-        "semver": "5.5.0",
-        "tar": "2.2.1",
-        "tar-pack": "3.4.0"
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^2.2.1",
+        "tar-pack": "^3.4.0"
       },
       "dependencies": {
         "ajv": {
@@ -9233,8 +9234,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "assert-plus": {
@@ -9257,7 +9258,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "cryptiles": {
@@ -9266,7 +9267,7 @@
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "form-data": {
@@ -9276,9 +9277,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "har-schema": {
@@ -9295,8 +9296,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
           }
         },
         "hawk": {
@@ -9305,10 +9306,10 @@
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
@@ -9324,9 +9325,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "performance-now": {
@@ -9350,28 +9351,28 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
           }
         },
         "sntp": {
@@ -9380,7 +9381,7 @@
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         }
       }
@@ -9391,8 +9392,8 @@
       "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
       "dev": true,
       "requires": {
-        "chalk": "0.4.0",
-        "underscore": "1.6.0"
+        "chalk": "~0.4.0",
+        "underscore": "~1.6.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9407,9 +9408,9 @@
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
+            "ansi-styles": "~1.0.0",
+            "has-color": "~0.1.0",
+            "strip-ansi": "~0.1.0"
           }
         },
         "strip-ansi": {
@@ -9433,8 +9434,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "abbrev": "1.1.0",
-        "osenv": "0.1.4"
+        "abbrev": "1",
+        "osenv": "^0.1.4"
       }
     },
     "normalize-package-data": {
@@ -9443,10 +9444,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -9455,7 +9456,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "normalize-pkg": {
@@ -9464,24 +9465,24 @@
       "integrity": "sha1-Luc3FJUXhQ2c7/WmI0r174nFFag=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "array-unique": "0.3.2",
-        "component-emitter": "1.2.1",
-        "export-files": "2.1.1",
-        "extend-shallow": "2.0.1",
-        "fs-exists-sync": "0.1.0",
-        "get-value": "2.0.6",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "map-schema": "0.2.4",
-        "minimist": "1.2.0",
-        "mixin-deep": "1.3.0",
-        "omit-empty": "0.4.1",
-        "parse-git-config": "1.1.1",
-        "repo-utils": "0.3.7",
-        "semver": "5.5.0",
-        "stringify-author": "0.1.3",
-        "write-json": "0.2.2"
+        "arr-union": "^3.1.0",
+        "array-unique": "^0.3.2",
+        "component-emitter": "^1.2.1",
+        "export-files": "^2.1.1",
+        "extend-shallow": "^2.0.1",
+        "fs-exists-sync": "^0.1.0",
+        "get-value": "^2.0.6",
+        "kind-of": "^3.0.4",
+        "lazy-cache": "^2.0.1",
+        "map-schema": "^0.2.3",
+        "minimist": "^1.2.0",
+        "mixin-deep": "^1.1.3",
+        "omit-empty": "^0.4.1",
+        "parse-git-config": "^1.0.2",
+        "repo-utils": "^0.3.6",
+        "semver": "^5.3.0",
+        "stringify-author": "^0.1.3",
+        "write-json": "^0.2.2"
       },
       "dependencies": {
         "array-unique": {
@@ -9496,7 +9497,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         },
         "minimist": {
@@ -9513,7 +9514,7 @@
       "integrity": "sha1-GKFNw/xJXcBs++Ao8AvhbdrE+uo=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.3.0"
       }
     },
     "npm-conf": {
@@ -9522,8 +9523,8 @@
       "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
       "dev": true,
       "requires": {
-        "config-chain": "1.1.11",
-        "pify": "3.0.0"
+        "config-chain": "^1.1.11",
+        "pify": "^3.0.0"
       }
     },
     "npm-run-all": {
@@ -9532,15 +9533,15 @@
       "integrity": "sha512-Z2aRlajMK4SQ8u19ZA75NZZu7wupfCNQWdYosIi8S6FgBdGf/8Y6Hgyjdc8zU2cYmIRVCx1nM80tJPkdEd+UYg==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.0",
-        "chalk": "2.3.0",
-        "cross-spawn": "5.1.0",
-        "memorystream": "0.3.1",
-        "minimatch": "3.0.4",
-        "ps-tree": "1.1.0",
-        "read-pkg": "3.0.0",
-        "shell-quote": "1.6.1",
-        "string.prototype.padend": "3.0.0"
+        "ansi-styles": "^3.2.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^5.1.0",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "ps-tree": "^1.1.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9549,7 +9550,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -9558,9 +9559,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "load-json-file": {
@@ -9569,10 +9570,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "parse-json": {
@@ -9581,8 +9582,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.1"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "path-type": {
@@ -9591,7 +9592,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "read-pkg": {
@@ -9600,9 +9601,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "3.0.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
         "strip-bom": {
@@ -9617,7 +9618,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -9629,10 +9630,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -9657,9 +9658,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       }
     },
     "object-keys": {
@@ -9674,7 +9675,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -9691,8 +9692,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "object.pick": {
@@ -9701,7 +9702,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -9718,9 +9719,9 @@
       "integrity": "sha1-KUo3gvLLIMdJfEEitiN8ncwMY6s=",
       "dev": true,
       "requires": {
-        "has-values": "0.1.4",
-        "kind-of": "3.2.2",
-        "reduce-object": "0.1.3"
+        "has-values": "^0.1.4",
+        "kind-of": "^3.0.3",
+        "reduce-object": "^0.1.3"
       },
       "dependencies": {
         "has-values": {
@@ -9736,7 +9737,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -9745,7 +9746,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "opener": {
@@ -9760,8 +9761,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "wordwrap": {
@@ -9778,15 +9779,15 @@
       "integrity": "sha1-y3ZRVboqhhwRCf8m4qIOqgZhKys=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "0.3.1",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "set-value": "0.4.3",
-        "to-object-path": "0.3.0"
+        "arr-flatten": "^1.0.3",
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^0.3.1",
+        "kind-of": "^3.2.2",
+        "lazy-cache": "^2.0.2",
+        "set-value": "^0.4.3",
+        "to-object-path": "^0.3.0"
       },
       "dependencies": {
         "lazy-cache": {
@@ -9795,7 +9796,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         },
         "set-value": {
@@ -9804,10 +9805,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
@@ -9818,12 +9819,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "options": {
@@ -9844,8 +9845,8 @@
       "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
       "dev": true,
       "requires": {
-        "is-stream": "1.1.0",
-        "readable-stream": "2.3.3"
+        "is-stream": "^1.0.1",
+        "readable-stream": "^2.0.1"
       }
     },
     "os-browserify": {
@@ -9873,8 +9874,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "p-cancelable": {
@@ -9889,7 +9890,7 @@
       "integrity": "sha1-jmtPT2XHK8W2/ii3XtqHT5akoIU=",
       "dev": true,
       "requires": {
-        "p-timeout": "1.2.1"
+        "p-timeout": "^1.1.1"
       }
     },
     "p-finally": {
@@ -9904,7 +9905,7 @@
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
       "dev": true,
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -9913,7 +9914,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.2.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-timeout": {
@@ -9922,7 +9923,7 @@
       "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
       "dev": true,
       "requires": {
-        "p-finally": "1.0.0"
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -9937,7 +9938,7 @@
       "integrity": "sha1-b7ySQEXSRPKiokRQMGDTv8YAl3Q=",
       "dev": true,
       "requires": {
-        "repeat-string": "1.6.1"
+        "repeat-string": "^1.5.2"
       }
     },
     "paginationator": {
@@ -9958,9 +9959,9 @@
       "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
       "dev": true,
       "requires": {
-        "cyclist": "0.2.2",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "cyclist": "~0.2.2",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
       }
     },
     "parse-asn1": {
@@ -9969,11 +9970,11 @@
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "dev": true,
       "requires": {
-        "asn1.js": "4.10.1",
-        "browserify-aes": "1.2.0",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.16"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
       }
     },
     "parse-author": {
@@ -9988,7 +9989,7 @@
       "integrity": "sha1-5ad1x0I7Bxa0wnQvs/zwVGJDAy4=",
       "dev": true,
       "requires": {
-        "copyright-regex": "1.1.6"
+        "copyright-regex": "^1.1.4"
       }
     },
     "parse-git-config": {
@@ -9997,10 +9998,10 @@
       "integrity": "sha1-06mYQxcTL1c5hxK7pDjhKVkN34w=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "fs-exists-sync": "0.1.0",
-        "git-config-path": "1.0.1",
-        "ini": "1.3.5"
+        "extend-shallow": "^2.0.1",
+        "fs-exists-sync": "^0.1.0",
+        "git-config-path": "^1.0.1",
+        "ini": "^1.3.4"
       }
     },
     "parse-github-url": {
@@ -10015,10 +10016,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parse-json": {
@@ -10027,7 +10028,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parse-passwd": {
@@ -10042,13 +10043,13 @@
       "integrity": "sha512-eqtUnI5+COkf1CQOYo8FmykN5Zs+5Yr60f/7GcPgQDZEEjdE/VZ4WMaMo9g37foof8h64t/TH2Uvk2Sq0fDy/g==",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "file-is-binary": "1.0.0",
-        "gray-matter": "3.1.1",
-        "isobject": "3.0.1",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.0",
-        "trim-leading-lines": "0.1.1"
+        "extend-shallow": "^2.0.1",
+        "file-is-binary": "^1.0.0",
+        "gray-matter": "^3.0.2",
+        "isobject": "^3.0.1",
+        "lazy-cache": "^2.0.2",
+        "mixin-deep": "^1.2.0",
+        "trim-leading-lines": "^0.1.1"
       },
       "dependencies": {
         "isobject": {
@@ -10063,7 +10064,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -10138,9 +10139,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -10157,7 +10158,7 @@
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "~2.3"
       }
     },
     "pbkdf2": {
@@ -10166,11 +10167,11 @@
       "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
       "dev": true,
       "requires": {
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.11"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "pend": {
@@ -10203,7 +10204,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -10212,7 +10213,7 @@
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "^2.1.0"
       }
     },
     "pkg-store": {
@@ -10221,11 +10222,11 @@
       "integrity": "sha1-sfXA+GIKWf1mWGrMXiVvTCw3oNg=",
       "dev": true,
       "requires": {
-        "cache-base": "0.8.5",
-        "kind-of": "3.2.2",
-        "lazy-cache": "1.0.4",
-        "union-value": "0.2.4",
-        "write-json": "0.2.2"
+        "cache-base": "^0.8.2",
+        "kind-of": "^3.0.2",
+        "lazy-cache": "^1.0.3",
+        "union-value": "^0.2.3",
+        "write-json": "^0.2.2"
       },
       "dependencies": {
         "cache-base": {
@@ -10234,16 +10235,16 @@
           "integrity": "sha1-YM6zUEAh7O7HAR/TOEt/TpVym/o=",
           "dev": true,
           "requires": {
-            "collection-visit": "0.2.3",
-            "component-emitter": "1.2.1",
-            "get-value": "2.0.6",
-            "has-value": "0.3.1",
-            "isobject": "3.0.1",
-            "lazy-cache": "2.0.2",
-            "set-value": "0.4.3",
-            "to-object-path": "0.3.0",
-            "union-value": "0.2.4",
-            "unset-value": "0.1.2"
+            "collection-visit": "^0.2.1",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.5",
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0",
+            "lazy-cache": "^2.0.1",
+            "set-value": "^0.4.2",
+            "to-object-path": "^0.3.0",
+            "union-value": "^0.2.3",
+            "unset-value": "^0.1.1"
           },
           "dependencies": {
             "lazy-cache": {
@@ -10252,7 +10253,7 @@
               "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
               "dev": true,
               "requires": {
-                "set-getter": "0.1.0"
+                "set-getter": "^0.1.0"
               }
             }
           }
@@ -10263,9 +10264,9 @@
           "integrity": "sha1-L2JIPK7MlfCDuaRUo+6eYTmteVc=",
           "dev": true,
           "requires": {
-            "lazy-cache": "2.0.2",
-            "map-visit": "0.1.5",
-            "object-visit": "0.3.4"
+            "lazy-cache": "^2.0.1",
+            "map-visit": "^0.1.5",
+            "object-visit": "^0.3.4"
           },
           "dependencies": {
             "lazy-cache": {
@@ -10274,7 +10275,7 @@
               "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
               "dev": true,
               "requires": {
-                "set-getter": "0.1.0"
+                "set-getter": "^0.1.0"
               }
             }
           }
@@ -10291,8 +10292,8 @@
           "integrity": "sha1-2+Q5J85VJbgN/BVzpE1oxR8mgWs=",
           "dev": true,
           "requires": {
-            "lazy-cache": "2.0.2",
-            "object-visit": "0.3.4"
+            "lazy-cache": "^2.0.1",
+            "object-visit": "^0.3.4"
           },
           "dependencies": {
             "lazy-cache": {
@@ -10301,7 +10302,7 @@
               "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
               "dev": true,
               "requires": {
-                "set-getter": "0.1.0"
+                "set-getter": "^0.1.0"
               }
             }
           }
@@ -10312,7 +10313,7 @@
           "integrity": "sha1-rhXPhvCy/dVRdxY2RIRSxUw9qCk=",
           "dev": true,
           "requires": {
-            "isobject": "2.1.0"
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -10332,10 +10333,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         },
         "union-value": {
@@ -10344,10 +10345,10 @@
           "integrity": "sha1-c3UVJ4ZnkFfns3qmdug0aPwCdPA=",
           "dev": true,
           "requires": {
-            "arr-union": "3.1.0",
-            "get-value": "2.0.6",
-            "is-extendable": "0.1.1",
-            "set-value": "0.4.3"
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
           }
         },
         "unset-value": {
@@ -10356,8 +10357,8 @@
           "integrity": "sha1-UGgQuGfyfCpabpsEgzYx9t5Y0xA=",
           "dev": true,
           "requires": {
-            "has-value": "0.3.1",
-            "isobject": "3.0.1"
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
           }
         }
       }
@@ -10380,9 +10381,9 @@
       "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1"
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
       }
     },
     "posix-character-classes": {
@@ -10415,8 +10416,8 @@
       "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
       "dev": true,
       "requires": {
-        "ansi-regex": "3.0.0",
-        "ansi-styles": "3.2.1"
+        "ansi-regex": "^3.0.0",
+        "ansi-styles": "^3.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -10431,7 +10432,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         }
       }
@@ -10442,8 +10443,8 @@
       "integrity": "sha1-ejvexAScYgzXxCt/NCt01W5z104=",
       "dev": true,
       "requires": {
-        "is-number": "2.1.0",
-        "nanoseconds": "0.1.0"
+        "is-number": "^2.0.2",
+        "nanoseconds": "^0.1.0"
       }
     },
     "private": {
@@ -10476,9 +10477,9 @@
       "integrity": "sha1-Pk94H+HulLB4apuuU1BjdsN5r2k=",
       "dev": true,
       "requires": {
-        "find-pkg": "0.1.2",
-        "git-repo-name": "0.6.0",
-        "minimist": "1.2.0"
+        "find-pkg": "^0.1.2",
+        "git-repo-name": "^0.6.0",
+        "minimist": "^1.2.0"
       },
       "dependencies": {
         "minimist": {
@@ -10501,12 +10502,12 @@
       "integrity": "sha512-7cJJ/8K2YSBLrcwobe0IRRMnveRi4q5WQ0JavBzWx5iaCfalRIpwEYxYqDTCjTIrJvWlLq/kBZgcmzHq9DvdPg==",
       "dev": true,
       "requires": {
-        "figures": "1.7.0",
-        "log-utils": "0.2.1",
-        "prompt-base": "0.5.2",
-        "prompt-choices": "0.4.1",
-        "readline-utils": "0.1.6",
-        "terminal-paginator": "0.2.2"
+        "figures": "^1.7.0",
+        "log-utils": "^0.2.1",
+        "prompt-base": "^0.5.0",
+        "prompt-choices": "^0.4.0",
+        "readline-utils": "^0.1.2",
+        "terminal-paginator": "^0.2.1"
       },
       "dependencies": {
         "figures": {
@@ -10515,8 +10516,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         }
       }
@@ -10527,12 +10528,12 @@
       "integrity": "sha1-vWyPQ1nbWt1OcCgNaOThhFak4kU=",
       "dev": true,
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "log-utils": "0.2.1",
-        "prompt-question": "0.4.1",
-        "readline-ui": "0.1.4"
+        "base": "^0.11.1",
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "log-utils": "^0.2.1",
+        "prompt-question": "^0.4.0",
+        "readline-ui": "^0.1.2"
       }
     },
     "prompt-choices": {
@@ -10541,21 +10542,21 @@
       "integrity": "sha1-EfqNWGr4T65DazOSL+88Gp9wLwM=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "choices-separator": "0.1.2",
-        "clone-deep": "0.2.4",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "is-number": "3.0.0",
-        "isobject": "2.1.0",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "log-utils": "0.2.1",
-        "radio-symbol": "0.2.3",
-        "set-value": "0.4.3",
-        "terminal-paginator": "0.2.2",
-        "toggle-array": "0.1.0"
+        "arr-flatten": "^1.0.1",
+        "choices-separator": "^0.1.2",
+        "clone-deep": "^0.2.4",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "isobject": "^2.1.0",
+        "kind-of": "^3.0.4",
+        "lazy-cache": "^2.0.1",
+        "log-utils": "^0.2.1",
+        "radio-symbol": "^0.2.1",
+        "set-value": "^0.4.0",
+        "terminal-paginator": "^0.2.0",
+        "toggle-array": "^0.1.0"
       },
       "dependencies": {
         "is-number": {
@@ -10564,7 +10565,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "lazy-cache": {
@@ -10573,7 +10574,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         },
         "set-value": {
@@ -10582,10 +10583,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
@@ -10596,13 +10597,13 @@
       "integrity": "sha1-UXOOVQXv7UjV/Du9GFq+ST+gJkQ=",
       "dev": true,
       "requires": {
-        "clone-deep": "0.2.4",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "prompt-choices": "0.4.1"
+        "clone-deep": "^0.2.4",
+        "debug": "^2.6.1",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^3.1.0",
+        "lazy-cache": "^2.0.2",
+        "prompt-choices": "^0.4.1"
       },
       "dependencies": {
         "lazy-cache": {
@@ -10611,7 +10612,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -10634,7 +10635,7 @@
       "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
       "dev": true,
       "requires": {
-        "event-stream": "3.3.4"
+        "event-stream": "~3.3.0"
       }
     },
     "pseudomap": {
@@ -10649,11 +10650,11 @@
       "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "parse-asn1": "5.1.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
       }
     },
     "pump": {
@@ -10662,8 +10663,8 @@
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "pumpify": {
@@ -10672,9 +10673,9 @@
       "integrity": "sha512-UWi0klDoq8xtVzlMRgENV9F7iCTZExaJQSQL187UXsxpk9NnrKGqTqqUNYAKGOzucSOxs2+jUnRNI+rLviPhJg==",
       "dev": true,
       "requires": {
-        "duplexify": "3.6.0",
-        "inherits": "2.0.3",
-        "pump": "2.0.1"
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
       },
       "dependencies": {
         "duplexify": {
@@ -10683,10 +10684,10 @@
           "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "stream-shift": "1.0.0"
+            "end-of-stream": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0",
+            "stream-shift": "^1.0.0"
           }
         }
       }
@@ -10720,25 +10721,25 @@
       "integrity": "sha1-C8JzKRdTQXB99azTHvLd9nApFo0=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "arr-union": "3.1.0",
-        "async-each-series": "1.1.0",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "get-value": "2.0.6",
-        "has-value": "0.3.1",
-        "inquirer2": "0.1.1",
-        "is-answer": "0.1.1",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.0",
-        "omit-empty": "0.4.1",
-        "option-cache": "3.5.0",
-        "os-homedir": "1.0.2",
-        "project-name": "0.2.6",
-        "set-value": "0.3.3",
-        "to-choices": "0.2.0",
-        "use": "2.0.2"
+        "arr-flatten": "^1.0.1",
+        "arr-union": "^3.1.0",
+        "async-each-series": "^1.1.0",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "get-value": "^2.0.6",
+        "has-value": "^0.3.1",
+        "inquirer2": "^0.1.1",
+        "is-answer": "^0.1.0",
+        "isobject": "^2.1.0",
+        "lazy-cache": "^2.0.1",
+        "mixin-deep": "^1.1.3",
+        "omit-empty": "^0.4.1",
+        "option-cache": "^3.4.0",
+        "os-homedir": "^1.0.1",
+        "project-name": "^0.2.5",
+        "set-value": "^0.3.3",
+        "to-choices": "^0.2.0",
+        "use": "^2.0.0"
       },
       "dependencies": {
         "lazy-cache": {
@@ -10747,7 +10748,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         },
         "use": {
@@ -10756,9 +10757,9 @@
           "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
           "dev": true,
           "requires": {
-            "define-property": "0.2.5",
-            "isobject": "3.0.1",
-            "lazy-cache": "2.0.2"
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "lazy-cache": "^2.0.2"
           },
           "dependencies": {
             "isobject": {
@@ -10777,13 +10778,13 @@
       "integrity": "sha1-gf1NRF9NWtwqYiPCUj+nEj4E/X0=",
       "dev": true,
       "requires": {
-        "common-config": "0.1.0",
-        "data-store": "0.16.1",
-        "debug": "2.6.9",
-        "is-answer": "0.1.1",
-        "lazy-cache": "2.0.2",
-        "project-name": "0.2.6",
-        "question-cache": "0.5.1"
+        "common-config": "^0.1.0",
+        "data-store": "^0.16.1",
+        "debug": "^2.2.0",
+        "is-answer": "^0.1.0",
+        "lazy-cache": "^2.0.1",
+        "project-name": "^0.2.6",
+        "question-cache": "^0.5.1"
       },
       "dependencies": {
         "lazy-cache": {
@@ -10792,7 +10793,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -10803,9 +10804,9 @@
       "integrity": "sha1-UbfC7uX8/rsmLpqQZe9HvcUrR7k=",
       "dev": true,
       "requires": {
-        "ansi-gray": "0.1.1",
-        "ansi-green": "0.1.1",
-        "is-windows": "1.0.1"
+        "ansi-gray": "^0.1.1",
+        "ansi-green": "^0.1.1",
+        "is-windows": "^1.0.1"
       }
     },
     "randomatic": {
@@ -10814,8 +10815,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -10824,7 +10825,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -10833,7 +10834,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -10844,7 +10845,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -10855,7 +10856,7 @@
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
@@ -10864,8 +10865,8 @@
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.1"
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "rc": {
@@ -10875,10 +10876,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -10902,9 +10903,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -10913,8 +10914,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -10923,8 +10924,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-exists": {
@@ -10933,7 +10934,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         }
       }
@@ -10944,13 +10945,13 @@
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -10959,10 +10960,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "readline-ui": {
@@ -10971,11 +10972,11 @@
       "integrity": "sha1-QSw3QzVZvBoKexXi3MpLqm2SJ1w=",
       "dev": true,
       "requires": {
-        "component-emitter": "1.2.1",
-        "debug": "2.6.9",
-        "readline-utils": "0.1.6",
-        "string-width": "2.1.1",
-        "strip-color": "0.1.0"
+        "component-emitter": "^1.2.1",
+        "debug": "^2.6.6",
+        "readline-utils": "^0.1.6",
+        "string-width": "^2.0.0",
+        "strip-color": "^0.1.0"
       }
     },
     "readline-utils": {
@@ -10984,14 +10985,14 @@
       "integrity": "sha1-Op2pqZaJDBfxflQMqJ5FajEhH2c=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "cli-width": "2.2.0",
-        "extend-shallow": "2.0.1",
-        "get-value": "2.0.6",
-        "is-number": "3.0.0",
-        "is-windows": "1.0.1",
-        "lazy-cache": "2.0.2",
-        "mute-stream": "0.0.7"
+        "arr-flatten": "^1.0.3",
+        "cli-width": "^2.1.0",
+        "extend-shallow": "^2.0.1",
+        "get-value": "^2.0.6",
+        "is-number": "^3.0.0",
+        "is-windows": "^1.0.1",
+        "lazy-cache": "^2.0.2",
+        "mute-stream": "^0.0.7"
       },
       "dependencies": {
         "is-number": {
@@ -11000,7 +11001,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "lazy-cache": {
@@ -11009,7 +11010,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -11020,8 +11021,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
         "mute-stream": "0.0.5"
       },
       "dependencies": {
@@ -11031,7 +11032,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "mute-stream": {
@@ -11048,8 +11049,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "reduce-object": {
@@ -11058,7 +11059,7 @@
       "integrity": "sha1-1UnUCmwpNvpOPpt4yonJMxRZQhg=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5"
+        "for-own": "^0.1.1"
       }
     },
     "regenerate": {
@@ -11079,9 +11080,9 @@
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.8"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       }
     },
     "regex-cache": {
@@ -11090,7 +11091,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regex-not": {
@@ -11099,8 +11100,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2",
-        "safe-regex": "1.1.0"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -11109,8 +11110,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           }
         },
         "is-extendable": {
@@ -11119,7 +11120,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -11130,9 +11131,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "regjsgen": {
@@ -11147,7 +11148,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -11164,7 +11165,7 @@
       "integrity": "sha1-Dc2OxUpdNaPBXhBFA9ZTdbWlNn8=",
       "dev": true,
       "requires": {
-        "isobject": "2.1.0"
+        "isobject": "^2.0.0"
       }
     },
     "remote-origin-url": {
@@ -11173,7 +11174,7 @@
       "integrity": "sha512-crQ7Xk1m/F2IiwBx5oTqk/c0hjoumrEz+a36+ZoVupskQRE/q7pAwHKsTNeiZ31sbSTELvVlVv4h1W0Xo5szKg==",
       "dev": true,
       "requires": {
-        "parse-git-config": "1.1.1"
+        "parse-git-config": "^1.1.1"
       }
     },
     "remove-trailing-separator": {
@@ -11200,7 +11201,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "replace-ext": {
@@ -11215,18 +11216,18 @@
       "integrity": "sha1-SrZq80DLEfp+XPgFgekr6Xwb964=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "get-value": "2.0.6",
-        "git-config-path": "1.0.1",
-        "is-absolute": "0.2.6",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.0",
-        "omit-empty": "0.4.1",
-        "parse-author": "1.0.0",
-        "parse-git-config": "1.1.1",
-        "parse-github-url": "0.3.2",
-        "project-name": "0.2.6"
+        "extend-shallow": "^2.0.1",
+        "get-value": "^2.0.6",
+        "git-config-path": "^1.0.1",
+        "is-absolute": "^0.2.6",
+        "kind-of": "^3.0.4",
+        "lazy-cache": "^2.0.1",
+        "mixin-deep": "^1.1.3",
+        "omit-empty": "^0.4.1",
+        "parse-author": "^1.0.0",
+        "parse-git-config": "^1.0.2",
+        "parse-github-url": "^0.3.2",
+        "project-name": "^0.2.6"
       },
       "dependencies": {
         "lazy-cache": {
@@ -11235,7 +11236,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -11246,28 +11247,28 @@
       "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       },
       "dependencies": {
         "qs": {
@@ -11284,8 +11285,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
     },
     "requires-port": {
@@ -11306,7 +11307,7 @@
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-dir": {
@@ -11315,8 +11316,8 @@
       "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "1.2.2",
-        "global-modules": "0.2.3"
+        "expand-tilde": "^1.2.2",
+        "global-modules": "^0.2.3"
       },
       "dependencies": {
         "expand-tilde": {
@@ -11325,7 +11326,7 @@
           "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
           "dev": true,
           "requires": {
-            "os-homedir": "1.0.2"
+            "os-homedir": "^1.0.1"
           }
         }
       }
@@ -11336,14 +11337,14 @@
       "integrity": "sha1-FNvsWhnThPXW3GSin9ZigV0xdpY=",
       "dev": true,
       "requires": {
-        "cwd": "0.10.0",
-        "expand-tilde": "2.0.2",
-        "extend-shallow": "2.0.1",
-        "fs-exists-sync": "0.1.0",
-        "global-modules": "0.2.3",
-        "homedir-polyfill": "1.0.1",
-        "lazy-cache": "2.0.2",
-        "resolve": "1.5.0"
+        "cwd": "^0.10.0",
+        "expand-tilde": "^2.0.1",
+        "extend-shallow": "^2.0.1",
+        "fs-exists-sync": "^0.1.0",
+        "global-modules": "^0.2.3",
+        "homedir-polyfill": "^1.0.0",
+        "lazy-cache": "^2.0.1",
+        "resolve": "^1.1.7"
       },
       "dependencies": {
         "cwd": {
@@ -11352,8 +11353,8 @@
           "integrity": "sha1-FyQAaUBXwioTsM8WFix+S3p/5Wc=",
           "dev": true,
           "requires": {
-            "find-pkg": "0.1.2",
-            "fs-exists-sync": "0.1.0"
+            "find-pkg": "^0.1.2",
+            "fs-exists-sync": "^0.1.0"
           }
         },
         "lazy-cache": {
@@ -11362,7 +11363,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -11379,11 +11380,11 @@
       "integrity": "sha512-wSW9pVGJRs89k0wEXhM7C6+va9998NsDhgc0Y+6Nv8hrHsu0hUS7Ug10J1EiVtU6N2tKlSNvx9wLihL8Ao22Lg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-valid-glob": "1.0.0",
-        "matched": "1.0.2",
-        "relative": "3.0.2",
-        "resolve-dir": "1.0.1"
+        "extend-shallow": "^2.0.1",
+        "is-valid-glob": "^1.0.0",
+        "matched": "^1.0.2",
+        "relative": "^3.0.2",
+        "resolve-dir": "^1.0.0"
       },
       "dependencies": {
         "global-modules": {
@@ -11392,9 +11393,9 @@
           "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
           "dev": true,
           "requires": {
-            "global-prefix": "1.0.2",
-            "is-windows": "1.0.1",
-            "resolve-dir": "1.0.1"
+            "global-prefix": "^1.0.1",
+            "is-windows": "^1.0.1",
+            "resolve-dir": "^1.0.0"
           }
         },
         "is-valid-glob": {
@@ -11409,8 +11410,8 @@
           "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
           "dev": true,
           "requires": {
-            "expand-tilde": "2.0.2",
-            "global-modules": "1.0.0"
+            "expand-tilde": "^2.0.0",
+            "global-modules": "^1.0.0"
           }
         }
       }
@@ -11427,8 +11428,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "ret": {
@@ -11443,12 +11444,12 @@
       "integrity": "sha1-xVKPGQ6J7HU1iJRSob5omWtfZhY=",
       "dev": true,
       "requires": {
-        "ansi-bgred": "0.1.1",
-        "ansi-red": "0.1.1",
-        "ansi-yellow": "0.1.1",
-        "extend-shallow": "1.1.4",
-        "lazy-cache": "0.2.7",
-        "right-align": "0.1.3"
+        "ansi-bgred": "^0.1.1",
+        "ansi-red": "^0.1.1",
+        "ansi-yellow": "^0.1.1",
+        "extend-shallow": "^1.1.4",
+        "lazy-cache": "^0.2.3",
+        "right-align": "^0.1.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -11457,7 +11458,7 @@
           "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
           "dev": true,
           "requires": {
-            "kind-of": "1.1.0"
+            "kind-of": "^1.1.0"
           }
         },
         "kind-of": {
@@ -11480,7 +11481,7 @@
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -11489,7 +11490,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       },
       "dependencies": {
         "glob": {
@@ -11498,12 +11499,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -11514,8 +11515,8 @@
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "rollup": {
@@ -11525,7 +11526,7 @@
       "dev": true,
       "requires": {
         "@types/estree": "0.0.38",
-        "@types/node": "10.0.0"
+        "@types/node": "*"
       }
     },
     "rollup-plugin-babel": {
@@ -11534,7 +11535,7 @@
       "integrity": "sha512-TGhQbliTZnRoUhd2214K3r4KJUBu9J1DPzcrAnkluVXOVrveU9OvAaYQ16KyOmujAoq+LMC1+x6YF2xBrU7t+g==",
       "dev": true,
       "requires": {
-        "rollup-pluginutils": "1.5.2"
+        "rollup-pluginutils": "^1.5.0"
       }
     },
     "rollup-plugin-commonjs": {
@@ -11543,10 +11544,10 @@
       "integrity": "sha512-NrfE0g30QljNCnlJr7I2Xguz+44mh0dCxvfxwLnCwtaCK2LwFUp1zzAs8MQuOfhH4mRskqsjfOwGUap/L+WtEw==",
       "dev": true,
       "requires": {
-        "estree-walker": "0.5.1",
-        "magic-string": "0.22.5",
-        "resolve": "1.5.0",
-        "rollup-pluginutils": "2.0.1"
+        "estree-walker": "^0.5.1",
+        "magic-string": "^0.22.4",
+        "resolve": "^1.5.0",
+        "rollup-pluginutils": "^2.0.1"
       },
       "dependencies": {
         "estree-walker": {
@@ -11561,8 +11562,8 @@
           "integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
           "dev": true,
           "requires": {
-            "estree-walker": "0.3.1",
-            "micromatch": "2.3.11"
+            "estree-walker": "^0.3.0",
+            "micromatch": "^2.3.11"
           },
           "dependencies": {
             "estree-walker": {
@@ -11581,9 +11582,9 @@
       "integrity": "sha512-9zHGr3oUJq6G+X0oRMYlzid9fXicBdiydhwGChdyeNRGPcN/majtegApRKHLR5drboUvEWU+QeUmGTyEZQs3WA==",
       "dev": true,
       "requires": {
-        "builtin-modules": "2.0.0",
-        "is-module": "1.0.0",
-        "resolve": "1.5.0"
+        "builtin-modules": "^2.0.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.1.6"
       },
       "dependencies": {
         "builtin-modules": {
@@ -11600,9 +11601,9 @@
       "integrity": "sha512-pK9mTd/FNrhtBxcTBXoh0YOwRIShV0gGhv9qvUtNcXHxIMRZMXqfiZKVBmCRGp8/2DJRy62z2JUE7/5tP6WxOQ==",
       "dev": true,
       "requires": {
-        "magic-string": "0.22.5",
-        "minimatch": "3.0.4",
-        "rollup-pluginutils": "2.0.1"
+        "magic-string": "^0.22.4",
+        "minimatch": "^3.0.2",
+        "rollup-pluginutils": "^2.0.1"
       },
       "dependencies": {
         "estree-walker": {
@@ -11617,8 +11618,8 @@
           "integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
           "dev": true,
           "requires": {
-            "estree-walker": "0.3.1",
-            "micromatch": "2.3.11"
+            "estree-walker": "^0.3.0",
+            "micromatch": "^2.3.11"
           }
         }
       }
@@ -11629,15 +11630,15 @@
       "integrity": "sha512-fAcKc1Q2qX3XbwsTRFmFHYFnfhdjh80Pg4e8veyzGvLKL0CJUgILBsHuvp1sykKeDSBksNrntCet2TqrISQNTQ==",
       "dev": true,
       "requires": {
-        "bytes": "3.0.0",
-        "chalk": "2.4.1",
-        "fast-deep-equal": "1.1.0",
-        "gzip-size": "4.1.0",
-        "jest-diff": "22.4.3",
-        "memory-fs": "0.4.1",
-        "rollup-plugin-replace": "2.0.0",
-        "uglify-es": "3.3.9",
-        "webpack": "4.7.0"
+        "bytes": "^3.0.0",
+        "chalk": "^2.3.2",
+        "fast-deep-equal": "^1.1.0",
+        "gzip-size": "^4.1.0",
+        "jest-diff": "^22.4.0",
+        "memory-fs": "^0.4.1",
+        "rollup-plugin-replace": "^2.0.0",
+        "uglify-es": "^3.3.9",
+        "webpack": "^4.5.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -11646,7 +11647,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -11655,9 +11656,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "commander": {
@@ -11690,7 +11691,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "uglify-es": {
@@ -11699,8 +11700,8 @@
           "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
           "dev": true,
           "requires": {
-            "commander": "2.13.0",
-            "source-map": "0.6.1"
+            "commander": "~2.13.0",
+            "source-map": "~0.6.1"
           }
         }
       }
@@ -11711,7 +11712,7 @@
       "integrity": "sha512-dehLu9eRRoV4l09aC+ySntRw1OAfoyKdbk8Nelblj03tHoynkSybqyEpgavemi1LBOH6S1vzI58/mpxkZIe1iQ==",
       "dev": true,
       "requires": {
-        "uglify-es": "3.3.9"
+        "uglify-es": "^3.3.7"
       },
       "dependencies": {
         "commander": {
@@ -11732,8 +11733,8 @@
           "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
           "dev": true,
           "requires": {
-            "commander": "2.13.0",
-            "source-map": "0.6.1"
+            "commander": "~2.13.0",
+            "source-map": "~0.6.1"
           }
         }
       }
@@ -11744,8 +11745,8 @@
       "integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
       "dev": true,
       "requires": {
-        "estree-walker": "0.2.1",
-        "minimatch": "3.0.4"
+        "estree-walker": "^0.2.1",
+        "minimatch": "^3.0.2"
       }
     },
     "run-async": {
@@ -11754,7 +11755,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "run-queue": {
@@ -11763,7 +11764,7 @@
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
-        "aproba": "1.1.1"
+        "aproba": "^1.1.1"
       }
     },
     "rx-lite": {
@@ -11778,7 +11779,7 @@
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
-        "rx-lite": "4.0.8"
+        "rx-lite": "*"
       }
     },
     "safe-buffer": {
@@ -11792,7 +11793,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "schema-utils": {
@@ -11801,8 +11802,8 @@
       "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
       "dev": true,
       "requires": {
-        "ajv": "6.4.0",
-        "ajv-keywords": "3.2.0"
+        "ajv": "^6.1.0",
+        "ajv-keywords": "^3.1.0"
       },
       "dependencies": {
         "ajv": {
@@ -11811,10 +11812,10 @@
           "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1",
-            "uri-js": "3.0.2"
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0",
+            "uri-js": "^3.0.2"
           }
         },
         "ajv-keywords": {
@@ -11831,7 +11832,7 @@
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "dev": true,
       "requires": {
-        "commander": "2.8.1"
+        "commander": "~2.8.1"
       }
     },
     "semver": {
@@ -11852,10 +11853,10 @@
       "integrity": "sha512-s7F8h2NrslMkG50KxvlGdj+ApSwaLex0vexuJ9iFf3GLTIp1ph/l1qZvRe9T9TJEYZgmq72ZwJ2VYiAEtChknw==",
       "dev": true,
       "requires": {
-        "etag": "1.8.1",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
         "ms": "2.0.0",
-        "parseurl": "1.3.2",
+        "parseurl": "~1.3.2",
         "safe-buffer": "5.1.1"
       }
     },
@@ -11871,7 +11872,7 @@
       "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
       "dev": true,
       "requires": {
-        "to-object-path": "0.3.0"
+        "to-object-path": "^0.3.0"
       }
     },
     "set-immediate-shim": {
@@ -11886,9 +11887,9 @@
       "integrity": "sha1-uBIjaBY4oQiP2IpDW4qdMtro2bo=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "isobject": "2.1.0",
-        "to-object-path": "0.2.0"
+        "extend-shallow": "^2.0.1",
+        "isobject": "^2.0.0",
+        "to-object-path": "^0.2.0"
       },
       "dependencies": {
         "to-object-path": {
@@ -11897,8 +11898,8 @@
           "integrity": "sha1-FjThtSqIugDjlJYZ/ACB3Jo7B8o=",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "is-arguments": "1.0.2"
+            "arr-flatten": "^1.0.1",
+            "is-arguments": "^1.0.2"
           }
         }
       }
@@ -11915,8 +11916,8 @@
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shallow-clone": {
@@ -11925,10 +11926,10 @@
       "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
       "dev": true,
       "requires": {
-        "is-extendable": "0.1.1",
-        "kind-of": "2.0.1",
-        "lazy-cache": "0.2.7",
-        "mixin-object": "2.0.1"
+        "is-extendable": "^0.1.1",
+        "kind-of": "^2.0.1",
+        "lazy-cache": "^0.2.3",
+        "mixin-object": "^2.0.1"
       },
       "dependencies": {
         "kind-of": {
@@ -11937,7 +11938,7 @@
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.0.2"
           }
         },
         "lazy-cache": {
@@ -11954,7 +11955,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -11969,10 +11970,10 @@
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "dev": true,
       "requires": {
-        "array-filter": "0.0.1",
-        "array-map": "0.0.0",
-        "array-reduce": "0.0.0",
-        "jsonify": "0.0.0"
+        "array-filter": "~0.0.0",
+        "array-map": "~0.0.0",
+        "array-reduce": "~0.0.0",
+        "jsonify": "~0.0.0"
       }
     },
     "sigmund": {
@@ -11999,7 +12000,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0"
+        "is-fullwidth-code-point": "^2.0.0"
       }
     },
     "snapdragon": {
@@ -12008,14 +12009,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.1",
-        "use": "3.1.0"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -12030,7 +12031,7 @@
           "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -12041,9 +12042,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -12052,7 +12053,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -12061,7 +12062,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -12070,7 +12071,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -12079,9 +12080,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "isobject": {
@@ -12104,7 +12105,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.2.0"
       }
     },
     "sniper": {
@@ -12113,17 +12114,17 @@
       "integrity": "sha1-3CBy30rvG8OhBIkComYpA4YZLEY=",
       "dev": true,
       "requires": {
-        "biojs-util-snippets": "0.1.16",
-        "bluebird": "3.5.1",
-        "commander": "2.8.1",
-        "concat-stream": "1.6.0",
-        "deepcopy": "0.4.0",
-        "director": "1.2.8",
-        "ecstatic": "0.5.8",
-        "minilog": "2.1.0",
-        "serve-favicon": "2.4.5",
-        "swig": "1.4.2",
-        "union": "0.4.6"
+        "biojs-util-snippets": "^0.1.16",
+        "bluebird": "^3.2.2",
+        "commander": "^2.3.0",
+        "concat-stream": "^1.4.6",
+        "deepcopy": "^0.4.0",
+        "director": "^1.2.3",
+        "ecstatic": "^0.5.4",
+        "minilog": "^2.0.6",
+        "serve-favicon": "^2.1.6",
+        "swig": "^1.4.2",
+        "union": "^0.4.2"
       },
       "dependencies": {
         "ecstatic": {
@@ -12132,9 +12133,9 @@
           "integrity": "sha1-gZFjw9Hoxz1ONuJoYm/qaN18OY0=",
           "dev": true,
           "requires": {
-            "he": "0.5.0",
-            "mime": "1.6.0",
-            "minimist": "1.2.0"
+            "he": "^0.5.0",
+            "mime": "^1.2.11",
+            "minimist": "^1.1.0"
           }
         },
         "he": {
@@ -12157,7 +12158,7 @@
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "dev": true,
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.x.x"
       }
     },
     "sort-keys": {
@@ -12166,7 +12167,7 @@
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "1.1.0"
+        "is-plain-obj": "^1.0.0"
       }
     },
     "sort-keys-length": {
@@ -12175,7 +12176,7 @@
       "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
       "dev": true,
       "requires": {
-        "sort-keys": "1.1.2"
+        "sort-keys": "^1.0.0"
       }
     },
     "sort-object-arrays": {
@@ -12184,7 +12185,7 @@
       "integrity": "sha1-mfVc8gWkkd3h9S8Jajaiawm0gy8=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "source-list-map": {
@@ -12205,11 +12206,11 @@
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "dev": true,
       "requires": {
-        "atob": "2.1.1",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.0.0",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-support": {
@@ -12218,7 +12219,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       }
     },
     "source-map-url": {
@@ -12233,7 +12234,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -12254,7 +12255,7 @@
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "split-string": {
@@ -12263,7 +12264,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -12272,8 +12273,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           }
         },
         "is-extendable": {
@@ -12282,7 +12283,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -12299,9 +12300,9 @@
       "integrity": "sha1-2T9G0oGjcAKB7A8wszoDFDiUpoE=",
       "dev": true,
       "requires": {
-        "duplexify": "3.5.3",
-        "merge-stream": "0.1.8",
-        "through2": "2.0.3"
+        "duplexify": "^3.4.2",
+        "merge-stream": "^0.1.8",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -12316,7 +12317,7 @@
           "integrity": "sha1-SKB7O0oSHXSj7b/c20sIrb8CQLE=",
           "dev": true,
           "requires": {
-            "through2": "0.6.5"
+            "through2": "^0.6.1"
           },
           "dependencies": {
             "through2": {
@@ -12325,8 +12326,8 @@
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
               "dev": true,
               "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "4.0.1"
+                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                "xtend": ">=4.0.0 <4.1.0-0"
               }
             }
           }
@@ -12337,10 +12338,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -12356,14 +12357,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "ssri": {
@@ -12372,7 +12373,7 @@
       "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.1"
       }
     },
     "static-extend": {
@@ -12381,8 +12382,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       }
     },
     "stream-browserify": {
@@ -12391,8 +12392,8 @@
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-combiner": {
@@ -12401,7 +12402,7 @@
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1"
+        "duplexer": "~0.1.1"
       }
     },
     "stream-each": {
@@ -12410,8 +12411,8 @@
       "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "stream-exhaust": {
@@ -12426,11 +12427,11 @@
       "integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.3",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "stream-shift": {
@@ -12445,8 +12446,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -12461,7 +12462,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -12472,9 +12473,9 @@
       "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.4.3",
+        "function-bind": "^1.0.2"
       }
     },
     "string_decoder": {
@@ -12483,7 +12484,7 @@
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringify-author": {
@@ -12502,7 +12503,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -12511,7 +12512,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-bom-buffer": {
@@ -12520,8 +12521,8 @@
       "integrity": "sha1-yj3cSRnBP5/d8wsd/xAKmDUki00=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6",
-        "is-utf8": "0.2.1"
+        "is-buffer": "^1.1.0",
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-bom-stream": {
@@ -12530,8 +12531,8 @@
       "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
       "dev": true,
       "requires": {
-        "first-chunk-stream": "1.0.0",
-        "strip-bom": "2.0.0"
+        "first-chunk-stream": "^1.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "strip-bom-string": {
@@ -12552,7 +12553,7 @@
       "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
       "dev": true,
       "requires": {
-        "is-natural-number": "4.0.1"
+        "is-natural-number": "^4.0.1"
       }
     },
     "strip-indent": {
@@ -12561,7 +12562,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
@@ -12576,7 +12577,7 @@
       "integrity": "sha1-qsC6YNLpDF1PJ1/Yhp/ZotMQ/7g=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.2"
       }
     },
     "success-symbol": {
@@ -12597,8 +12598,8 @@
       "integrity": "sha1-QIXKBFM2kQS11IPihBs5t64aq6U=",
       "dev": true,
       "requires": {
-        "optimist": "0.6.1",
-        "uglify-js": "2.4.24"
+        "optimist": "~0.6",
+        "uglify-js": "~2.4"
       },
       "dependencies": {
         "async": {
@@ -12619,7 +12620,7 @@
           "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "uglify-js": {
@@ -12628,10 +12629,10 @@
           "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
           "dev": true,
           "requires": {
-            "async": "0.2.10",
+            "async": "~0.2.6",
             "source-map": "0.1.34",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.5.4"
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.5.4"
           }
         },
         "wordwrap": {
@@ -12646,8 +12647,8 @@
           "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
           "dev": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0",
             "wordwrap": "0.0.2"
           }
@@ -12660,12 +12661,12 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
-        "chalk": "2.3.0",
-        "lodash": "4.17.4",
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12674,7 +12675,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -12683,9 +12684,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "supports-color": {
@@ -12694,7 +12695,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -12705,7 +12706,7 @@
       "integrity": "sha1-fCngEzsn1ItWuedtOijSQd8bOiQ=",
       "dev": true,
       "requires": {
-        "isobject": "2.1.0"
+        "isobject": "^2.0.0"
       }
     },
     "tapable": {
@@ -12720,9 +12721,9 @@
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
       }
     },
     "tar-pack": {
@@ -12732,14 +12733,14 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "debug": "2.6.9",
-        "fstream": "1.0.11",
-        "fstream-ignore": "1.0.5",
-        "once": "1.4.0",
-        "readable-stream": "2.3.3",
-        "rimraf": "2.6.2",
-        "tar": "2.2.1",
-        "uid-number": "0.0.6"
+        "debug": "^2.2.0",
+        "fstream": "^1.0.10",
+        "fstream-ignore": "^1.0.5",
+        "once": "^1.3.3",
+        "readable-stream": "^2.1.4",
+        "rimraf": "^2.5.1",
+        "tar": "^2.2.1",
+        "uid-number": "^0.0.6"
       }
     },
     "tar-stream": {
@@ -12748,10 +12749,10 @@
       "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "dev": true,
       "requires": {
-        "bl": "1.2.1",
-        "end-of-stream": "1.4.1",
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "bl": "^1.0.0",
+        "end-of-stream": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "template-error": {
@@ -12760,10 +12761,10 @@
       "integrity": "sha1-GMn2ANkPLz37oIM+N/fLb0E1QtQ=",
       "dev": true,
       "requires": {
-        "engine": "0.1.12",
-        "kind-of": "2.0.1",
-        "lazy-cache": "0.2.7",
-        "rethrow": "0.2.3"
+        "engine": "^0.1.5",
+        "kind-of": "^2.0.1",
+        "lazy-cache": "^0.2.3",
+        "rethrow": "^0.2.3"
       },
       "dependencies": {
         "kind-of": {
@@ -12772,7 +12773,7 @@
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.0.2"
           }
         },
         "lazy-cache": {
@@ -12789,27 +12790,27 @@
       "integrity": "sha1-jin24WsFJvfGEmDP+sx57c9QIVs=",
       "dev": true,
       "requires": {
-        "any": "1.0.0",
-        "arr-flatten": "1.1.0",
-        "arr-union": "3.1.0",
-        "center-align": "0.1.3",
-        "export-files": "2.1.1",
-        "fs-exists-sync": "0.1.0",
-        "get-value": "2.0.6",
-        "helper-slugify": "0.2.0",
-        "is-absolute": "0.2.6",
-        "is-number": "2.1.0",
-        "is-plain-object": "2.0.4",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "make-iterator": "0.3.1",
-        "object.omit": "2.0.1",
-        "relative": "3.0.2",
-        "right-align": "0.1.3",
-        "strip-color": "0.1.0",
-        "titlecase": "1.1.2",
-        "to-gfm-code-block": "0.1.1",
-        "word-wrap": "1.2.3"
+        "any": "^1.0.0",
+        "arr-flatten": "^1.0.1",
+        "arr-union": "^3.1.0",
+        "center-align": "^0.1.3",
+        "export-files": "^2.1.1",
+        "fs-exists-sync": "^0.1.0",
+        "get-value": "^2.0.6",
+        "helper-slugify": "^0.2.0",
+        "is-absolute": "^0.2.5",
+        "is-number": "^2.1.0",
+        "is-plain-object": "^2.0.1",
+        "kind-of": "^3.0.3",
+        "lazy-cache": "^2.0.1",
+        "make-iterator": "^0.3.0",
+        "object.omit": "^2.0.0",
+        "relative": "^3.0.2",
+        "right-align": "^0.1.3",
+        "strip-color": "^0.1.0",
+        "titlecase": "^1.1.2",
+        "to-gfm-code-block": "^0.1.1",
+        "word-wrap": "^1.1.0"
       },
       "dependencies": {
         "lazy-cache": {
@@ -12818,7 +12819,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         },
         "make-iterator": {
@@ -12827,7 +12828,7 @@
           "integrity": "sha1-4calMrVGon8TlIoG+CUJsz25gRI=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.1.0"
           }
         }
       }
@@ -12838,39 +12839,39 @@
       "integrity": "sha1-i6uicOGlcnR022hXX4Ic4bT+TQU=",
       "dev": true,
       "requires": {
-        "array-sort": "0.1.4",
-        "async-each": "1.0.1",
-        "base": "0.11.2",
-        "base-data": "0.6.2",
-        "base-engines": "0.2.1",
-        "base-helpers": "0.1.1",
-        "base-option": "0.8.4",
-        "base-plugins": "0.4.13",
-        "base-routes": "0.2.2",
-        "debug": "2.6.9",
-        "deep-bind": "0.3.0",
-        "define-property": "0.2.5",
-        "engine-base": "0.1.3",
-        "export-files": "2.1.1",
-        "extend-shallow": "2.0.1",
-        "falsey": "0.3.2",
-        "get-value": "2.0.6",
-        "get-view": "0.1.3",
-        "group-array": "0.3.3",
-        "has-glob": "0.1.1",
-        "has-value": "0.3.1",
-        "inflection": "1.12.0",
-        "is-valid-app": "0.2.1",
-        "layouts": "0.11.0",
-        "lazy-cache": "2.0.2",
-        "match-file": "0.2.2",
-        "mixin-deep": "1.3.0",
-        "paginationator": "0.1.4",
-        "pascalcase": "0.1.1",
-        "set-value": "0.3.3",
-        "template-error": "0.1.2",
-        "vinyl-item": "0.1.0",
-        "vinyl-view": "0.1.2"
+        "array-sort": "^0.1.2",
+        "async-each": "^1.0.0",
+        "base": "^0.11.1",
+        "base-data": "^0.6.0",
+        "base-engines": "^0.2.0",
+        "base-helpers": "^0.1.1",
+        "base-option": "^0.8.3",
+        "base-plugins": "^0.4.13",
+        "base-routes": "^0.2.1",
+        "debug": "^2.2.0",
+        "deep-bind": "^0.3.0",
+        "define-property": "^0.2.5",
+        "engine-base": "^0.1.2",
+        "export-files": "^2.1.1",
+        "extend-shallow": "^2.0.1",
+        "falsey": "^0.3.0",
+        "get-value": "^2.0.6",
+        "get-view": "^0.1.1",
+        "group-array": "^0.3.0",
+        "has-glob": "^0.1.1",
+        "has-value": "^0.3.1",
+        "inflection": "^1.10.0",
+        "is-valid-app": "^0.2.0",
+        "layouts": "^0.11.0",
+        "lazy-cache": "^2.0.1",
+        "match-file": "^0.2.0",
+        "mixin-deep": "^1.1.3",
+        "paginationator": "^0.1.3",
+        "pascalcase": "^0.1.1",
+        "set-value": "^0.3.3",
+        "template-error": "^0.1.2",
+        "vinyl-item": "^0.1.0",
+        "vinyl-view": "^0.1.2"
       },
       "dependencies": {
         "lazy-cache": {
@@ -12879,7 +12880,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -12890,8 +12891,8 @@
       "integrity": "sha1-6TuGAoorcrhHAIwQAj5ZNbV5mTA=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "log-utils": "0.2.1"
+        "debug": "^2.6.6",
+        "log-utils": "^0.2.1"
       }
     },
     "text-table": {
@@ -12912,8 +12913,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "through2-filter": {
@@ -12922,8 +12923,8 @@
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "dev": true,
       "requires": {
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
+        "through2": "~2.0.0",
+        "xtend": "~4.0.0"
       }
     },
     "time-diff": {
@@ -12932,10 +12933,10 @@
       "integrity": "sha1-Jej7c07qnmy15LA5TwWBC5yHwtg=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-number": "2.1.0",
-        "log-utils": "0.1.5",
-        "pretty-time": "0.2.0"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^2.1.0",
+        "log-utils": "^0.1.0",
+        "pretty-time": "^0.2.0"
       },
       "dependencies": {
         "ansi-colors": {
@@ -12944,33 +12945,33 @@
           "integrity": "sha1-M0rDbNPq1wjeXGnhmpjRhkImtD8=",
           "dev": true,
           "requires": {
-            "ansi-bgblack": "0.1.1",
-            "ansi-bgblue": "0.1.1",
-            "ansi-bgcyan": "0.1.1",
-            "ansi-bggreen": "0.1.1",
-            "ansi-bgmagenta": "0.1.1",
-            "ansi-bgred": "0.1.1",
-            "ansi-bgwhite": "0.1.1",
-            "ansi-bgyellow": "0.1.1",
-            "ansi-black": "0.1.1",
-            "ansi-blue": "0.1.1",
-            "ansi-bold": "0.1.1",
-            "ansi-cyan": "0.1.1",
-            "ansi-dim": "0.1.1",
-            "ansi-gray": "0.1.1",
-            "ansi-green": "0.1.1",
-            "ansi-grey": "0.1.1",
-            "ansi-hidden": "0.1.1",
-            "ansi-inverse": "0.1.1",
-            "ansi-italic": "0.1.1",
-            "ansi-magenta": "0.1.1",
-            "ansi-red": "0.1.1",
-            "ansi-reset": "0.1.1",
-            "ansi-strikethrough": "0.1.1",
-            "ansi-underline": "0.1.1",
-            "ansi-white": "0.1.1",
-            "ansi-yellow": "0.1.1",
-            "lazy-cache": "0.2.7"
+            "ansi-bgblack": "^0.1.1",
+            "ansi-bgblue": "^0.1.1",
+            "ansi-bgcyan": "^0.1.1",
+            "ansi-bggreen": "^0.1.1",
+            "ansi-bgmagenta": "^0.1.1",
+            "ansi-bgred": "^0.1.1",
+            "ansi-bgwhite": "^0.1.1",
+            "ansi-bgyellow": "^0.1.1",
+            "ansi-black": "^0.1.1",
+            "ansi-blue": "^0.1.1",
+            "ansi-bold": "^0.1.1",
+            "ansi-cyan": "^0.1.1",
+            "ansi-dim": "^0.1.1",
+            "ansi-gray": "^0.1.1",
+            "ansi-green": "^0.1.1",
+            "ansi-grey": "^0.1.1",
+            "ansi-hidden": "^0.1.1",
+            "ansi-inverse": "^0.1.1",
+            "ansi-italic": "^0.1.1",
+            "ansi-magenta": "^0.1.1",
+            "ansi-red": "^0.1.1",
+            "ansi-reset": "^0.1.1",
+            "ansi-strikethrough": "^0.1.1",
+            "ansi-underline": "^0.1.1",
+            "ansi-white": "^0.1.1",
+            "ansi-yellow": "^0.1.1",
+            "lazy-cache": "^0.2.4"
           }
         },
         "lazy-cache": {
@@ -12985,13 +12986,13 @@
           "integrity": "sha1-3g84+Vf0zW69Xctoddijua4HT3c=",
           "dev": true,
           "requires": {
-            "ansi-colors": "0.1.0",
-            "error-symbol": "0.1.0",
-            "info-symbol": "0.1.0",
-            "log-ok": "0.1.1",
-            "success-symbol": "0.1.0",
-            "time-stamp": "1.1.0",
-            "warning-symbol": "0.1.0"
+            "ansi-colors": "^0.1.0",
+            "error-symbol": "^0.1.0",
+            "info-symbol": "^0.1.0",
+            "log-ok": "^0.1.1",
+            "success-symbol": "^0.1.0",
+            "time-stamp": "^1.0.1",
+            "warning-symbol": "^0.1.0"
           }
         }
       }
@@ -13014,7 +13015,7 @@
       "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
       "dev": true,
       "requires": {
-        "setimmediate": "1.0.5"
+        "setimmediate": "^1.0.4"
       }
     },
     "titlecase": {
@@ -13029,7 +13030,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-absolute-glob": {
@@ -13038,7 +13039,7 @@
       "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1"
+        "extend-shallow": "^2.0.1"
       }
     },
     "to-arraybuffer": {
@@ -13053,8 +13054,8 @@
       "integrity": "sha1-IufnWgfWl9fkzsvVaxvwPBVlTXM=",
       "dev": true,
       "requires": {
-        "ansi-gray": "0.1.1",
-        "mixin-deep": "1.3.0"
+        "ansi-gray": "^0.1.1",
+        "mixin-deep": "^1.1.3"
       }
     },
     "to-fast-properties": {
@@ -13069,14 +13070,14 @@
       "integrity": "sha1-I2xsCIBl5XDe+9Fc9LTlZb5G6pM=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "file-contents": "0.2.4",
-        "glob-parent": "2.0.0",
-        "is-valid-glob": "0.3.0",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
-        "vinyl": "1.2.0"
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "file-contents": "^0.2.4",
+        "glob-parent": "^2.0.0",
+        "is-valid-glob": "^0.3.0",
+        "isobject": "^2.1.0",
+        "lazy-cache": "^2.0.1",
+        "vinyl": "^1.1.1"
       },
       "dependencies": {
         "lazy-cache": {
@@ -13085,7 +13086,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -13108,7 +13109,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "to-regex": {
@@ -13117,10 +13118,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "regex-not": "1.0.2",
-        "safe-regex": "1.1.0"
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -13129,8 +13130,8 @@
           "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2",
-            "isobject": "3.0.1"
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
           }
         },
         "extend-shallow": {
@@ -13139,8 +13140,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           }
         },
         "is-accessor-descriptor": {
@@ -13149,7 +13150,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -13158,7 +13159,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -13167,9 +13168,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "is-extendable": {
@@ -13178,7 +13179,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         },
         "isobject": {
@@ -13201,8 +13202,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       },
       "dependencies": {
         "is-number": {
@@ -13211,7 +13212,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         }
       }
@@ -13222,7 +13223,7 @@
       "integrity": "sha1-MFwEaxt7G40dA5jQvrT+mhnxNPs=",
       "dev": true,
       "requires": {
-        "isobject": "2.1.0"
+        "isobject": "^2.1.0"
       }
     },
     "tough-cookie": {
@@ -13230,7 +13231,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "trim-leading-lines": {
@@ -13239,7 +13240,7 @@
       "integrity": "sha1-DnysPoMELc+Vp07TaWbxd0TVwWk=",
       "dev": true,
       "requires": {
-        "is-whitespace": "0.3.0"
+        "is-whitespace": "^0.3.0"
       }
     },
     "trim-newlines": {
@@ -13254,7 +13255,7 @@
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.2"
       }
     },
     "trim-right": {
@@ -13274,7 +13275,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -13289,7 +13290,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -13311,9 +13312,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       }
     },
     "uglify-to-browserify": {
@@ -13328,14 +13329,14 @@
       "integrity": "sha512-hIQJ1yxAPhEA2yW/i7Fr+SXZVMp+VEI3d42RTHBgQd2yhp/1UdBcR3QEWPV5ahBxlqQDMEMTuTEvDHSFINfwSw==",
       "dev": true,
       "requires": {
-        "cacache": "10.0.4",
-        "find-cache-dir": "1.0.0",
-        "schema-utils": "0.4.5",
-        "serialize-javascript": "1.5.0",
-        "source-map": "0.6.1",
-        "uglify-es": "3.3.9",
-        "webpack-sources": "1.1.0",
-        "worker-farm": "1.6.0"
+        "cacache": "^10.0.4",
+        "find-cache-dir": "^1.0.0",
+        "schema-utils": "^0.4.5",
+        "serialize-javascript": "^1.4.0",
+        "source-map": "^0.6.1",
+        "uglify-es": "^3.3.4",
+        "webpack-sources": "^1.1.0",
+        "worker-farm": "^1.5.2"
       },
       "dependencies": {
         "commander": {
@@ -13356,8 +13357,8 @@
           "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
           "dev": true,
           "requires": {
-            "commander": "2.13.0",
-            "source-map": "0.6.1"
+            "commander": "~2.13.0",
+            "source-map": "~0.6.1"
           }
         }
       }
@@ -13381,8 +13382,8 @@
       "integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
       "dev": true,
       "requires": {
-        "buffer": "3.6.0",
-        "through": "2.3.8"
+        "buffer": "^3.0.1",
+        "through": "^2.3.6"
       }
     },
     "unc-path-regex": {
@@ -13403,7 +13404,7 @@
       "integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
       "dev": true,
       "requires": {
-        "qs": "2.3.3"
+        "qs": "~2.3.3"
       }
     },
     "union-value": {
@@ -13412,10 +13413,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
       },
       "dependencies": {
         "set-value": {
@@ -13424,10 +13425,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
@@ -13438,7 +13439,7 @@
       "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
       "dev": true,
       "requires": {
-        "unique-slug": "2.0.0"
+        "unique-slug": "^2.0.0"
       }
     },
     "unique-slug": {
@@ -13447,7 +13448,7 @@
       "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
       "dev": true,
       "requires": {
-        "imurmurhash": "0.1.4"
+        "imurmurhash": "^0.1.4"
       }
     },
     "unique-stream": {
@@ -13456,8 +13457,8 @@
       "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
       "dev": true,
       "requires": {
-        "json-stable-stringify": "1.0.1",
-        "through2-filter": "2.0.0"
+        "json-stable-stringify": "^1.0.0",
+        "through2-filter": "^2.0.0"
       }
     },
     "unset-value": {
@@ -13466,8 +13467,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -13490,35 +13491,35 @@
       "integrity": "sha1-saCRwRo+KK4xui7vWLcRuCzpixQ=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "assemble-core": "0.25.0",
-        "assemble-loader": "0.6.1",
-        "base-cli-process": "0.1.19",
-        "base-config-process": "0.1.9",
-        "base-generators": "0.4.6",
-        "base-questions": "0.7.4",
-        "base-runtimes": "0.2.0",
-        "base-store": "0.4.4",
-        "common-config": "0.1.0",
-        "data-store": "0.16.1",
-        "export-files": "2.1.1",
-        "extend-shallow": "2.0.1",
-        "find-pkg": "0.1.2",
-        "fs-exists-sync": "0.1.0",
-        "global-modules": "0.2.3",
-        "gulp-choose-files": "0.1.3",
-        "is-valid-app": "0.2.1",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
-        "log-utils": "0.2.1",
-        "parser-front-matter": "1.6.4",
-        "resolve-dir": "0.1.1",
-        "resolve-file": "0.2.2",
-        "set-blocking": "2.0.0",
-        "strip-color": "0.1.0",
-        "text-table": "0.2.0",
-        "through2": "2.0.3",
-        "yargs-parser": "2.4.1"
+        "arr-union": "^3.1.0",
+        "assemble-core": "^0.25.0",
+        "assemble-loader": "^0.6.1",
+        "base-cli-process": "^0.1.18",
+        "base-config-process": "^0.1.9",
+        "base-generators": "^0.4.5",
+        "base-questions": "^0.7.3",
+        "base-runtimes": "^0.2.0",
+        "base-store": "^0.4.4",
+        "common-config": "^0.1.0",
+        "data-store": "^0.16.1",
+        "export-files": "^2.1.1",
+        "extend-shallow": "^2.0.1",
+        "find-pkg": "^0.1.2",
+        "fs-exists-sync": "^0.1.0",
+        "global-modules": "^0.2.2",
+        "gulp-choose-files": "^0.1.3",
+        "is-valid-app": "^0.2.0",
+        "isobject": "^2.1.0",
+        "lazy-cache": "^2.0.1",
+        "log-utils": "^0.2.1",
+        "parser-front-matter": "^1.4.1",
+        "resolve-dir": "^0.1.0",
+        "resolve-file": "^0.2.0",
+        "set-blocking": "^2.0.0",
+        "strip-color": "^0.1.0",
+        "text-table": "^0.2.0",
+        "through2": "^2.0.1",
+        "yargs-parser": "^2.4.1"
       },
       "dependencies": {
         "lazy-cache": {
@@ -13527,7 +13528,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -13538,17 +13539,17 @@
       "integrity": "sha512-SzvJi0kl+CtcvY9XeESpAKbvwqcJXjW6kX1zjyQeAdng0yPyjZsU4JW+7le5mTQ7Orl/c5ANAVFFqael9abamQ==",
       "dev": true,
       "requires": {
-        "engine": "0.1.12",
-        "isobject": "3.0.1",
-        "lazy-cache": "2.0.2",
-        "leven": "2.1.0",
-        "load-pkg": "3.0.1",
-        "mixin-deep": "1.3.0",
-        "omit-empty": "0.4.1",
-        "parse-author": "2.0.0",
-        "parse-copyright": "0.4.0",
-        "update-year": "0.5.2",
-        "year": "0.2.1"
+        "engine": "^0.1.12",
+        "isobject": "^3.0.0",
+        "lazy-cache": "^2.0.2",
+        "leven": "^2.1.0",
+        "load-pkg": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "omit-empty": "^0.4.1",
+        "parse-author": "^2.0.0",
+        "parse-copyright": "^0.4.0",
+        "update-year": "^0.5.2",
+        "year": "^0.2.1"
       },
       "dependencies": {
         "isobject": {
@@ -13563,7 +13564,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         },
         "parse-author": {
@@ -13572,7 +13573,7 @@
           "integrity": "sha1-00YL8d3Q367tQtp1QkLmX7aEqB8=",
           "dev": true,
           "requires": {
-            "author-regex": "1.0.0"
+            "author-regex": "^1.0.0"
           }
         }
       }
@@ -13583,8 +13584,8 @@
       "integrity": "sha1-tFvD4glgvUax6uJuw3EubARJ+uE=",
       "dev": true,
       "requires": {
-        "array-unique": "0.2.1",
-        "year": "0.2.1"
+        "array-unique": "^0.2.1",
+        "year": "^0.2.1"
       }
     },
     "updater-license": {
@@ -13593,18 +13594,18 @@
       "integrity": "sha512-xwTZViaWqdXIcc4/C1KZ6bNyE0CHFsed65NdBi0WWdyav2pbw4cdANxDJv0p32cRx/z7/ncjeiOeWSLOJ+AT4A==",
       "dev": true,
       "requires": {
-        "delete": "1.1.0",
-        "engine": "0.1.12",
-        "extend-shallow": "2.0.1",
-        "generate-license": "0.6.1",
-        "helper-ask": "0.2.1",
-        "is-valid-app": "0.3.0",
-        "lazy-cache": "2.0.2",
-        "parse-copyright": "0.4.0",
-        "parser-front-matter": "1.6.4",
-        "through2": "2.0.3",
-        "update-copyright": "1.0.0",
-        "year": "0.2.1"
+        "delete": "^1.0.1",
+        "engine": "^0.1.12",
+        "extend-shallow": "^2.0.1",
+        "generate-license": "^0.6.1",
+        "helper-ask": "^0.2.1",
+        "is-valid-app": "^0.3.0",
+        "lazy-cache": "^2.0.2",
+        "parse-copyright": "^0.4.0",
+        "parser-front-matter": "^1.6.3",
+        "through2": "^2.0.3",
+        "update-copyright": "^1.0.0",
+        "year": "^0.2.1"
       },
       "dependencies": {
         "is-valid-app": {
@@ -13613,10 +13614,10 @@
           "integrity": "sha1-eBBrdR88oyOF+0VJK/KUF7WZPIA=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "is-registered": "0.1.5",
-            "is-valid-instance": "0.3.0",
-            "lazy-cache": "2.0.2"
+            "debug": "^2.6.3",
+            "is-registered": "^0.1.5",
+            "is-valid-instance": "^0.3.0",
+            "lazy-cache": "^2.0.2"
           }
         },
         "is-valid-instance": {
@@ -13625,8 +13626,8 @@
           "integrity": "sha1-9KxzAjxNTYubw7PsPmZjBRbijp4=",
           "dev": true,
           "requires": {
-            "isobject": "3.0.1",
-            "pascalcase": "0.1.1"
+            "isobject": "^3.0.0",
+            "pascalcase": "^0.1.1"
           }
         },
         "isobject": {
@@ -13641,7 +13642,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -13658,7 +13659,7 @@
       "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
       "dev": true,
       "requires": {
-        "punycode": "2.1.0"
+        "punycode": "^2.1.0"
       },
       "dependencies": {
         "punycode": {
@@ -13705,7 +13706,7 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
-        "prepend-http": "1.0.4"
+        "prepend-http": "^1.0.1"
       }
     },
     "url-to-options": {
@@ -13720,8 +13721,8 @@
       "integrity": "sha1-bjgy/rholXNJSsanrLX++zd7LNE=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "isobject": "2.1.0"
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0"
       }
     },
     "util": {
@@ -13764,8 +13765,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "verror": {
@@ -13773,9 +13774,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vinyl": {
@@ -13784,8 +13785,8 @@
       "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
       "dev": true,
       "requires": {
-        "clone": "1.0.3",
-        "clone-stats": "0.0.1",
+        "clone": "^1.0.0",
+        "clone-stats": "^0.0.1",
         "replace-ext": "0.0.1"
       }
     },
@@ -13795,23 +13796,23 @@
       "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
       "dev": true,
       "requires": {
-        "duplexify": "3.5.3",
-        "glob-stream": "5.3.5",
-        "graceful-fs": "4.1.11",
+        "duplexify": "^3.2.0",
+        "glob-stream": "^5.3.2",
+        "graceful-fs": "^4.0.0",
         "gulp-sourcemaps": "1.6.0",
-        "is-valid-glob": "0.3.0",
-        "lazystream": "1.0.0",
-        "lodash.isequal": "4.5.0",
-        "merge-stream": "1.0.1",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1",
-        "readable-stream": "2.3.3",
-        "strip-bom": "2.0.0",
-        "strip-bom-stream": "1.0.0",
-        "through2": "2.0.3",
-        "through2-filter": "2.0.0",
-        "vali-date": "1.0.0",
-        "vinyl": "1.2.0"
+        "is-valid-glob": "^0.3.0",
+        "lazystream": "^1.0.0",
+        "lodash.isequal": "^4.0.0",
+        "merge-stream": "^1.0.0",
+        "mkdirp": "^0.5.0",
+        "object-assign": "^4.0.0",
+        "readable-stream": "^2.0.4",
+        "strip-bom": "^2.0.0",
+        "strip-bom-stream": "^1.0.0",
+        "through2": "^2.0.0",
+        "through2-filter": "^2.0.0",
+        "vali-date": "^1.0.0",
+        "vinyl": "^1.0.0"
       }
     },
     "vinyl-item": {
@@ -13820,16 +13821,16 @@
       "integrity": "sha1-8ngTyBFC66ScpYSd5PQvb6Dl4Jg=",
       "dev": true,
       "requires": {
-        "base": "0.8.1",
-        "base-option": "0.8.4",
-        "base-plugins": "0.4.13",
-        "clone": "1.0.3",
-        "clone-stats": "1.0.0",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
-        "vinyl": "1.2.0"
+        "base": "^0.8.1",
+        "base-option": "^0.8.2",
+        "base-plugins": "^0.4.12",
+        "clone": "^1.0.2",
+        "clone-stats": "^1.0.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "isobject": "^2.1.0",
+        "lazy-cache": "^2.0.1",
+        "vinyl": "^1.1.1"
       },
       "dependencies": {
         "base": {
@@ -13838,14 +13839,14 @@
           "integrity": "sha1-aQC7MA8sdZbJnz2DurhyLYGLdI8=",
           "dev": true,
           "requires": {
-            "arr-union": "3.1.0",
-            "cache-base": "0.8.5",
-            "class-utils": "0.3.6",
-            "component-emitter": "1.2.1",
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "lazy-cache": "1.0.4",
-            "mixin-deep": "1.3.0"
+            "arr-union": "^3.1.0",
+            "cache-base": "^0.8.2",
+            "class-utils": "^0.3.2",
+            "component-emitter": "^1.2.0",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "lazy-cache": "^1.0.3",
+            "mixin-deep": "^1.1.3"
           },
           "dependencies": {
             "lazy-cache": {
@@ -13862,16 +13863,16 @@
           "integrity": "sha1-YM6zUEAh7O7HAR/TOEt/TpVym/o=",
           "dev": true,
           "requires": {
-            "collection-visit": "0.2.3",
-            "component-emitter": "1.2.1",
-            "get-value": "2.0.6",
-            "has-value": "0.3.1",
-            "isobject": "3.0.1",
-            "lazy-cache": "2.0.2",
-            "set-value": "0.4.3",
-            "to-object-path": "0.3.0",
-            "union-value": "0.2.4",
-            "unset-value": "0.1.2"
+            "collection-visit": "^0.2.1",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.5",
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0",
+            "lazy-cache": "^2.0.1",
+            "set-value": "^0.4.2",
+            "to-object-path": "^0.3.0",
+            "union-value": "^0.2.3",
+            "unset-value": "^0.1.1"
           },
           "dependencies": {
             "isobject": {
@@ -13894,9 +13895,9 @@
           "integrity": "sha1-L2JIPK7MlfCDuaRUo+6eYTmteVc=",
           "dev": true,
           "requires": {
-            "lazy-cache": "2.0.2",
-            "map-visit": "0.1.5",
-            "object-visit": "0.3.4"
+            "lazy-cache": "^2.0.1",
+            "map-visit": "^0.1.5",
+            "object-visit": "^0.3.4"
           }
         },
         "lazy-cache": {
@@ -13905,7 +13906,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         },
         "map-visit": {
@@ -13914,8 +13915,8 @@
           "integrity": "sha1-2+Q5J85VJbgN/BVzpE1oxR8mgWs=",
           "dev": true,
           "requires": {
-            "lazy-cache": "2.0.2",
-            "object-visit": "0.3.4"
+            "lazy-cache": "^2.0.1",
+            "object-visit": "^0.3.4"
           }
         },
         "object-visit": {
@@ -13924,7 +13925,7 @@
           "integrity": "sha1-rhXPhvCy/dVRdxY2RIRSxUw9qCk=",
           "dev": true,
           "requires": {
-            "isobject": "2.1.0"
+            "isobject": "^2.0.0"
           }
         },
         "set-value": {
@@ -13933,10 +13934,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         },
         "union-value": {
@@ -13945,10 +13946,10 @@
           "integrity": "sha1-c3UVJ4ZnkFfns3qmdug0aPwCdPA=",
           "dev": true,
           "requires": {
-            "arr-union": "3.1.0",
-            "get-value": "2.0.6",
-            "is-extendable": "0.1.1",
-            "set-value": "0.4.3"
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
           }
         },
         "unset-value": {
@@ -13957,8 +13958,8 @@
           "integrity": "sha1-UGgQuGfyfCpabpsEgzYx9t5Y0xA=",
           "dev": true,
           "requires": {
-            "has-value": "0.3.1",
-            "isobject": "3.0.1"
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -13977,13 +13978,13 @@
       "integrity": "sha1-CaxtfIASEr8JJr2dQQb0XmxPyXc=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "engine-base": "0.1.3",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
-        "mixin-deep": "1.3.0",
-        "vinyl-item": "0.1.0"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "engine-base": "^0.1.2",
+        "isobject": "^2.1.0",
+        "lazy-cache": "^2.0.1",
+        "mixin-deep": "^1.1.3",
+        "vinyl-item": "^0.1.0"
       },
       "dependencies": {
         "lazy-cache": {
@@ -13992,7 +13993,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         }
       }
@@ -14024,9 +14025,9 @@
       "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
       "dev": true,
       "requires": {
-        "chokidar": "2.0.3",
-        "graceful-fs": "4.1.11",
-        "neo-async": "2.5.1"
+        "chokidar": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "neo-async": "^2.5.0"
       },
       "dependencies": {
         "anymatch": {
@@ -14035,8 +14036,8 @@
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "dev": true,
           "requires": {
-            "micromatch": "3.1.10",
-            "normalize-path": "2.1.1"
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
           }
         },
         "arr-diff": {
@@ -14057,16 +14058,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.2",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -14075,7 +14076,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -14086,18 +14087,18 @@
           "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
           "dev": true,
           "requires": {
-            "anymatch": "2.0.0",
-            "async-each": "1.0.1",
-            "braces": "2.3.2",
-            "fsevents": "1.1.3",
-            "glob-parent": "3.1.0",
-            "inherits": "2.0.3",
-            "is-binary-path": "1.0.1",
-            "is-glob": "4.0.0",
-            "normalize-path": "2.1.1",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.1.0",
-            "upath": "1.0.5"
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.0",
+            "braces": "^2.3.0",
+            "fsevents": "^1.1.2",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^2.1.1",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0",
+            "upath": "^1.0.0"
           }
         },
         "define-property": {
@@ -14106,8 +14107,8 @@
           "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2",
-            "isobject": "3.0.1"
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
           }
         },
         "expand-brackets": {
@@ -14116,13 +14117,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -14131,7 +14132,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
@@ -14140,7 +14141,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
@@ -14149,7 +14150,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -14158,7 +14159,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -14169,7 +14170,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -14178,7 +14179,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -14189,9 +14190,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               }
             },
             "kind-of": {
@@ -14208,8 +14209,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -14218,7 +14219,7 @@
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "dev": true,
               "requires": {
-                "is-plain-object": "2.0.4"
+                "is-plain-object": "^2.0.4"
               }
             }
           }
@@ -14229,14 +14230,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -14245,7 +14246,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "extend-shallow": {
@@ -14254,7 +14255,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -14265,10 +14266,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
           },
           "dependencies": {
             "extend-shallow": {
@@ -14277,7 +14278,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -14288,8 +14289,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
           },
           "dependencies": {
             "is-glob": {
@@ -14298,7 +14299,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
               }
             }
           }
@@ -14309,7 +14310,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -14318,7 +14319,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -14327,9 +14328,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "is-extglob": {
@@ -14344,7 +14345,7 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.1"
           }
         },
         "is-number": {
@@ -14353,7 +14354,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -14362,7 +14363,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -14385,19 +14386,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
           }
         }
       }
@@ -14408,25 +14409,25 @@
       "integrity": "sha512-OXOAip9mjy0ahFYCXu6LLNzTiIQzd2UOHkNHANc/dyxf8CYCgcJ5UKsTXfbfeJb4tqkKb6B1FIQ9Xtl6gftb8Q==",
       "dev": true,
       "requires": {
-        "acorn": "5.3.0",
-        "acorn-dynamic-import": "3.0.0",
-        "ajv": "6.4.0",
-        "ajv-keywords": "3.2.0",
-        "chrome-trace-event": "0.1.3",
-        "enhanced-resolve": "4.0.0",
-        "eslint-scope": "3.7.1",
-        "loader-runner": "2.3.0",
-        "loader-utils": "1.1.0",
-        "memory-fs": "0.4.1",
-        "micromatch": "3.1.10",
-        "mkdirp": "0.5.1",
-        "neo-async": "2.5.1",
-        "node-libs-browser": "2.1.0",
-        "schema-utils": "0.4.5",
-        "tapable": "1.0.0",
-        "uglifyjs-webpack-plugin": "1.2.5",
-        "watchpack": "1.6.0",
-        "webpack-sources": "1.1.0"
+        "acorn": "^5.0.0",
+        "acorn-dynamic-import": "^3.0.0",
+        "ajv": "^6.1.0",
+        "ajv-keywords": "^3.1.0",
+        "chrome-trace-event": "^0.1.1",
+        "enhanced-resolve": "^4.0.0",
+        "eslint-scope": "^3.7.1",
+        "loader-runner": "^2.3.0",
+        "loader-utils": "^1.1.0",
+        "memory-fs": "~0.4.1",
+        "micromatch": "^3.1.8",
+        "mkdirp": "~0.5.0",
+        "neo-async": "^2.5.0",
+        "node-libs-browser": "^2.0.0",
+        "schema-utils": "^0.4.4",
+        "tapable": "^1.0.0",
+        "uglifyjs-webpack-plugin": "^1.2.4",
+        "watchpack": "^1.5.0",
+        "webpack-sources": "^1.0.1"
       },
       "dependencies": {
         "ajv": {
@@ -14435,10 +14436,10 @@
           "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1",
-            "uri-js": "3.0.2"
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0",
+            "uri-js": "^3.0.2"
           }
         },
         "ajv-keywords": {
@@ -14465,16 +14466,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.2",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -14483,7 +14484,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -14494,8 +14495,8 @@
           "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2",
-            "isobject": "3.0.1"
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
           }
         },
         "expand-brackets": {
@@ -14504,13 +14505,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -14519,7 +14520,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
@@ -14528,7 +14529,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
@@ -14537,7 +14538,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -14546,7 +14547,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -14557,7 +14558,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -14566,7 +14567,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -14577,9 +14578,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               }
             },
             "kind-of": {
@@ -14596,8 +14597,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -14606,7 +14607,7 @@
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "dev": true,
               "requires": {
-                "is-plain-object": "2.0.4"
+                "is-plain-object": "^2.0.4"
               }
             }
           }
@@ -14617,14 +14618,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -14633,7 +14634,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "extend-shallow": {
@@ -14642,7 +14643,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -14653,10 +14654,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
           },
           "dependencies": {
             "extend-shallow": {
@@ -14665,7 +14666,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -14676,7 +14677,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -14685,7 +14686,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -14694,9 +14695,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "is-number": {
@@ -14705,7 +14706,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -14714,7 +14715,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -14737,19 +14738,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
           }
         }
       }
@@ -14760,8 +14761,8 @@
       "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
       "dev": true,
       "requires": {
-        "source-list-map": "2.0.0",
-        "source-map": "0.6.1"
+        "source-list-map": "^2.0.0",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -14778,7 +14779,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "wide-align": {
@@ -14788,7 +14789,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -14798,7 +14799,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -14808,9 +14809,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -14839,7 +14840,7 @@
       "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
       "dev": true,
       "requires": {
-        "errno": "0.1.7"
+        "errno": "~0.1.7"
       }
     },
     "wrappy": {
@@ -14853,7 +14854,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "write-json": {
@@ -14862,7 +14863,7 @@
       "integrity": "sha1-+k4VKennY6T5LwfZhBMX49JI2vM=",
       "dev": true,
       "requires": {
-        "write": "0.2.1"
+        "write": "^0.2.1"
       }
     },
     "ws": {
@@ -14871,8 +14872,8 @@
       "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
       "dev": true,
       "requires": {
-        "options": "0.0.6",
-        "ultron": "1.0.2"
+        "options": ">=0.0.5",
+        "ultron": "1.0.x"
       }
     },
     "xtend": {
@@ -14900,9 +14901,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       },
       "dependencies": {
@@ -14921,8 +14922,8 @@
       "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
       "dev": true,
       "requires": {
-        "camelcase": "3.0.0",
-        "lodash.assign": "4.2.0"
+        "camelcase": "^3.0.0",
+        "lodash.assign": "^4.0.6"
       },
       "dependencies": {
         "camelcase": {
@@ -14939,8 +14940,8 @@
       "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "0.2.13",
-        "fd-slicer": "1.0.1"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.0.1"
       }
     },
     "year": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -59,7 +59,6 @@ const configs = [
       commonjs({ include: '**/node_modules/**' }),
       BABEL ? babel(getBabelOptions()) : {},
       replace(envVariables),
-      !FILE ? sizeSnapshot() : {},
       uglify({
         compress: {
           warnings: false,


### PR DESCRIPTION
Since both `umd` and `min` bundles are identical there is not reason to
make a snapshot of them both.