### PR TITLE
Fix label split so to avoid to render empty lines

### DIFF
--- a/src/extensions/renderer/base/coord-ele-math/labels.js
+++ b/src/extensions/renderer/base/coord-ele-math/labels.js
@@ -387,7 +387,9 @@ BRp.getLabelText = function( ele, prefix ){
           if( testW <= maxW ){ // word fits on current line
             subline += word + wordSeparator;
           } else { // word starts new line
-            wrappedLines.push( subline );
+            if( subline ){
+              wrappedLines.push( subline );
+            }
             subline = word + wordSeparator;
           }
         }


### PR DESCRIPTION
If you try to create a label with long unsplittable name in the first line, it tries to split it, push an empty line as first line and renders the whole string in the second line.

This PR adds the logic to avoid to render the first line empty in the label.