### PR TITLE
Optimizations for mapped style properties

### DIFF
--- a/src/style/apply.js
+++ b/src/style/apply.js
@@ -578,7 +578,7 @@ styfn.applyParsedProperty = function( ele, parsedProp ){
 
   case types.fn: {
     let fn = prop.value;
-    let fnRetVal = fn( ele );
+    let fnRetVal = prop.fnValue || fn( ele ); // check for cached value before calling function
 
     if( fnRetVal == null ){
       util.warn('Custom function mappers may not return null (i.e. `' + prop.name + '` for ele `' + ele.id() + '` is null)');

--- a/src/style/apply.js
+++ b/src/style/apply.js
@@ -74,7 +74,7 @@ styfn.getPropertiesDiff = function( oldCxtKey, newCxtKey ){
     let cxtHasDiffed = oldHasCxt !== newHasCxt;
     let cxtHasMappedProps = cxt.mappedProperties.length > 0;
 
-    if( cxtHasDiffed || cxtHasMappedProps ){
+    if( cxtHasDiffed || ( newHasCxt && cxtHasMappedProps )){
       let props;
 
       if( cxtHasDiffed && cxtHasMappedProps ){
@@ -205,6 +205,13 @@ styfn.applyContextStyle = function( cxtMeta, cxtStyle, ele ){
 
     // save cycles when the context prop doesn't need to be applied
     if( eleProp === cxtProp ){ continue; }
+
+    // save cycles when a mapped context prop doesn't need to be applied
+    if( is.fn( cxtProp.value )) {
+      cxtProp.fnValue = cxtProp.value( ele ); // temporarily cache the value in case of a miss
+
+      if( cxtProp.fnValue === eleProp.previousValue ){ continue; }
+    }
 
     let retDiffProp = retDiffProps[ diffPropName ] = {
       prev: eleProp

--- a/src/style/parse.js
+++ b/src/style/parse.js
@@ -35,6 +35,11 @@ styfn.parse = function( name, value, propIsBypass, propIsFlat ){
     }
   }
 
+  // cache the original, unparsed value for comparison on the next iteration
+  if( ret ){
+    ret.previousValue = util.copy( value );
+  }
+
   return ret;
 };
 


### PR DESCRIPTION
This PR includes two proposed performance optimizations to styling, specifically for mapped properties.

Optimization 1:
* Mapped properties for contexts an element doesn't have still get flagged as ```diffProps``` and are processed as such only to get "deleted" (those properties won't get set in ```getContextStyle```) from the style later . The optimization catches this case earlier in the styling process.
* Specific changes: In ```getPropertiesDiff```, only consider a context if 1) the context has changed, or 2) if the element has the context and the context has mapped properties (case 2 contains the new behavior).

Optimization 2:
* Mapped properties get recomputed and reapplied every time regardless of whether they changed or not. The optimization caches the previous, un-parsed value (could be changed to the full ```argHash``` if necessary) for a property and compares it to the return value of the mapped property on the next iteration to determine if reapplying can be skipped.
* Specific changes: Cache the previous, un-parsed value in ```parse``` and skip properties in ```applyContextStyle``` if the newly computed return value for a mapped property matches the cached value (also temporarily cache the return value in case they don't match to avoid computing it a second time during parsing).