### PR TITLE
Check self-loop before compound-loop

### DIFF
--- a/src/extensions/renderer/base/coord-ele-math/edge-control-points.js
+++ b/src/extensions/renderer/base/coord-ele-math/edge-control-points.js
@@ -834,7 +834,7 @@ BRp.findEdgeControlPoints = function( edges ){
       if(
         hasCompounds &&
         ( src.isParent() || src.isChild() || tgt.isParent() || tgt.isChild() ) &&
-        ( src.parents().anySame(tgt) || tgt.parents().anySame(src) || src.same(tgt) )
+        ( src.parents().anySame(tgt) || tgt.parents().anySame(src) || (src.same(tgt) && src.isParent()) )
       ){
         this.findCompoundLoopPoints(edge, passedPairInfo, i, edgeIsUnbundled);
 


### PR DESCRIPTION
When a self-loop was inside a compound, the findCompoundLoopPoints took precedence over the self-loop, thus `loop-direction` and `loop-sweep` values were ignored.

@maxkfranz is there any reason to have the compound check before the self-loop check?

![loop-in-compound](https://user-images.githubusercontent.com/3845764/62577375-70c96d00-b864-11e9-8eb0-5311b238a962.png)
