### PR TITLE
Check for animation status before printing edge is impossible to draw

### DIFF
--- a/src/extensions/renderer/base/coord-ele-math/edge-control-points.js
+++ b/src/extensions/renderer/base/coord-ele-math/edge-control-points.js
@@ -126,9 +126,10 @@ BRp.storeAllpts = function( edge ){
 
 BRp.checkForInvalidEdgeWarning = function( edge ){
   var rs = edge._private.rscratch;
+  var cy = this.cy;
 
   if( !is.number(rs.startX) || !is.number(rs.startY) || !is.number(rs.endX) || !is.number(rs.endY) ){
-    if( !rs.loggedErr ){
+    if( !cy.animated() && !rs.loggedErr ){
       rs.loggedErr = true;
       util.warn('Edge `' + edge.id() + '` has invalid endpoints and so it is impossible to draw.  Adjust your edge style (e.g. control points) accordingly or use an alternative edge type.  This is expected behaviour when the source node and the target node overlap.');
     }


### PR DESCRIPTION
This PR is a simple condition check to ignore warnings that may be out of date. For example, if nodes were too close but laid out nicer later, the warnings are not really that useful, and can be noisy.

Closes https://github.com/cytoscape/cytoscape.js/issues/2258