### PR TITLE
Breadthfirst layout ordering

### DIFF
--- a/src/extensions/layout/breadthfirst.js
+++ b/src/extensions/layout/breadthfirst.js
@@ -258,7 +258,7 @@ BreadthFirstLayout.prototype.run = function(){
       let nDepth = depths[ depth ].length;
 
       if( depth < eleDepth ){ // only get influenced by elements above
-        percent += index / ( nDepth - 1 );
+        percent += index / nDepth;
         samples++;
       }
     }


### PR DESCRIPTION
Breadthfirst orders nodes by their connections to their predecessors, but in case of a tie uses the nodes' IDs. However, in the case of a particular depth having only 1 node, there is a division by 0 and all that node's successors have a weight of NaN, causing them to be ordered arbitrarily.

A minimal example of this problem:
https://jsfiddle.net/sLx814y5/

This does not match my expectation of child 1-3 being in order from left to right.

Being able to control the order of nodes in this way is very useful to me but I can't control it in this scenario.