### PR TITLE
Rounded polygon shapes (e.g. `round-triangle`)

### DIFF
--- a/documentation/demos/node-types/data.json
+++ b/documentation/demos/node-types/data.json
@@ -40,11 +40,23 @@
   }
 }, {
   "data": {
+    "type": "round-diamond"
+  }
+}, {
+  "data": {
     "type": "pentagon"
   }
 }, {
   "data": {
+    "type": "round-pentagon"
+  }
+}, {
+  "data": {
     "type": "hexagon"
+  }
+}, {
+  "data": {
+    "type": "round-hexagon"
   }
 }, {
   "data": {
@@ -56,7 +68,15 @@
   }
 }, {
   "data": {
+    "type": "round-heptagon"
+  }
+}, {
+  "data": {
     "type": "octagon"
+  }
+}, {
+  "data": {
+    "type": "round-octagon"
   }
 }, {
   "data": {
@@ -65,6 +85,10 @@
 }, {
   "data": {
     "type": "tag"
+  }
+}, {
+  "data": {
+    "type": "round-tag"
   }
 }, {
   "data": {

--- a/documentation/demos/node-types/data.json
+++ b/documentation/demos/node-types/data.json
@@ -8,6 +8,10 @@
   }
 }, {
   "data": {
+    "type": "round-triangle"
+  }
+}, {
+  "data": {
     "type": "rectangle"
   }
 }, {

--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -176,13 +176,19 @@ Shape:
     * `barrel`
     * `rhomboid`
     * `diamond`
+    * `round-diamond`
     * `pentagon`
+    * `round-pentagon`
     * `hexagon`
+    * `round-hexagon`
     * `concave-hexagon`
     * `heptagon`
+    * `round-heptagon`
     * `octagon`
+    * `round-octagon`
     * `star`
     * `tag`
+    * `round-tag`
     * `vee`
     * `polygon` (custom polygon specified via `shape-polygon-points`).
  * **`shape-polygon-points`** : An array (or a space-separated string) of numbers ranging on [-1, 1], representing alternating x and y values (i.e. `x1 y1   x2 y2,   x3 y3 ...`).  This represents the points in the polygon for the node's shape.  The bounding box of the node is given by (-1, -1), (1, -1), (1, 1), (-1, 1).  The node's position is the origin (0, 0).

--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -168,6 +168,7 @@ Shape:
  * **`shape`** : The shape of the node's body.  Note that each shape fits within the specified `width` and `height`, and so you may have to adjust `width` and `height` if you desire an equilateral shape (i.e. `width !== height` for several equilateral shapes).  Only `*rectangle` shapes are supported by compounds, because the dimensions of a compound are defined by the bounding box of the children.  The following values are accepted:
     * `ellipse`
     * `triangle`
+    * `round-triangle`
     * `rectangle`
     * `round-rectangle`
     * `bottom-round-rectangle`

--- a/src/extensions/renderer/base/node-shapes.js
+++ b/src/extensions/renderer/base/node-shapes.js
@@ -513,8 +513,7 @@ BRp.registerNodeShapes = function(){
   this.generateEllipse();
 
   this.generatePolygon( 'triangle', math.generateUnitNgonPointsFitToSquare( 3, 0 ) );
-
-  this.generateRoundPolygon('round-triangle', math.generateUnitNgonPointsFitToSquare(3, 0));
+  this.generateRoundPolygon( 'round-triangle', math.generateUnitNgonPointsFitToSquare( 3, 0 ) );
 
   this.generatePolygon( 'rectangle', math.generateUnitNgonPointsFitToSquare( 4, 0 ) );
   nodeShapes[ 'square' ] = nodeShapes[ 'rectangle' ];
@@ -527,20 +526,28 @@ BRp.registerNodeShapes = function(){
 
   this.generateBottomRoundrectangle();
 
-  this.generatePolygon( 'diamond', [
-    0, 1,
-    1, 0,
-    0, -1,
-    -1, 0
-  ] );
+  {
+    const diamondPoints = [
+      0, 1,
+      1, 0,
+      0, -1,
+      -1, 0
+    ];
+    this.generatePolygon( 'diamond', diamondPoints );
+    this.generateRoundPolygon( 'round-diamond', diamondPoints );
+  }
 
   this.generatePolygon( 'pentagon', math.generateUnitNgonPointsFitToSquare( 5, 0 ) );
+  this.generateRoundPolygon( 'round-pentagon', math.generateUnitNgonPointsFitToSquare( 5, 0) );
 
   this.generatePolygon( 'hexagon', math.generateUnitNgonPointsFitToSquare( 6, 0 ) );
+  this.generateRoundPolygon( 'round-hexagon', math.generateUnitNgonPointsFitToSquare( 6, 0) );
 
   this.generatePolygon( 'heptagon', math.generateUnitNgonPointsFitToSquare( 7, 0 ) );
+  this.generateRoundPolygon( 'round-heptagon', math.generateUnitNgonPointsFitToSquare( 7, 0) );
 
   this.generatePolygon( 'octagon', math.generateUnitNgonPointsFitToSquare( 8, 0 ) );
+  this.generateRoundPolygon( 'round-octagon', math.generateUnitNgonPointsFitToSquare( 8, 0) );
 
   var star5Points = new Array( 20 );
   {
@@ -592,13 +599,17 @@ BRp.registerNodeShapes = function(){
     1, -0.95
   ] );
 
-  this.generatePolygon( 'tag', [
-    -1, -1,
-    0.25, -1,
-    1, 0,
-    0.25,1,
-    -1, 1
-  ]);
+  {
+    const tagPoints = [
+      -1, -1,
+      0.25, -1,
+      1, 0,
+      0.25,1,
+      -1, 1
+    ];
+    this.generatePolygon( 'tag', tagPoints );
+    this.generateRoundPolygon( 'round-tag', tagPoints );
+  }
 
   nodeShapes.makePolygon = function( points ){
 

--- a/src/extensions/renderer/base/node-shapes.js
+++ b/src/extensions/renderer/base/node-shapes.js
@@ -59,6 +59,48 @@ BRp.generateEllipse = function(){
   } );
 };
 
+BRp.generateRoundTriangle = function(){
+  return ( this.nodeShapes['round-triangle'] = this.nodeShapes['roundtriangle'] = {
+    renderer: this,
+
+    name: 'round-triangle',
+
+    points: math.generateUnitNgonPointsFitToSquare(3, 0 ),
+
+    draw: function(context, centerX, centerY, width, height ){
+      this.renderer.nodeShapeImpl( this.name, context, centerX, centerY, width, height );
+    },
+
+    intersectLine: function( nodeX, nodeY, width, height, x, y, padding ){
+      return math.roundTriangleIntersectLine(
+          x, y,
+          nodeX,
+          nodeY,
+          width, height,
+          padding )
+      ;
+    },
+
+    checkPoint: function(
+        x, y, padding, width, height, centerX, centerY ){
+
+      var cornerRadius = math.getRoundTriangleRadius( width, height );
+      var diam = cornerRadius * 2;
+
+      // Check box
+      if ( math.pointInsidePolygon(x, y, this.points,
+          centerX, centerY + cornerRadius * 0.5, width - diam, height - cornerRadius, [0, -1], padding ) ){
+        return true;
+      }
+
+      // Todo: Add checks for the cirles around the edges
+
+      return false;
+    }
+  } );
+};
+
+
 BRp.generateRoundRectangle = function(){
   return ( this.nodeShapes['round-rectangle'] = this.nodeShapes['roundrectangle'] = {
     renderer: this,
@@ -454,6 +496,8 @@ BRp.registerNodeShapes = function(){
   this.generateEllipse();
 
   this.generatePolygon( 'triangle', math.generateUnitNgonPointsFitToSquare( 3, 0 ) );
+
+  this.generateRoundTriangle();
 
   this.generatePolygon( 'rectangle', math.generateUnitNgonPointsFitToSquare( 4, 0 ) );
   nodeShapes[ 'square' ] = nodeShapes[ 'rectangle' ];

--- a/src/extensions/renderer/base/node-shapes.js
+++ b/src/extensions/renderer/base/node-shapes.js
@@ -59,47 +59,36 @@ BRp.generateEllipse = function(){
   } );
 };
 
-BRp.generateRoundTriangle = function(){
-  return ( this.nodeShapes['round-triangle'] = this.nodeShapes['roundtriangle'] = {
+BRp.generateRoundPolygon = function( name, points ){
+  return ( this.nodeShapes[ name ] = {
     renderer: this,
 
-    name: 'round-triangle',
+    name: name,
 
-    points: math.generateUnitNgonPointsFitToSquare(3, 0 ),
+    points: points,
 
-    draw: function(context, centerX, centerY, width, height ){
-      this.renderer.nodeShapeImpl( this.name, context, centerX, centerY, width, height );
+    draw: function( context, centerX, centerY, width, height ){
+      this.renderer.nodeShapeImpl( 'round-polygon', context, centerX, centerY, width, height, this.points );
     },
 
     intersectLine: function( nodeX, nodeY, width, height, x, y, padding ){
-      return math.roundTriangleIntersectLine(
+      return math.polygonIntersectLine(
           x, y,
+          this.points,
           nodeX,
           nodeY,
-          width, height,
+          width / 2, height / 2,
           padding )
-      ;
+          ;
     },
 
-    checkPoint: function(
-        x, y, padding, width, height, centerX, centerY ){
-
-      var cornerRadius = math.getRoundTriangleRadius( width, height );
-      var diam = cornerRadius * 2;
-
-      // Check box
-      if ( math.pointInsidePolygon(x, y, this.points,
-          centerX, centerY + cornerRadius * 0.5, width - diam, height - cornerRadius, [0, -1], padding ) ){
-        return true;
-      }
-
-      // Todo: Add checks for the cirles around the edges
-
-      return false;
+    checkPoint: function( x, y, padding, width, height, centerX, centerY ){
+      return math.pointInsidePolygon( x, y, this.points,
+          centerX, centerY, width, height, [0, -1], padding )
+          ;
     }
   } );
 };
-
 
 BRp.generateRoundRectangle = function(){
   return ( this.nodeShapes['round-rectangle'] = this.nodeShapes['roundrectangle'] = {
@@ -497,7 +486,7 @@ BRp.registerNodeShapes = function(){
 
   this.generatePolygon( 'triangle', math.generateUnitNgonPointsFitToSquare( 3, 0 ) );
 
-  this.generateRoundTriangle();
+  this.generateRoundPolygon('round-triangle', math.generateUnitNgonPointsFitToSquare(3, 0));
 
   this.generatePolygon( 'rectangle', math.generateUnitNgonPointsFitToSquare( 4, 0 ) );
   nodeShapes[ 'square' ] = nodeShapes[ 'rectangle' ];

--- a/src/extensions/renderer/canvas/drawing-shapes.js
+++ b/src/extensions/renderer/canvas/drawing-shapes.js
@@ -20,28 +20,37 @@ CRp.drawPolygonPath = function(
   context.closePath();
 };
 
-CRp.drawRoundTrianglePath = function(
-  context, x, y, width, height) {
+CRp.drawRoundPolygonPath = function(
+    context, x, y, width, height, points ){
 
-  var cornerRadius = math.getRoundTriangleRadius( width, height );
-  var halfWidth = width / 2;
-  var halfHeight = height / 2;
-  var quarterWidth = width / 4;
+    var halfW = width / 2;
+    var halfH = height / 2;
+    var cornerRadius = math.getRoundPolygonRadius( width, height );
 
-  if( context.beginPath ){ context.beginPath(); }
+    const midPoint = ( i0, i1 ) => {
+        return {
+            x: x + halfW * 0.5 * ( points[ i0 * 2 ] + points[ i1 * 2 ] ),
+            y: y + halfH * 0.5 * ( points[ i0 * 2 + 1 ] + points[ i1 * 2 + 1 ] )
+        };
+    };
 
-  // Start at bottom middle
-  context.moveTo( x, y + halfHeight );
-  // Arc from bottom middle to left middle
-  context.arcTo(x - halfWidth, y + halfHeight, x - quarterWidth, y, cornerRadius);
-  // Arc from bottom left to right middle
-  context.arcTo(x, y - halfHeight, x + quarterWidth, y, cornerRadius);
-  // Arc from bottom right to bottom middle
-  context.arcTo(x + halfWidth, y + halfHeight, x, y + halfHeight, cornerRadius);
-  // Join line
-  context.lineTo(x, y + halfHeight);
+    if( context.beginPath ){ context.beginPath(); }
 
-  context.closePath();
+    const lastIndex = (points.length / 2) - 1;
+
+    // We start from the mid point between the last and the first
+    let m = midPoint(lastIndex, 0);
+    context.moveTo( m.x, m.y );
+
+    for( var i = 0; i < (points.length / 2) - 1; i++ ){
+        m = midPoint(i, i + 1);
+        context.arcTo(x + halfW * points[i * 2], y + halfH *  points[i * 2 + 1], m.x, m.y, cornerRadius);
+    }
+
+    m = midPoint(lastIndex, 0);
+    context.arcTo(x + halfW * points[lastIndex * 2], y + halfH * points[lastIndex * 2 + 1], m.x, m.y, cornerRadius);
+
+    context.closePath();
 };
 
 // Round rectangle drawing

--- a/src/extensions/renderer/canvas/drawing-shapes.js
+++ b/src/extensions/renderer/canvas/drawing-shapes.js
@@ -20,6 +20,30 @@ CRp.drawPolygonPath = function(
   context.closePath();
 };
 
+CRp.drawRoundTrianglePath = function(
+  context, x, y, width, height) {
+
+  var cornerRadius = math.getRoundTriangleRadius( width, height );
+  var halfWidth = width / 2;
+  var halfHeight = height / 2;
+  var quarterWidth = width / 4;
+
+  if( context.beginPath ){ context.beginPath(); }
+
+  // Start at bottom middle
+  context.moveTo( x, y + halfHeight );
+  // Arc from bottom middle to left middle
+  context.arcTo(x - halfWidth, y + halfHeight, x - quarterWidth, y, cornerRadius);
+  // Arc from bottom left to right middle
+  context.arcTo(x, y - halfHeight, x + quarterWidth, y, cornerRadius);
+  // Arc from bottom right to bottom middle
+  context.arcTo(x + halfWidth, y + halfHeight, x, y + halfHeight, cornerRadius);
+  // Join line
+  context.lineTo(x, y + halfHeight);
+
+  context.closePath();
+};
+
 // Round rectangle drawing
 CRp.drawRoundRectanglePath = function(
   context, x, y, width, height ){

--- a/src/extensions/renderer/canvas/drawing-shapes.js
+++ b/src/extensions/renderer/canvas/drawing-shapes.js
@@ -23,32 +23,41 @@ CRp.drawPolygonPath = function(
 CRp.drawRoundPolygonPath = function(
     context, x, y, width, height, points ){
 
-    var halfW = width / 2;
-    var halfH = height / 2;
-    var cornerRadius = math.getRoundPolygonRadius( width, height );
-
-    const midPoint = ( i0, i1 ) => {
-        return {
-            x: x + halfW * 0.5 * ( points[ i0 * 2 ] + points[ i1 * 2 ] ),
-            y: y + halfH * 0.5 * ( points[ i0 * 2 + 1 ] + points[ i1 * 2 + 1 ] )
-        };
-    };
+    const halfW = width / 2;
+    const halfH = height / 2;
+    const cornerRadius = math.getRoundPolygonRadius( width, height );
 
     if( context.beginPath ){ context.beginPath(); }
 
-    const lastIndex = (points.length / 2) - 1;
+    for ( let i = 0; i < points.length / 4; i++ ){
+        let sourceUv, destUv;
+        if ( i === 0 ) {
+            sourceUv = points.length - 2;
+        } else {
+            sourceUv = i * 4 - 2;
+        }
+        destUv = i * 4 + 2;
 
-    // We start from the mid point between the last and the first
-    let m = midPoint(lastIndex, 0);
-    context.moveTo( m.x, m.y );
+        const px = x + halfW * points[ i * 4 ];
+        const py = y + halfH * points[ i * 4 + 1 ];
 
-    for( var i = 0; i < (points.length / 2) - 1; i++ ){
-        m = midPoint(i, i + 1);
-        context.arcTo(x + halfW * points[i * 2], y + halfH *  points[i * 2 + 1], m.x, m.y, cornerRadius);
+
+        const cosTheta = (-points[ sourceUv ] * points[ destUv ] - points[ sourceUv + 1 ] * points[ destUv + 1]);
+        const offset = cornerRadius / Math.tan(Math.acos(cosTheta) / 2);
+
+        const cp0x = px - offset * points[ sourceUv ];
+        const cp0y = py - offset * points[ sourceUv + 1 ];
+        const cp1x = px + offset * points[ destUv ];
+        const cp1y = py + offset * points[ destUv + 1 ];
+
+        if (i === 0) {
+            context.moveTo( cp0x, cp0y );
+        } else {
+            context.lineTo( cp0x, cp0y );
+        }
+
+        context.arcTo( px, py, cp1x, cp1y, cornerRadius );
     }
-
-    m = midPoint(lastIndex, 0);
-    context.arcTo(x + halfW * points[lastIndex * 2], y + halfH * points[lastIndex * 2 + 1], m.x, m.y, cornerRadius);
 
     context.closePath();
 };

--- a/src/extensions/renderer/canvas/node-shapes.js
+++ b/src/extensions/renderer/canvas/node-shapes.js
@@ -6,6 +6,9 @@ CRp.nodeShapeImpl = function( name, context, centerX, centerY, width, height, po
       return this.drawEllipsePath( context, centerX, centerY, width, height );
     case 'polygon':
       return this.drawPolygonPath( context, centerX, centerY, width, height, points );
+    case 'roundtriangle':
+    case 'round-triangle':
+      return this.drawRoundTrianglePath(context, centerX, centerY, width, height, points );
     case 'roundrectangle':
     case 'round-rectangle':
       return this.drawRoundRectanglePath( context, centerX, centerY, width, height );

--- a/src/extensions/renderer/canvas/node-shapes.js
+++ b/src/extensions/renderer/canvas/node-shapes.js
@@ -6,9 +6,8 @@ CRp.nodeShapeImpl = function( name, context, centerX, centerY, width, height, po
       return this.drawEllipsePath( context, centerX, centerY, width, height );
     case 'polygon':
       return this.drawPolygonPath( context, centerX, centerY, width, height, points );
-    case 'roundtriangle':
-    case 'round-triangle':
-      return this.drawRoundTrianglePath(context, centerX, centerY, width, height, points );
+    case 'round-polygon':
+      return this.drawRoundPolygonPath(context, centerX, centerY, width, height, points );
     case 'roundrectangle':
     case 'round-rectangle':
       return this.drawRoundRectanglePath( context, centerX, centerY, width, height );

--- a/src/math.js
+++ b/src/math.js
@@ -371,119 +371,6 @@ export const boundingBoxInBoundingBox = ( bb1, bb2 ) => (
   && inBoundingBox( bb1, bb2.x2, bb2.y2 )
 );
 
-export const roundTriangleIntersectLine = ( x, y, nodeX, nodeY, width, height, padding ) => {
-
-  let cornerRadius = getRoundTriangleRadius( width, height );
-
-  let halfWidth = width / 2;
-  let halfHeight = height / 2;
-
-  // Check intersections with straight line segments
-  let straightLineIntersections;
-
-  // Bottom segment left to right
-  {
-    let bottomStartX = nodeX - halfWidth + cornerRadius - padding;
-    let bottomStartY = nodeY + halfHeight + padding;
-    let bottomEndX = nodeX + halfWidth - cornerRadius + padding;
-    let bottomEndY = bottomStartY;
-
-    straightLineIntersections = finiteLinesIntersect(
-        x, y, nodeX, nodeY, bottomStartX, bottomStartY, bottomEndX, bottomEndY, false );
-
-    if( straightLineIntersections.length > 0 ){
-      return straightLineIntersections;
-    }
-  }
-
-  // Left segment left/bottom to right/top
-  {
-    let leftStartX = nodeX - halfWidth + cornerRadius - padding;
-    let leftStartY = nodeY + halfHeight - cornerRadius + padding;
-    let leftEndX = nodeX - cornerRadius;
-    let leftEndY = nodeY - halfHeight + cornerRadius - padding;
-
-    straightLineIntersections = finiteLinesIntersect(
-        x, y, nodeX, nodeY, leftStartX, leftStartY, leftEndX, leftEndY, false );
-
-    if( straightLineIntersections.length > 0 ){
-      return straightLineIntersections;
-    }
-  }
-
-  // Right segment left/top to right/bottom
-  {
-    let rightStartX = nodeX + cornerRadius;
-    let rightStartY = nodeY - halfHeight + cornerRadius - padding;
-    let rightEndX = nodeX + halfWidth - cornerRadius + padding;
-    let rightEndY = nodeY + halfHeight - cornerRadius + padding;
-
-    straightLineIntersections = finiteLinesIntersect(
-        x, y, nodeX, nodeY, rightStartX, rightStartY, rightEndX, rightEndY, false );
-
-    if( straightLineIntersections.length > 0 ){
-      return straightLineIntersections;
-    }
-  }
-
-  // Check intersections with arc segments
-  let arcIntersections;
-
-  // Top
-  {
-    let topCenterX = nodeX;
-    let topCenterY = nodeY - halfHeight + cornerRadius;
-    arcIntersections = intersectLineCircle(
-        x, y, nodeX, nodeY,
-        topCenterX, topCenterY, cornerRadius + padding );
-
-    // Ensure the intersection is on the desired third of the circle
-    // Todo: Check this validation
-    if( arcIntersections.length > 0
-        && arcIntersections[0] <= topCenterX
-        && arcIntersections[1] <= topCenterY ){
-      return [ arcIntersections[0], arcIntersections[1] ];
-    }
-  }
-
-  // Left
-  {
-    let leftCenterX = nodeX - halfWidth + cornerRadius;
-    let leftCenterY = nodeY + halfHeight - cornerRadius;
-    arcIntersections = intersectLineCircle(
-        x, y, nodeX, nodeY,
-        leftCenterX, leftCenterY, cornerRadius + padding );
-
-    // Ensure the intersection is on the desired third of the circle
-    // Todo: Check this validation
-    if( arcIntersections.length > 0
-        && arcIntersections[0] <= leftCenterX
-        && arcIntersections[1] <= leftCenterY ){
-      return [ arcIntersections[0], arcIntersections[1] ];
-    }
-  }
-
-  // Right
-  {
-    let rightCenterX = nodeX + halfWidth - cornerRadius;
-    let rightCenterY = nodeY + halfHeight - cornerRadius;
-    arcIntersections = intersectLineCircle(
-        x, y, nodeX, nodeY,
-        rightCenterX, rightCenterY, cornerRadius + padding );
-
-    // Ensure the intersection is on the desired third of the circle
-    // Todo: Check this validation
-    if( arcIntersections.length > 0
-        && arcIntersections[0] <= rightCenterX
-        && arcIntersections[1] <= rightCenterY ){
-      return [ arcIntersections[0], arcIntersections[1] ];
-    }
-  }
-
-  return []; // if nothing
-
-};
-
 export const roundRectangleIntersectLine = ( x, y, nodeX, nodeY, width, height, padding ) => {
 
   let cornerRadius = getRoundRectangleRadius( width, height );
@@ -1346,7 +1233,7 @@ export const getRoundRectangleRadius = ( width, height ) =>
   Math.min( width / 4, height / 4, 8 );
 
 // Set the default radius
-export const getRoundTriangleRadius = ( width, height ) =>
+export const getRoundPolygonRadius = (width, height ) =>
     Math.min( width / 10, height / 10, 8 );
 
 export const getCutRectangleCornerLength = () => 8;

--- a/src/math.js
+++ b/src/math.js
@@ -808,6 +808,49 @@ export const pointInsidePolygon = ( x, y, basePoints, centerX, centerY, width, h
   return pointInsidePolygonPoints( x, y, points );
 };
 
+export const pointInsideRoundPolygon = ( x, y, basePoints, centerX, centerY, width, height ) => {
+  const cutPolygonPoints = new Array( basePoints.length);
+  const halfW = width / 2;
+  const halfH = height / 2;
+  const cornerRadius = getRoundPolygonRadius(width, height);
+  const squaredCornerRadius = cornerRadius * cornerRadius;
+
+  for ( let i = 0; i < basePoints.length / 4; i++ ){
+    let sourceUv, destUv;
+    if ( i === 0 ) {
+      sourceUv = basePoints.length - 2;
+    } else {
+      sourceUv = i * 4 - 2;
+    }
+    destUv = i * 4 + 2;
+
+    const px = centerX + halfW * basePoints[ i * 4 ];
+    const py = centerY + halfH * basePoints[ i * 4 + 1 ];
+    const cosTheta = (-basePoints[ sourceUv ] * basePoints[ destUv ] - basePoints[ sourceUv + 1 ] * basePoints[ destUv + 1]);
+    const offset = cornerRadius / Math.tan(Math.acos(cosTheta) / 2);
+
+    const cp0x = px - offset * basePoints[ sourceUv ];
+    const cp0y = py - offset * basePoints[ sourceUv + 1 ];
+    const cp1x = px + offset * basePoints[ destUv ];
+    const cp1y = py + offset * basePoints[ destUv + 1 ];
+    cutPolygonPoints[ i * 4] = cp0x;
+    cutPolygonPoints[ i * 4 + 1] = cp0y;
+    cutPolygonPoints[ i * 4 + 2] = cp1x;
+    cutPolygonPoints[ i * 4 + 3] = cp1y;
+
+    // Check intersection with rounded corner
+    const cx = cp0x + basePoints[sourceUv + 1] * cornerRadius;
+    const cy = cp0y - basePoints[sourceUv] * cornerRadius;
+
+    const squaredDistance = Math.pow(cx  - x, 2) + Math.pow(cy - y, 2);
+    if (squaredDistance <= squaredCornerRadius) {
+      return true;
+    }
+  }
+
+  return pointInsidePolygonPoints(x, y, cutPolygonPoints);
+};
+
 export const joinLines = ( lineSet ) => {
 
   let vertices = new Array( lineSet.length / 2 );
@@ -1142,6 +1185,84 @@ export const polygonIntersectLine = ( x, y, basePoints, centerX, centerY, width,
     if( intersection.length !== 0 ){
       intersections.push( intersection[0], intersection[1] );
     }
+  }
+
+  return intersections;
+};
+
+export const roundPolygonIntersectLine = ( x, y, basePoints, centerX, centerY, width, height, padding ) => {
+  let intersections = [];
+  let intersection;
+  let lines = new Array(basePoints.length);
+  const halfW = width / 2;
+  const halfH = height / 2;
+  const cornerRadius = getRoundPolygonRadius(width, height);
+
+  for ( let i = 0; i < basePoints.length / 4; i++ ){
+    let sourceUv, destUv;
+    if ( i === 0 ) {
+      sourceUv = basePoints.length - 2;
+    } else {
+      sourceUv = i * 4 - 2;
+    }
+    destUv = i * 4 + 2;
+
+    const px = centerX + halfW * basePoints[ i * 4 ];
+    const py = centerY + halfH * basePoints[ i * 4 + 1 ];
+
+
+    const cosTheta = (-basePoints[ sourceUv ] * basePoints[ destUv ] - basePoints[ sourceUv + 1 ] * basePoints[ destUv + 1]);
+    const offset = cornerRadius / Math.tan(Math.acos(cosTheta) / 2);
+
+    const cp0x = px - offset * basePoints[ sourceUv ];
+    const cp0y = py - offset * basePoints[ sourceUv + 1 ];
+    const cp1x = px + offset * basePoints[ destUv ];
+    const cp1y = py + offset * basePoints[ destUv + 1 ];
+
+    if (i === 0) {
+      lines[basePoints.length - 2] = cp0x;
+      lines[basePoints.length - 1] = cp0y;
+    } else {
+      lines[i * 4 - 2] = cp0x;
+      lines[i * 4 - 1] = cp0y;
+    }
+
+    lines[i * 4] = cp1x;
+    lines[i * 4 + 1] = cp1y;
+
+    // Check intersection with circle
+    const cx = cp0x + basePoints[sourceUv + 1] * cornerRadius;
+    const cy = cp0y - basePoints[sourceUv] * cornerRadius;
+    intersection = intersectLineCircle(x, y, centerX, centerY, cx, cy, cornerRadius);
+
+    if( intersection.length !== 0 ){
+      intersections.push( intersection[0], intersection[1] );
+    }
+  }
+
+  for( let i = 0; i < lines.length / 4; i++ ) {
+    intersection = finiteLinesIntersect(
+        x, y, centerX, centerY,
+        lines[i * 4], lines[i * 4 + 1],
+        lines[i * 4 + 2], lines[i * 4 + 3], false );
+
+    if( intersection.length !== 0 ){
+      intersections.push( intersection[0], intersection[1] );
+    }
+  }
+
+  if (intersections.length > 2) {
+    let lowestIntersection = [ intersections[0], intersections[1] ];
+    let lowestSquaredDistance = Math.pow(lowestIntersection[0] - x, 2) + Math.pow(lowestIntersection[1] - y, 2);
+    for ( let i = 1; i < intersections.length / 2; i++){
+      const squaredDistance = Math.pow(intersections[ i * 2 ] - x, 2) + Math.pow(intersections[ i * 2 + 1 ] - y, 2);
+      if ( squaredDistance <= lowestSquaredDistance ){
+        lowestIntersection[0] = intersections[ i * 2 ];
+        lowestIntersection[1] = intersections[ i * 2 + 1 ];
+        lowestSquaredDistance = squaredDistance;
+      }
+    }
+    return lowestIntersection;
   }
 
   return intersections;

--- a/src/math.js
+++ b/src/math.js
@@ -838,9 +838,16 @@ export const pointInsideRoundPolygon = ( x, y, basePoints, centerX, centerY, wid
     cutPolygonPoints[ i * 4 + 2] = cp1x;
     cutPolygonPoints[ i * 4 + 3] = cp1y;
 
-    // Check intersection with rounded corner
-    const cx = cp0x + basePoints[sourceUv + 1] * cornerRadius;
-    const cy = cp0y - basePoints[sourceUv] * cornerRadius;
+    let orthx = basePoints[ sourceUv + 1 ];
+    let orthy = -basePoints[ sourceUv ];
+    const cosAlpha = orthx * basePoints[ destUv ] + orthy * basePoints [ destUv + 1 ];
+    if (cosAlpha < 0) {
+      orthx *= -1;
+      orthy *= -1;
+    }
+
+    const cx = cp0x + orthx * cornerRadius;
+    const cy = cp0y + orthy * cornerRadius;
 
     const squaredDistance = Math.pow(cx  - x, 2) + Math.pow(cy - y, 2);
     if (squaredDistance <= squaredCornerRadius) {
@@ -1230,9 +1237,17 @@ export const roundPolygonIntersectLine = ( x, y, basePoints, centerX, centerY, w
     lines[i * 4] = cp1x;
     lines[i * 4 + 1] = cp1y;
 
-    // Check intersection with circle
-    const cx = cp0x + basePoints[sourceUv + 1] * cornerRadius;
-    const cy = cp0y - basePoints[sourceUv] * cornerRadius;
+    let orthx = basePoints[ sourceUv + 1 ];
+    let orthy = -basePoints[ sourceUv ];
+    const cosAlpha = orthx * basePoints[ destUv ] + orthy * basePoints [ destUv + 1 ];
+    if (cosAlpha < 0) {
+      orthx *= -1;
+      orthy *= -1;
+    }
+
+    const cx = cp0x + orthx * cornerRadius;
+    const cy = cp0y + orthy * cornerRadius;
+
     intersection = intersectLineCircle(x, y, centerX, centerY, cx, cy, cornerRadius);
 
     if( intersection.length !== 0 ){

--- a/src/math.js
+++ b/src/math.js
@@ -371,6 +371,119 @@ export const boundingBoxInBoundingBox = ( bb1, bb2 ) => (
   && inBoundingBox( bb1, bb2.x2, bb2.y2 )
 );
 
+export const roundTriangleIntersectLine = ( x, y, nodeX, nodeY, width, height, padding ) => {
+
+  let cornerRadius = getRoundTriangleRadius( width, height );
+
+  let halfWidth = width / 2;
+  let halfHeight = height / 2;
+
+  // Check intersections with straight line segments
+  let straightLineIntersections;
+
+  // Bottom segment left to right
+  {
+    let bottomStartX = nodeX - halfWidth + cornerRadius - padding;
+    let bottomStartY = nodeY + halfHeight + padding;
+    let bottomEndX = nodeX + halfWidth - cornerRadius + padding;
+    let bottomEndY = bottomStartY;
+
+    straightLineIntersections = finiteLinesIntersect(
+        x, y, nodeX, nodeY, bottomStartX, bottomStartY, bottomEndX, bottomEndY, false );
+
+    if( straightLineIntersections.length > 0 ){
+      return straightLineIntersections;
+    }
+  }
+
+  // Left segment left/bottom to right/top
+  {
+    let leftStartX = nodeX - halfWidth + cornerRadius - padding;
+    let leftStartY = nodeY + halfHeight - cornerRadius + padding;
+    let leftEndX = nodeX - cornerRadius;
+    let leftEndY = nodeY - halfHeight + cornerRadius - padding;
+
+    straightLineIntersections = finiteLinesIntersect(
+        x, y, nodeX, nodeY, leftStartX, leftStartY, leftEndX, leftEndY, false );
+
+    if( straightLineIntersections.length > 0 ){
+      return straightLineIntersections;
+    }
+  }
+
+  // Right segment left/top to right/bottom
+  {
+    let rightStartX = nodeX + cornerRadius;
+    let rightStartY = nodeY - halfHeight + cornerRadius - padding;
+    let rightEndX = nodeX + halfWidth - cornerRadius + padding;
+    let rightEndY = nodeY + halfHeight - cornerRadius + padding;
+
+    straightLineIntersections = finiteLinesIntersect(
+        x, y, nodeX, nodeY, rightStartX, rightStartY, rightEndX, rightEndY, false );
+
+    if( straightLineIntersections.length > 0 ){
+      return straightLineIntersections;
+    }
+  }
+
+  // Check intersections with arc segments
+  let arcIntersections;
+
+  // Top
+  {
+    let topCenterX = nodeX;
+    let topCenterY = nodeY - halfHeight + cornerRadius;
+    arcIntersections = intersectLineCircle(
+        x, y, nodeX, nodeY,
+        topCenterX, topCenterY, cornerRadius + padding );
+
+    // Ensure the intersection is on the desired third of the circle
+    // Todo: Check this validation
+    if( arcIntersections.length > 0
+        && arcIntersections[0] <= topCenterX
+        && arcIntersections[1] <= topCenterY ){
+      return [ arcIntersections[0], arcIntersections[1] ];
+    }
+  }
+
+  // Left
+  {
+    let leftCenterX = nodeX - halfWidth + cornerRadius;
+    let leftCenterY = nodeY + halfHeight - cornerRadius;
+    arcIntersections = intersectLineCircle(
+        x, y, nodeX, nodeY,
+        leftCenterX, leftCenterY, cornerRadius + padding );
+
+    // Ensure the intersection is on the desired third of the circle
+    // Todo: Check this validation
+    if( arcIntersections.length > 0
+        && arcIntersections[0] <= leftCenterX
+        && arcIntersections[1] <= leftCenterY ){
+      return [ arcIntersections[0], arcIntersections[1] ];
+    }
+  }
+
+  // Right
+  {
+    let rightCenterX = nodeX + halfWidth - cornerRadius;
+    let rightCenterY = nodeY + halfHeight - cornerRadius;
+    arcIntersections = intersectLineCircle(
+        x, y, nodeX, nodeY,
+        rightCenterX, rightCenterY, cornerRadius + padding );
+
+    // Ensure the intersection is on the desired third of the circle
+    // Todo: Check this validation
+    if( arcIntersections.length > 0
+        && arcIntersections[0] <= rightCenterX
+        && arcIntersections[1] <= rightCenterY ){
+      return [ arcIntersections[0], arcIntersections[1] ];
+    }
+  }
+
+  return []; // if nothing
+
+};
+
 export const roundRectangleIntersectLine = ( x, y, nodeX, nodeY, width, height, padding ) => {
 
   let cornerRadius = getRoundRectangleRadius( width, height );
@@ -1231,6 +1344,10 @@ export const generateUnitNgonPoints = ( sides, rotationRadians ) => {
 // Set the default radius, unless half of width or height is smaller than default
 export const getRoundRectangleRadius = ( width, height ) =>
   Math.min( width / 4, height / 4, 8 );
+
+// Set the default radius
+export const getRoundTriangleRadius = ( width, height ) =>
+    Math.min( width / 10, height / 10, 8 );
 
 export const getCutRectangleCornerLength = () => 8;
 

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -65,8 +65,8 @@ const styfn = {};
     textBackgroundShape: { enums: [ 'rectangle', 'roundrectangle', 'round-rectangle' ]},
     nodeShape: { enums: [
       'rectangle', 'roundrectangle', 'round-rectangle', 'cutrectangle', 'cut-rectangle', 'bottomroundrectangle', 'bottom-round-rectangle', 'barrel',
-      'ellipse', 'triangle', 'round-triangle', 'square', 'pentagon', 'hexagon', 'concavehexagon', 'concave-hexagon', 'heptagon', 'octagon',
-      'tag', 'star', 'diamond', 'vee', 'rhomboid', 'polygon'
+      'ellipse', 'triangle', 'round-triangle', 'square', 'pentagon', 'round-pentagon', 'hexagon', 'round-hexagon', 'concavehexagon', 'concave-hexagon', 'heptagon', 'round-heptagon', 'octagon', 'round-octagon',
+      'tag', 'round-tag', 'star', 'diamond', 'round-diamond', 'vee', 'rhomboid', 'polygon',
     ] },
     compoundIncludeLabels: { enums: [ 'include', 'exclude' ] },
     arrowShape: { enums: [ 'tee', 'triangle', 'triangle-tee', 'triangle-cross', 'triangle-backcurve', 'vee', 'square', 'circle', 'diamond', 'chevron', 'none' ] },

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -65,7 +65,7 @@ const styfn = {};
     textBackgroundShape: { enums: [ 'rectangle', 'roundrectangle', 'round-rectangle' ]},
     nodeShape: { enums: [
       'rectangle', 'roundrectangle', 'round-rectangle', 'cutrectangle', 'cut-rectangle', 'bottomroundrectangle', 'bottom-round-rectangle', 'barrel',
-      'ellipse', 'triangle', 'square', 'pentagon', 'hexagon', 'concavehexagon', 'concave-hexagon', 'heptagon', 'octagon',
+      'ellipse', 'triangle', 'roundtriangle', 'round-triangle', 'square', 'pentagon', 'hexagon', 'concavehexagon', 'concave-hexagon', 'heptagon', 'octagon',
       'tag', 'star', 'diamond', 'vee', 'rhomboid', 'polygon'
     ] },
     compoundIncludeLabels: { enums: [ 'include', 'exclude' ] },

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -65,7 +65,7 @@ const styfn = {};
     textBackgroundShape: { enums: [ 'rectangle', 'roundrectangle', 'round-rectangle' ]},
     nodeShape: { enums: [
       'rectangle', 'roundrectangle', 'round-rectangle', 'cutrectangle', 'cut-rectangle', 'bottomroundrectangle', 'bottom-round-rectangle', 'barrel',
-      'ellipse', 'triangle', 'roundtriangle', 'round-triangle', 'square', 'pentagon', 'hexagon', 'concavehexagon', 'concave-hexagon', 'heptagon', 'octagon',
+      'ellipse', 'triangle', 'round-triangle', 'square', 'pentagon', 'hexagon', 'concavehexagon', 'concave-hexagon', 'heptagon', 'octagon',
       'tag', 'star', 'diamond', 'vee', 'rhomboid', 'polygon'
     ] },
     compoundIncludeLabels: { enums: [ 'include', 'exclude' ] },


### PR DESCRIPTION
Feature request: Add the following rounded node shapes: round-triangle, round-diamond, round-pentagon, round-hexagon, round-heptagon, round-octagon, round-tag

OP follows:

-- 


I would like to add a new shape, would something like this be accepted into the code base (once finished)?


![round-triangle-vs-triangle](https://user-images.githubusercontent.com/3845764/62808354-753c9280-babd-11e9-8c3f-5902c8efc8d7.png)
