### PR TITLE
Zoom animation can cause zoom value to be outside of [minZoom, maxZoom]

### DIFF
--- a/src/core/animation/step.js
+++ b/src/core/animation/step.js
@@ -1,6 +1,7 @@
 import easings from './easings';
 import ease from './ease';
 import * as is from '../../is';
+import {bound} from '../../math';
 
 function step( self, ani, now, isCore ){
   let isEles = !isCore;
@@ -110,7 +111,7 @@ function step( self, ani, now, isCore ){
     let animatingZoom = endZoom != null && isCore;
     if( animatingZoom ){
       if( valid( startZoom, endZoom ) ){
-        _p.zoom = ease( startZoom, endZoom, percent, easing );
+        _p.zoom = bound( _p.minZoom, ease( startZoom, endZoom, percent, easing ), _p.maxZoom );
       }
 
       self.emit( 'zoom' );

--- a/test/core-graph-manipulation.js
+++ b/test/core-graph-manipulation.js
@@ -834,4 +834,19 @@ describe('Core graph manipulation', function(){
     });
   });
 
+  describe('cy.zoom()', function(){
+    describe('cy.zoom(number)', function() {
+      it('should not return a negative value', function() {
+        cy.zoom(-10);
+        expect(cy.zoom() >= 0).to.equal(true);
+      });
+    });
+
+    describe('cy.zoom({level: number})', function() {
+      it('should not return a negative value', function() {
+        cy.zoom({level: -10});
+        expect(cy.zoom() >= 0).to.equal(true);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## The problem
We are using cytoscape within a React application. We noticed that when 2 nodes were at least 15,000 units apart, a `fitSelected` followed by a `fit` would cause cytoscape to crash.
![cytoscape-bug-1](https://user-images.githubusercontent.com/3931162/58125920-b7051d80-7bdf-11e9-8bc6-32f4f37eb07f.gif)

## Investigation: Part 1
What is happening is that `new OffscreenCanvas(NaN, NaN)` is being invoked because `zoom` is temporarily a negative number which makes `lvl` equate `NaN`.
https://github.com/cytoscape/cytoscape.js/blob/85f0c8dfebc3ed9796651fef43be7ff871db88ce/src/extensions/renderer/canvas/layered-texture-cache.js#L118

The reason why `lvl` is a `NaN` is because `Math.log` and `Math.log2` result in `NaN` at negative values.
```js
Math.log2(1) // 0
Math.log2(0) // -Infinity
Math.log2(-1) // NaN
```

This explains why the docs specifically mention that `zoom` must be positive.
https://github.com/stephencorwin/cytoscape.js/blob/unstable/documentation/md/core/zoom.md
> The zoom level must be a positive number.

## Investigation: Part 2
The cytoscape animation `step()` leverages `ease()` which can temporarily dip `zoom` into the negative range based on the values of `startZoom` and `endZoom`.
https://github.com/cytoscape/cytoscape.js/blob/40a1a8f1e9e9e086ff8f4e43fb122194a2252b1f/src/core/animation/step.js#L113

However, we need zoom to be able to temporarily dip into the negative to give the *bounce* effect of easing.

## Resolution
Because it is unsafe to pass a negative zoom into `Math.log` and cytoscape already has a wrapper for `Math.log2`, it is reasonable to default to clamping the `n` argument to `0` and providing an optional `safe` argument in the event that `NaN` is an acceptable outcome.

**Note:** If we never see a reason where `NaN` is acceptable, we can remove the argument check and always clamp.

## Other fixes
Since I am adjusting the cytoscape wrapper in the `math.js` module, it made sense to create a new test file in `/test/modules/`. When I was attempting to do this, I realized that `npm test` was not discovering any tests within sub directories.

I added the `--recursive` argument to the npm scripts so that all sub directories in the `test` directory are now discovered. This revealed 1 test failure for `/test/modules/emitter.js`. The test was calling `removeAllListeners` which seems to have been deprecated and subsequently removed awhile back. I eliminated this test as it was no longer necessary.