### PR TITLE
Opt out of loop edge with inside-to-node

### DIFF
--- a/src/extensions/renderer/base/coord-ele-math/edge-control-points.js
+++ b/src/extensions/renderer/base/coord-ele-math/edge-control-points.js
@@ -808,7 +808,7 @@ BRp.findEdgeControlPoints = function( edges ){
       rs.tgtIntn = passedPairInfo.tgtIntn;
 
       if(
-        hasCompounds &&
+        edge.pstyle( 'target-endpoint' ).value !== 'inside-to-node' && hasCompounds &&
         ( src.isParent() || src.isChild() || tgt.isParent() || tgt.isChild() ) &&
         ( src.parents().anySame(tgt) || tgt.parents().anySame(src) || src.same(tgt) )
       ){


### PR DESCRIPTION
It would be nice to be able to opt out of the looping behavior when a node points to its parent. This PR allows nodes to point to their parent's center with `'target-endpoint' : 'inside-to-node'`

![Screenshot 2019-03-30 11 01 58](https://user-images.githubusercontent.com/327664/55277881-4296b800-52db-11e9-85b7-bb46c7ddfdee.png)

It might be cleaner to add a different style property to opt out of the loop behavior and just respect whichever target-endpoint value is set by the user. Any feedback or recommendations on that is welcome.