### PR TITLE
#2245 Fix broken maxZoom setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  only:
+  - master
 language: node_js
 node_js:
   - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-branches:
-  only:
-  - master
 language: node_js
 node_js:
   - "6"

--- a/src/core/viewport.js
+++ b/src/core/viewport.js
@@ -306,7 +306,7 @@ let corefn = ({
       _p.maxZoom = max;
     } else if( is.number( min ) && max === undefined && min <= _p.maxZoom ){
       _p.minZoom = min;
-    } else if( is.number( max ) && min === undefined && max <= _p.minZoom ){
+    } else if( is.number( max ) && min === undefined && max >= _p.minZoom ){
       _p.maxZoom = max;
     }
 

--- a/test/core-init.js
+++ b/test/core-init.js
@@ -260,5 +260,20 @@ describe('Core initialisation', function(){
       done();
     });
   });
+  
+  it('sets maxZoom', function(done){
+    var cy = cytoscape({
+      maxZoom: 1.25,
+      headless: true,
+      styleEnabled: true,
+      elements: { nodes: [], edges: [] }
+    });
+
+    cy.ready(function(){
+      expect( cy.maxZoom() ).to.equal( 1.25 );
+      cy.destroy();
+      done();
+    });
+  });
 
 });


### PR DESCRIPTION
This PR includes a fix for #2245 maxZoom initialisation option has no effect.
In `zoomRange()` when only `maxZoom` is set, then max should be >= _p.minZoom instead of `max <= _p.minZoom`
