### PR TITLE
Added new CDN - PageCDN

### DIFF
--- a/documentation/md/getting-started.md
+++ b/documentation/md/getting-started.md
@@ -10,7 +10,7 @@ If you are using a simple HTML environment (without a build system), then includ
 <script src="cytoscape.min.js"></script>
 ```
 
-To use Cytoscape.js from a CDN, use [CDNJS](https://cdnjs.com/libraries/cytoscape) or [Unpkg](https://unpkg.com) ([in the dist directory](https://unpkg.com/cytoscape/dist/)).  Please do not hotlink to copies of Cytoscape.js from the documentation --- they're just for the demos.
+To use Cytoscape.js from a CDN, use [PageCDN](https://pagecdn.com/lib/cytoscape), [CDNJS](https://cdnjs.com/libraries/cytoscape) or [Unpkg](https://unpkg.com/cytoscape/dist/).  Please do not hotlink to copies of Cytoscape.js from the documentation --- they're just for the demos.
 
 The available files are available under [`cytoscape/dist/`](https://github.com/cytoscape/cytoscape.js/tree/master/dist) in the npm package:
 


### PR DESCRIPTION
PageCDN uses brotli-11 compression that reduces cytoscape's file sizes by upto 28 KBs compared to other CDNs. In addition, immutable caching is enabled by default to optimize content delivery a little more aggressively. This will make PageCDN a valuable addition to the documentation.

Thanks.