### PR TITLE
change style application to satisfy CSP style-src 'self'

### DIFF
--- a/src/extensions/renderer/canvas/index.js
+++ b/src/extensions/renderer/canvas/index.js
@@ -51,10 +51,11 @@ function CanvasRenderer( options ){
   };
 
   var tapHlOff = '-webkit-tap-highlight-color: rgba(0,0,0,0);';
-
+  var tapHlOffAttr = '-webkit-tap-highlight-color';
+  var tapHlOffStyle = 'rgba(0,0,0,0)';
   r.data.canvasContainer = document.createElement( 'div' ); // eslint-disable-line no-undef
   var containerStyle = r.data.canvasContainer.style;
-  r.data.canvasContainer.setAttribute( 'style', tapHlOff );
+  r.data.canvasContainer.style[tapHlOffAttr] = tapHlOffStyle;
   containerStyle.position = 'relative';
   containerStyle.zIndex = '0';
   containerStyle.overflow = 'hidden';
@@ -63,13 +64,28 @@ function CanvasRenderer( options ){
   container.appendChild( r.data.canvasContainer );
 
   if( (container.getAttribute('style') || '').indexOf(tapHlOff) < 0 ){
-    container.setAttribute( 'style', ( container.getAttribute( 'style' ) || '' ) + tapHlOff );
+    container.style[tapHlOffAttr] = tapHlOffStyle;
+  }
+
+  var styleMap = {
+    '-webkit-user-select': 'none',
+    '-moz-user-select': '-moz-none',
+    'user-select': 'none',
+    '-webkit-tap-highlight-color': 'rgba(0,0,0,0)',
+    'outline-style': 'none',
+  }
+
+  if(is.ms()) {
+    styleMap['-ms-touch-action'] = 'none'
+    styleMap['touch-action'] = 'none'
   }
 
   for( var i = 0; i < CRp.CANVAS_LAYERS; i++ ){
     var canvas = r.data.canvases[ i ] = document.createElement( 'canvas' );  // eslint-disable-line no-undef
     r.data.contexts[ i ] = canvas.getContext( '2d' );
-    canvas.setAttribute( 'style', '-webkit-user-select: none; -moz-user-select: -moz-none; user-select: none; -webkit-tap-highlight-color: rgba(0,0,0,0); outline-style: none;' + ( is.ms() ? ' -ms-touch-action: none; touch-action: none; ' : '' ) );
+    for(const [k,v] of Object.entries(styleMap)) {
+      canvas.style[k] = v;
+    }
     canvas.style.position = 'absolute';
     canvas.setAttribute( 'data-id', 'layer' + i );
     canvas.style.zIndex = String( CRp.CANVAS_LAYERS - i );

--- a/src/extensions/renderer/canvas/index.js
+++ b/src/extensions/renderer/canvas/index.js
@@ -73,11 +73,11 @@ function CanvasRenderer( options ){
     'user-select': 'none',
     '-webkit-tap-highlight-color': 'rgba(0,0,0,0)',
     'outline-style': 'none',
-  }
+  };
 
   if(is.ms()) {
-    styleMap['-ms-touch-action'] = 'none'
-    styleMap['touch-action'] = 'none'
+    styleMap['-ms-touch-action'] = 'none';
+    styleMap['touch-action'] = 'none';
   }
 
   for( var i = 0; i < CRp.CANVAS_LAYERS; i++ ){

--- a/src/extensions/renderer/canvas/index.js
+++ b/src/extensions/renderer/canvas/index.js
@@ -50,7 +50,6 @@ function CanvasRenderer( options ){
     bufferContexts: new Array( CRp.CANVAS_LAYERS ),
   };
 
-  var tapHlOff = '-webkit-tap-highlight-color: rgba(0,0,0,0);';
   var tapHlOffAttr = '-webkit-tap-highlight-color';
   var tapHlOffStyle = 'rgba(0,0,0,0)';
   r.data.canvasContainer = document.createElement( 'div' ); // eslint-disable-line no-undef
@@ -62,10 +61,7 @@ function CanvasRenderer( options ){
 
   var container = options.cy.container();
   container.appendChild( r.data.canvasContainer );
-
-  if( (container.getAttribute('style') || '').indexOf(tapHlOff) < 0 ){
-    container.style[tapHlOffAttr] = tapHlOffStyle;
-  }
+  container.style[tapHlOffAttr] = tapHlOffStyle;
 
   var styleMap = {
     '-webkit-user-select': 'none',

--- a/src/extensions/renderer/canvas/index.js
+++ b/src/extensions/renderer/canvas/index.js
@@ -79,9 +79,9 @@ function CanvasRenderer( options ){
   for( var i = 0; i < CRp.CANVAS_LAYERS; i++ ){
     var canvas = r.data.canvases[ i ] = document.createElement( 'canvas' );  // eslint-disable-line no-undef
     r.data.contexts[ i ] = canvas.getContext( '2d' );
-    for(const [k,v] of Object.entries(styleMap)) {
-      canvas.style[k] = v;
-    }
+    Object.keys(styleMap).forEach((k) => {
+      canvas.style[k] = styleMap[k];
+    });
     canvas.style.position = 'absolute';
     canvas.setAttribute( 'data-id', 'layer' + i );
     canvas.style.zIndex = String( CRp.CANVAS_LAYERS - i );


### PR DESCRIPTION
Hi!

### Problem

I'm a bit focused on security, so my webservers all run with a very strict Content-Security-Policy; currently it's set to:

> Content-Security-Policy: default-src 'none'; img-src 'self'; script-src 'self'; prefetch-src 'self'; worker-src 'self'; connect-src 'self'; style-src 'self'

With current unstable, Chrome will refuse some style applications with the message:

> Refused to apply inline style because it violates the following Content Security Policy directive: "style-src 'self'".

### Changes

I've changed `src/extensions/renderer/canvas/index.js` to apply the style without triggering the error.
Please check that the changes do not change behaviour, I'm not confident with JavaScript, yet.

### Need help with

There is another problem that I cannot figure out by myself:
https://github.com/cytoscape/cytoscape.js/blob/d9424465f7a90303fa122cdef9df476ed6151072/src/extensions/renderer/base/index.js#L39-L46

Line 45 will trigger the same error, but I don't know hot to fix it. Can you help?