### PR TITLE
Add module field to package.json to enable ES modules interoperability

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "node": ">=0.10"
   },
   "main": "dist/cytoscape.cjs.js",
+  "module": "dist/cytoscape.esm.js",
   "scripts": {
     "lint": "eslint src benchmark",
     "build": "rollup -c",


### PR DESCRIPTION
This pull request adds `module` field to package.json. It enables automatic consumption of ES module by bundlers like Webpack.

This is in line with the intent stated in the documentation:

> cytoscape.esm.js : A non-minified ESM (import / export) build without any bundled dependencies. This is intended to be consumed automatically by Node.js or a bundler like Webpack via import cytoscape from 'cytoscape'.
~ [http://js.cytoscape.org/#getting-started/including-cytoscape.js]()

It was also suggested as a next step in #2084.