### PR TITLE
Add unpkg and jsdelivr entry points

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
     "node": ">=0.10"
   },
   "main": "dist/cytoscape.cjs.js",
+  "unpkg": "dist/cytoscape.min.js",
+  "jsdelivr": "dist/cytoscape.min.js",
   "scripts": {
     "lint": "eslint src benchmark",
     "build": "rollup -c",


### PR DESCRIPTION
This PR adds [unpkg](https://unpkg.com/) & [jdelivr](https://www.jsdelivr.com/) fields, so AMD loaders like d3-require can load cytoscape.js in a web browser. The UMD builds already exist (yay), so this just configures them to be used.