### PR TITLE
Fail on CI if size snapshot is not updated

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "build/cytoscape.umd.js": {
-    "bundled": 854989,
-    "minified": 317897,
-    "gzipped": 98067
+    "bundled": 853764,
+    "minified": 317482,
+    "gzipped": 98094
   },
   "build/cytoscape.cjs.js": {
-    "bundled": 787562,
-    "minified": 331520,
-    "gzipped": 99471
+    "bundled": 786403,
+    "minified": 331098,
+    "gzipped": 99517
   },
   "build/cytoscape.esm.js": {
-    "bundled": 787389,
-    "minified": 331387,
-    "gzipped": 99432,
+    "bundled": 786230,
+    "minified": 330965,
+    "gzipped": 99480,
     "treeshaked": {
-      "rollup": 311743,
-      "webpack": 313997
+      "rollup": 311328,
+      "webpack": 313582
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "watch:build:umd": "cross-env FILE=umd SOURCEMAPS=true NODE_ENV=development rollup -c -w",
     "test": "mocha -r esm",
     "test:build": "cross-env TEST_BUILD=true mocha -r esm",
-    "test:travis": "run-s build test:build lint",
+    "test:travis": "cross-env SNAPSHOT=match run-s build test:build lint",
     "sniper": "sniper .",
     "docs": "run-s docs:build docs:js",
     "docs:js": "cpy build/cytoscape.min.js documentation/js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,6 +10,7 @@ const FILE = process.env.FILE;
 const SOURCEMAPS = process.env.SOURCEMAPS === 'true'; // default false
 const BABEL = process.env.BABEL !== 'false'; // default true
 const NODE_ENV = process.env.NODE_ENV === 'development' ? 'development' : 'production'; // default prod
+const matchSnapshot = process.env.SNAPSHOT === 'match';
 
 const input = './src/index.js';
 
@@ -43,7 +44,7 @@ const configs = [
       commonjs({ include: '**/node_modules/**' }),
       BABEL ? babel(getBabelOptions()) : {},
       replace(envVariables),
-      !FILE ? sizeSnapshot() : {}
+      !FILE ? sizeSnapshot({ matchSnapshot }) : {}
     ]
   },
 
@@ -76,7 +77,7 @@ const configs = [
       nodeResolve(),
       BABEL ? babel(getBabelOptions()) : {},
       replace(envVariables),
-      !FILE ? sizeSnapshot() : {}
+      !FILE ? sizeSnapshot({ matchSnapshot }) : {}
     ]
   },
 
@@ -88,7 +89,7 @@ const configs = [
       nodeResolve(),
       BABEL ? babel(getBabelOptions()) : {},
       replace(envVariables),
-      !FILE ? sizeSnapshot() : {}
+      !FILE ? sizeSnapshot({ matchSnapshot }) : {}
     ]
   }
 ];


### PR DESCRIPTION
Sometimes it's easy to forget to run build and commit snapshot. This
leads to unobjective differences in snapshots in further commits.

`matchSnapshot` option allows to fail if existing commit and generating
one are not matched. This is useful to fail on CI.