### PR TITLE
Feature/ignore hidden nodes during layout process

### DIFF
--- a/src/extensions/layout/breadthfirst.js
+++ b/src/extensions/layout/breadthfirst.js
@@ -23,7 +23,8 @@ const defaults = {
   animateFilter: function ( node, i ){ return true; }, // a function that determines whether the node should be animated.  All nodes animated by default on animate enabled.  Non-animated nodes are positioned immediately when the layout starts
   ready: undefined, // callback on layoutready
   stop: undefined, // callback on layoutstop
-  transform: function (node, position ){ return position; } // transform a given node position. Useful for changing flow direction in discrete layouts
+  transform: function (node, position ){ return position; }, // transform a given node position. Useful for changing flow direction in discrete layouts
+  ignoreHiddenElements: false // if true, it will only layout visible nodes
 };
 /* eslint-enable */
 
@@ -38,6 +39,11 @@ BreadthFirstLayout.prototype.run = function(){
   let cy = params.cy;
   let eles = options.eles;
   let nodes = eles.nodes().filter( n => !n.isParent() );
+
+  if(options.ignoreHiddenElements){
+    nodes = nodes.not(':hidden');
+  }
+
   let graph = eles;
 
   let bb = math.makeBoundingBox( options.boundingBox ? options.boundingBox : {

--- a/src/extensions/layout/circle.js
+++ b/src/extensions/layout/circle.js
@@ -20,8 +20,8 @@ let defaults = {
   animateFilter: function ( node, i ){ return true; }, // a function that determines whether the node should be animated.  All nodes animated by default on animate enabled.  Non-animated nodes are positioned immediately when the layout starts
   ready: undefined, // callback on layoutready
   stop: undefined, // callback on layoutstop
-  transform: function (node, position ){ return position; } // transform a given node position. Useful for changing flow direction in discrete layouts 
-
+  transform: function (node, position ){ return position; }, // transform a given node position. Useful for changing flow direction in discrete layouts
+  ignoreHiddenElements: false // if true, it will only layout visible nodes
 };
 
 function CircleLayout( options ){
@@ -38,6 +38,10 @@ CircleLayout.prototype.run = function(){
   let clockwise = options.counterclockwise !== undefined ? !options.counterclockwise : options.clockwise;
 
   let nodes = eles.nodes().not( ':parent' );
+
+  if(options.ignoreHiddenElements){
+    nodes = nodes.not(':hidden');
+  }
 
   if( options.sort ){
     nodes = nodes.sort( options.sort );

--- a/src/extensions/layout/concentric.js
+++ b/src/extensions/layout/concentric.js
@@ -27,7 +27,9 @@ let defaults = {
   animateFilter: function ( node, i ){ return true; }, // a function that determines whether the node should be animated.  All nodes animated by default on animate enabled.  Non-animated nodes are positioned immediately when the layout starts
   ready: undefined, // callback on layoutready
   stop: undefined, // callback on layoutstop
-  transform: function (node, position ){ return position; } // transform a given node position. Useful for changing flow direction in discrete layouts
+  transform: function (node, position ){ return position; }, // transform a given node position. Useful for changing flow direction in discrete layouts
+  sort: undefined, // a sorting function to order the nodes; e.g. function(a, b){ return a.data('weight') - b.data('weight') }
+  ignoreHiddenElements: false // if true, it will only layout visible nodes
 };
 
 function ConcentricLayout( options ){
@@ -44,6 +46,14 @@ ConcentricLayout.prototype.run = function(){
 
   let eles = options.eles;
   let nodes = eles.nodes().not( ':parent' );
+
+  if(options.ignoreHiddenElements){
+    nodes = nodes.not(':hidden');
+  }
+
+  if( options.sort ){
+    nodes = nodes.sort( options.sort );
+  }
 
   let bb = math.makeBoundingBox( options.boundingBox ? options.boundingBox : {
     x1: 0, y1: 0, w: cy.width(), h: cy.height()

--- a/src/extensions/layout/grid.js
+++ b/src/extensions/layout/grid.js
@@ -20,7 +20,8 @@ let defaults = {
   animateFilter: function ( node, i ){ return true; }, // a function that determines whether the node should be animated.  All nodes animated by default on animate enabled.  Non-animated nodes are positioned immediately when the layout starts
   ready: undefined, // callback on layoutready
   stop: undefined, // callback on layoutstop
-  transform: function (node, position ){ return position; } // transform a given node position. Useful for changing flow direction in discrete layouts 
+  transform: function (node, position ){ return position; }, // transform a given node position. Useful for changing flow direction in discrete layouts
+  ignoreHiddenElements: false // if true, it will only layout visible nodes
 };
 
 function GridLayout( options ){
@@ -34,6 +35,10 @@ GridLayout.prototype.run = function(){
   let cy = params.cy;
   let eles = options.eles;
   let nodes = eles.nodes().not( ':parent' );
+
+  if(options.ignoreHiddenElements){
+    nodes = nodes.not(':hidden');
+  }
 
   if( options.sort ){
     nodes = nodes.sort( options.sort );


### PR DESCRIPTION
Hi all,
_this is my first time contributing to anything, so tell me if I am doing anything wrong.
I tried to follow your guide http://blog.js.cytoscape.org/2017/06/13/contributing/ as close as possible._

This change adds the option to only layout the visible elements in a graph.
For my use, I have to make nodes invisible in certain situation, and re-layout the graph, therefore I have holes in the circle, which look wierd.

I simply added an option to the code, and if it is set to true, it will filter out the hidden nodes before the rest of the layout process calculates the positions.

To maintain compatibility, I set this option to false by default.

