### PR TITLE
cy.json should remove the contents of compounds nodes.

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -313,6 +313,7 @@ util.extend( corefn, {
     let cy = this;
     let _p = cy._private;
     let eles = cy.mutableElements();
+    let getFreshRef = ele => cy.getElementById(ele.id());
 
     if( is.plainObject( obj ) ){ // set
 
@@ -384,11 +385,11 @@ util.extend( corefn, {
           })
         );
 
-        parentsToRemove.forEach( function ( ele ) {
-          ele.children().move({ parent: null }); // so that children are not removed w/
-          ele.remove();
-        } );
+        // so that children are not removed w/parent
+        parentsToRemove.forEach(ele => ele.children().move({ parent: null }));
 
+        // intermediate parents may be moved by prior line, so make sure we remove by fresh refs
+        parentsToRemove.forEach(ele => getFreshRef(ele).remove());
       }
 
       if( obj.style ){

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -375,7 +375,7 @@ util.extend( corefn, {
             return !idInJson[ ele.id() ];
         } ).forEach( function ( ele ) {
           if ( ele.isParent() ) {
-              parentsToRemove.merge(ele)
+              parentsToRemove.merge(ele);
           } else {
             ele.remove();
           }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -375,8 +375,6 @@ util.extend( corefn, {
         (eles
           .filter(ele => !idInJson[ ele.id() ])
           .forEach(ele => {
-            if( idInJson[ ele.id() ] ){ return true; }
-
             if ( ele.isParent() ) {
               parentsToRemove.merge(ele);
             } else {

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -371,15 +371,18 @@ util.extend( corefn, {
 
         let parentsToRemove = cy.collection();
 
-        eles.stdFilter( function( ele ){
-            return !idInJson[ ele.id() ];
-        } ).forEach( function ( ele ) {
-          if ( ele.isParent() ) {
+        (eles
+          .filter(ele => !idInJson[ ele.id() ])
+          .forEach(ele => {
+            if( idInJson[ ele.id() ] ){ return true; }
+
+            if ( ele.isParent() ) {
               parentsToRemove.merge(ele);
-          } else {
-            ele.remove();
-          }
-        } );
+            } else {
+              ele.remove();
+            }
+          })
+        );
 
         parentsToRemove.forEach( function ( ele ) {
           ele.children().move({ parent: null }); // so that children are not removed w/

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -369,25 +369,23 @@ util.extend( corefn, {
           }
         }
 
-        let filterElesToRemove = function (eles) {
-          return eles.stdFilter( function( ele ){
-              return !idInJson[ ele.id() ];
-          }).toArray();
-        };
+        let parentsToRemove = cy.collection();
 
-        let elesToRemove = filterElesToRemove(eles);
-
-        // elements not specified in json should be removed
-        for( let i = 0; i < elesToRemove.length; i++ ){
-            let ele = elesToRemove[i];
-
-            if( ele.isParent() ) {
-              // Elements are not "moved" they are copied, extend elesToRemoveList
-              let children = ele.children().move({ parent: null }); // so that children are not removed w/ parent
-              util.push(elesToRemove, filterElesToRemove(children));
-            }
+        eles.stdFilter( function( ele ){
+            return !idInJson[ ele.id() ];
+        } ).forEach( function ( ele ) {
+          if ( ele.isParent() ) {
+              parentsToRemove.merge(ele)
+          } else {
             ele.remove();
-        }
+          }
+        } );
+
+        parentsToRemove.forEach( function ( ele ) {
+          ele.children().move({ parent: null }); // so that children are not removed w/
+          ele.remove();
+        } );
+
       }
 
       if( obj.style ){

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -369,18 +369,25 @@ util.extend( corefn, {
           }
         }
 
-        // elements not specified in json should be removed
-        eles.stdFilter( function( ele ){
-          return !idInJson[ ele.id() ];
-        } ).forEach( function ( ele ){
-          if( ele.isParent() ){
-            ele.children().move({ parent: null }); // so that children are not removed w/ parent
+        let filterElesToRemove = function (eles) {
+          return eles.stdFilter( function( ele ){
+              return !idInJson[ ele.id() ];
+          }).toArray();
+        };
 
-            ele.remove(); // remove parent
-          } else {
+        let elesToRemove = filterElesToRemove(eles);
+
+        // elements not specified in json should be removed
+        for( let i = 0; i < elesToRemove.length; i++ ){
+            let ele = elesToRemove[i];
+
+            if( ele.isParent() ) {
+              // Elements are not "moved" they are copied, extend elesToRemoveList
+              let children = ele.children().move({ parent: null }); // so that children are not removed w/ parent
+              util.push(elesToRemove, filterElesToRemove(children));
+            }
             ele.remove();
-          }
-        } );
+        }
       }
 
       if( obj.style ){

--- a/test/core-graph-manipulation.js
+++ b/test/core-graph-manipulation.js
@@ -521,6 +521,29 @@ describe('Core graph manipulation', function(){
       expect( cy.$('#c').isOrphan(), 'c is orphan' ).to.be.true;
     });
 
+      it('cy.json() removes parent and children', function(){
+          // clean up before test:
+          cy.elements().remove();
+          cy.add([
+              { data: { id: 'a' } },
+              { data: { id: 'b', parent: 'a' } },
+              { data: { id: 'c', parent: 'a' } },
+              { data: { id: 'd' } }
+          ]);
+
+          cy.json({
+              elements: [
+                  // a, b and c are gone
+                  { data: { id: 'd' } }
+              ]
+          });
+
+          expect( cy.$('#a').empty(), 'node a not in graph' ).to.be.true;
+          expect( cy.$('#b').empty(), 'node b not in graph' ).to.be.true;
+          expect( cy.$('#c').empty(), 'node c not in graph' ).to.be.true;
+          expect( cy.$('#d').nonempty(), 'node d in graph' ).to.be.true;
+      });
+
     it('cy.json() orphans children', function(){
       // clean up before test:
       cy.elements().remove();

--- a/test/core-graph-manipulation.js
+++ b/test/core-graph-manipulation.js
@@ -567,6 +567,33 @@ describe('Core graph manipulation', function(){
         expect( cy.$('#d').nonempty(), 'node d in graph' ).to.be.true;
     });
 
+    it('cy.json() removes middle parent of depth 2', function(){
+        // clean up before test:
+        cy.elements().remove();
+        cy.add([
+            { data: { id: 'a' } },
+            { data: { id: 'b', parent: 'a' } },
+            { data: { id: 'c', parent: 'b' } },
+            { data: { id: 'd' } }
+        ]);
+
+        cy.json({
+            elements: [
+                // Remove 'b' and parent of 'c' is 'a' now
+                { data: { id: 'a' } },
+                { data: { id: 'c', parent: 'a' } },
+                { data: { id: 'd' } }
+            ]
+        });
+
+        expect( cy.$('#a').nonempty(), 'node a in graph' ).to.be.true;
+        expect( cy.$('#b').empty(), 'node b not in graph' ).to.be.true;
+        expect( cy.$('#c').nonempty(), 'node c in graph' ).to.be.true;
+        expect( cy.$('#d').nonempty(), 'node d in graph' ).to.be.true;
+        expect( cy.$('#a').isParent(), 'a is parent' ).to.be.true;
+        expect( cy.$('#c').parent().id(), 'parent of c is a' ).to.equal('a');
+    });
+
     it('cy.json() orphans children', function(){
       // clean up before test:
       cy.elements().remove();

--- a/test/core-graph-manipulation.js
+++ b/test/core-graph-manipulation.js
@@ -544,6 +544,29 @@ describe('Core graph manipulation', function(){
         expect( cy.$('#d').nonempty(), 'node d in graph' ).to.be.true;
     });
 
+    it('cy.json() removes parent and children with depth 2', function(){
+        // clean up before test:
+        cy.elements().remove();
+        cy.add([
+            { data: { id: 'a' } },
+            { data: { id: 'b', parent: 'a' } },
+            { data: { id: 'c', parent: 'b' } },
+            { data: { id: 'd' } }
+        ]);
+
+        cy.json({
+            elements: [
+                // a, b and c are gone
+                { data: { id: 'd' } }
+            ]
+        });
+
+        expect( cy.$('#a').empty(), 'node a not in graph' ).to.be.true;
+        expect( cy.$('#b').empty(), 'node b not in graph' ).to.be.true;
+        expect( cy.$('#c').empty(), 'node c not in graph' ).to.be.true;
+        expect( cy.$('#d').nonempty(), 'node d in graph' ).to.be.true;
+    });
+
     it('cy.json() orphans children', function(){
       // clean up before test:
       cy.elements().remove();

--- a/test/core-graph-manipulation.js
+++ b/test/core-graph-manipulation.js
@@ -521,28 +521,28 @@ describe('Core graph manipulation', function(){
       expect( cy.$('#c').isOrphan(), 'c is orphan' ).to.be.true;
     });
 
-      it('cy.json() removes parent and children', function(){
-          // clean up before test:
-          cy.elements().remove();
-          cy.add([
-              { data: { id: 'a' } },
-              { data: { id: 'b', parent: 'a' } },
-              { data: { id: 'c', parent: 'a' } },
-              { data: { id: 'd' } }
-          ]);
+    it('cy.json() removes parent and children', function(){
+        // clean up before test:
+        cy.elements().remove();
+        cy.add([
+            { data: { id: 'a' } },
+            { data: { id: 'b', parent: 'a' } },
+            { data: { id: 'c', parent: 'a' } },
+            { data: { id: 'd' } }
+        ]);
 
-          cy.json({
-              elements: [
-                  // a, b and c are gone
-                  { data: { id: 'd' } }
-              ]
-          });
+        cy.json({
+            elements: [
+                // a, b and c are gone
+                { data: { id: 'd' } }
+            ]
+        });
 
-          expect( cy.$('#a').empty(), 'node a not in graph' ).to.be.true;
-          expect( cy.$('#b').empty(), 'node b not in graph' ).to.be.true;
-          expect( cy.$('#c').empty(), 'node c not in graph' ).to.be.true;
-          expect( cy.$('#d').nonempty(), 'node d in graph' ).to.be.true;
-      });
+        expect( cy.$('#a').empty(), 'node a not in graph' ).to.be.true;
+        expect( cy.$('#b').empty(), 'node b not in graph' ).to.be.true;
+        expect( cy.$('#c').empty(), 'node c not in graph' ).to.be.true;
+        expect( cy.$('#d').nonempty(), 'node d in graph' ).to.be.true;
+    });
 
     it('cy.json() orphans children', function(){
       // clean up before test:


### PR DESCRIPTION
 eles.move(...) creates a copy of the elements to be "moved" and
 deletes the originals, thus we need to check if we need to remove the
 new elements.

Targeting master as this is a bugfix