### PR TITLE
COSE offset component separation by left-top of component

### DIFF
--- a/src/extensions/layout/cose.js
+++ b/src/extensions/layout/cose.js
@@ -1302,8 +1302,8 @@ var separateComponents = function( layoutInfo, options ){
       var n = c[ j ];
 
       if( !n.isLocked ){
-        n.positionX += x;
-        n.positionY += y;
+        n.positionX += (x - c.x1);
+        n.positionY += (y - c.y1);
       }
     }
 


### PR DESCRIPTION
There is a very slight bug in the cose layout that components that are already separate are again separated when a layout is re-run. If you perform a cose layout, then use that as the starting position to perform another layout, the components separate even more. If you keep re-doing the layout, the components keep on separating. This leads to bigger and bigger separations on re-layouts. This can be undone by offsetting the component separation by the x1 and y1 of the component. 