### PR TITLE
Fix cache drawing of rotated labels

### DIFF
--- a/src/collection/dimensions/bounds.js
+++ b/src/collection/dimensions/bounds.js
@@ -362,16 +362,40 @@ let updateBoundsFromLabel = function( bounds, ele, prefix ){
       let theta = isAutorotate ? prefixedProperty( _p.rstyle, 'labelAngle', prefix ) : rotation.pfValue;
       let cos = Math.cos( theta );
       let sin = Math.sin( theta );
-      let xMid = (lx1 + lx2)/2;
-      let yMid = (ly1 + ly2)/2;
+
+      // rotation point (default value for center-center)
+      let xo = (lx1 + lx2)/2;
+      let yo = (ly1 + ly2)/2;
+
+      if( !isEdge ){
+        switch( halign.value ){
+          case 'left':
+            xo = lx2;
+            break;
+
+          case 'right':
+            xo = lx1;
+            break;
+        }
+
+        switch( valign.value ){
+          case 'top':
+            yo = ly2;
+            break;
+
+          case 'bottom':
+            yo = ly1;
+            break;
+        }
+      }
 
       let rotate = function( x, y ){
-        x = x - xMid;
-        y = y - yMid;
+        x = x - xo;
+        y = y - yo;
 
         return {
-          x: x * cos - y * sin + xMid,
-          y: x * sin + y * cos + yMid
+          x: x * cos - y * sin + xo,
+          y: x * sin + y * cos + yo
         };
       };
 

--- a/src/extensions/renderer/canvas/drawing-elements.js
+++ b/src/extensions/renderer/canvas/drawing-elements.js
@@ -40,11 +40,10 @@ CRp.drawCachedElementPortion = function( context, ele, eleTxrCache, pxRatio, lvl
     let x, y, sx, sy, smooth;
 
     if( theta !== 0 ){
-      let halfW = w/2;
-      let halfH = h/2;
+      let rotPt = eleTxrCache.getRotationPoint(ele);
 
-      sx = x1 + halfW;
-      sy = y1 + halfH;
+      sx = rotPt.x;
+      sy = rotPt.y;
 
       context.translate(sx, sy);
       context.rotate(theta);
@@ -53,8 +52,10 @@ CRp.drawCachedElementPortion = function( context, ele, eleTxrCache, pxRatio, lvl
 
       if( !smooth ){ r.setImgSmoothing(context, true); }
 
-      x = -halfW;
-      y = -halfH;
+      let off = eleTxrCache.getRotationOffset(ele);
+
+      x = off.x;
+      y = off.y;
     } else {
       x = x1;
       y = y1;
@@ -67,7 +68,7 @@ CRp.drawCachedElementPortion = function( context, ele, eleTxrCache, pxRatio, lvl
       context.globalAlpha = oldGlobalAlpha * opacity;
     }
 
-    context.drawImage( eleCache.texture.canvas, eleCache.x, 0, eleCache.width, eleCache.height, x, y, bb.w, bb.h );
+    context.drawImage( eleCache.texture.canvas, eleCache.x, 0, eleCache.width, eleCache.height, x, y, w, h );
 
     if( opacity !== 1 ){
       context.globalAlpha = oldGlobalAlpha;

--- a/src/extensions/renderer/canvas/ele-texture-cache.js
+++ b/src/extensions/renderer/canvas/ele-texture-cache.js
@@ -34,6 +34,8 @@ const initDefaults = defaults({
   doesEleInvalidateKey: falsify,
   drawElement: null,
   getBoundingBox: null,
+  getRotationPoint: null,
+  getRotationOffset: null,
   isVisible: trueify,
   allowEdgeTxrCaching: true,
   allowParentTxrCaching: true

--- a/src/extensions/renderer/canvas/index.js
+++ b/src/extensions/renderer/canvas/index.js
@@ -159,6 +159,22 @@ function CanvasRenderer( options ){
       }
     }
 
+    let theta = ele.numericStyle('text-rotation');
+    let marginX = ele.pstyle('text-margin-x').pfValue;
+    let marginY = ele.pstyle('text-margin-y').pfValue;
+    if (theta != 0) {
+        // Rotate the margin [x,y]' using the rotation angle to find out how much to move in each direction.
+        let localMarginX = marginX;
+        let localMarginY = marginY;
+        let cosTheta = Math.cos(theta);
+        let sinTheta = Math.sin(theta);
+        marginX = cosTheta * localMarginX - sinTheta * localMarginY;
+        marginY = sinTheta * localMarginX + cosTheta * localMarginY;
+    }
+
+    p.x -= marginX;
+    p.y -= marginY;
+
     return p;
   };
 


### PR DESCRIPTION
@maxkfranz I added code on top of `ele-txr-cache-rotpt` to handle the `text-margin-x` and `text-margin-y`, please review.


Related to #2256 