### PR TITLE
Add Eulerian trail search algorithm

### DIFF
--- a/documentation/docmaker.json
+++ b/documentation/docmaker.json
@@ -3235,7 +3235,23 @@
                 }
               ],
               "md": "collection/bellmanFord"
-            }
+            },
+
+            {
+              "name": "eles.hierholzer",
+              "descr": "Perform the [Hierholzer](https://en.wikipedia.org/wiki/Eulerian_path#Hierholzer's_algorithm) search algorithm on the elements in the collection. This finds Eulerian trails and circuits.",
+              "formats": [
+                {
+                  "args": [
+                    { "name": "options", "fields": [
+                      { "name": "root", "descr": "The root node (selector or collection) where the search starts.", "optional": true },
+                      { "name": "directed", "descr": "A boolean indicating whether the algorithm should only go along edges from source to target (default `false`).", "optional": true }
+                    ] }
+                  ]
+                }
+              ],
+              "md": "collection/hierholzer"
+            },
 
           ]
         },

--- a/documentation/md/collection/hierholzer.md
+++ b/documentation/md/collection/hierholzer.md
@@ -1,0 +1,26 @@
+## Details
+
+Note that this function performs Hierholzer's algorithm on only the subset of the graph in the calling collection.
+
+This function returns an object of the following form:
+
+```js
+{
+  found, /* true or false */
+  trail /* Ordered collection of elements in the Eulerian trail or cycle, if found */
+}
+```
+
+Regarding optional options:
+
+* If no root node is provided, the first node in the collection will be taken as the starting node in the algorithm.
+* The graph is assumed to be undirected unless specified otherwise.
+
+
+## Examples
+
+```js
+var hierholzer = cy.elements().hierholzer({ root: "#j", directed: true });
+
+hierholzer.trail.select();
+```

--- a/package.json
+++ b/package.json
@@ -65,6 +65,11 @@
     {
       "name": "Josejulio Martínez",
       "url": "https://github.com/josejulio"
+    },
+    {
+      "name": "Rhys Balevicius",
+      "email": "rhysbalevicius@gmail.com",
+      "url": "https://github.com/r-ba"
     }
   ],
   "keywords": [

--- a/src/collection/algorithms/hierholzer.js
+++ b/src/collection/algorithms/hierholzer.js
@@ -2,7 +2,7 @@ import * as is from '../../is';
 import { defaults } from '../../util';
 
 const hierholzerDefaults = defaults({
-  root: false,
+  root: undefined,
   directed: false
 });
 
@@ -18,7 +18,7 @@ let elesfn = ({
     let oddIn;
     let oddOut;
     let startVertex;
-    if (root) startVertex = root.slice(1);
+    if (root) startVertex = is.string(root) ? this.filter(root)[0].id() : root[0].id();
     let nodes = {};
     let edges = {};
 
@@ -66,15 +66,12 @@ let elesfn = ({
     }
 
     let result = {
-      pathExists: false,
-      circuitExists: false,
-      connected: undefined,
+      found: false,
       trail: undefined
     };
 
     if (dflag) return result;
     else if (oddOut && oddIn) {
-      result.pathExists = true;
       if (directed) {
         if (startVertex && (oddOut != startVertex)) {
           return result;
@@ -88,7 +85,6 @@ let elesfn = ({
         }
       }
     } else {
-      result.circuitExists = true;
       if (!startVertex) startVertex = eles[0].id();
     }
 
@@ -128,11 +124,10 @@ let elesfn = ({
 
     for (let d in nodes) {
       if (nodes[d].length) {
-        result.connected = false;
         return result;
       }
     }
-    result.connected = true;
+    result.found = true;
     result.trail = this.spawn( trail );
     return result;
   },

--- a/src/collection/algorithms/hierholzer.js
+++ b/src/collection/algorithms/hierholzer.js
@@ -22,34 +22,54 @@ let elesfn = ({
     if (root) startVertex = root.slice(1); // remove #
     let nodes = {}; // nodeId -> [...edgeIds]
     let edges = {}; // edgeId -> [source, target]
+
     // setup ds for alg and check if not eulerian
-    eles.forEach(function(ele){
-      let id = ele.id();
-      if(ele.isNode()) {
-        let ind = ele.indegree(true);
-        let outd = ele.outdegree(true);
-        let d1 = ind - outd;
-        let d2 = outd - ind;
-        // ensure existence: either all nodes have ind==outd, or
-        // exactly one has ind-outd==1 and exactly one has outd-ind==1
-        if (d1 == 1) {
-          if (oddIn) dflag = true;
-          else oddIn = id; // terminal node
-        } else if (d2 == 1) {
-          if (oddOut) dflag = true;
-          else oddOut = id; // startVertex
-        } else if ((d2 > 1) || (d1 > 1)) {
-          dflag = true;
-        }
-        // collect the ids of each outgoing edge
-        nodes[id] = [];
-        ele.outgoers().forEach(e => {
-          if (e.isEdge()) nodes[id].push(e.id());
-        });
-      } else {
-        edges[id] = ele.target().id();
-      };
-    });
+    if (directed) {
+      eles.forEach(function(ele){
+        let id = ele.id();
+        if(ele.isNode()) {
+          let ind = ele.indegree(true);
+          let outd = ele.outdegree(true);
+          let d1 = ind - outd;
+          let d2 = outd - ind;
+          // ensure existence: either all nodes have ind==outd, or
+          // exactly one has ind-outd==1 and exactly one has outd-ind==1
+          if (d1 == 1) {
+            if (oddIn) dflag = true;
+            else oddIn = id; // terminal node
+          } else if (d2 == 1) {
+            if (oddOut) dflag = true;
+            else oddOut = id; // startVertex
+          } else if ((d2 > 1) || (d1 > 1)) {
+            dflag = true;
+          }
+          // collect the ids of each outgoing edge
+          nodes[id] = [];
+          ele.outgoers().forEach(e => {
+            if (e.isEdge()) nodes[id].push(e.id());
+          });
+        } else {
+          edges[id] = [undefined, ele.target().id()];
+        };
+      });
+    } else {
+      eles.forEach(function(ele){
+        let id = ele.id();
+        if(ele.isNode()) {
+          let d = ele.degree(true);
+          // ensure existence: more than two vertices with odd degree => not eulerian
+          if (d%2) {
+            if (!oddIn) oddIn = id;
+            else if (!oddOut) oddOut = id;
+            else dflag = true;
+          };
+          nodes[id] = [];
+          ele.connectedEdges().forEach(e => nodes[id].push(e.id()));
+        } else {
+          edges[id] = [ele.source().id(), ele.target().id()];
+        };
+      });
+    };
 
     let result = {
       pathExists: false,
@@ -65,28 +85,40 @@ let elesfn = ({
     // if an eulerian circuit exists then any starting node can be used
     if (oddOut && oddIn) {
       result.pathExists = true;
-      // ensure root provided is oddOut
-      if (startVertex && (oddOut != startVertex)) {
-        return result;
-      }
-      startVertex = oddOut;
+      if (directed) {
+        // ensure root provided is oddOut
+        if (startVertex && (oddOut != startVertex)) {
+          return result;
+        };
+        startVertex = oddOut;
+      } else {
+        if (startVertex && (oddOut != startVertex) && (oddIn != startVertex)) {
+          return result;
+        } else if (!startVertex) {
+          startVertex = oddOut;
+        };
+      };
     } else {
       result.circuitExists = true;
       if (!startVertex) startVertex = eles[0].id();
-    }
+    };
 
     const walk = (v) => {
       let currentNode = v;
       let subtour = [v];
-      let adj, adjHead;
+      let adj, adjTail, adjHead;
       while (nodes[currentNode].length) {
         adj = nodes[currentNode].shift();
-        adjHead = edges[adj];
+        adjTail = edges[adj][0];
+        adjHead = edges[adj][1];
         // if adj is not loop, remove other ref to edge
         if (currentNode != adjHead) {
           nodes[adjHead] = nodes[adjHead].filter(e => e != adj);
           currentNode = adjHead;
-        }
+        } else if (!directed && (currentNode != adjTail)) {
+          nodes[adjTail] = nodes[adjTail].filter(e => e != adj);
+          currentNode = adjTail;
+        };
         subtour.unshift(adj);
         subtour.unshift(currentNode);
       }

--- a/src/collection/algorithms/hierholzer.js
+++ b/src/collection/algorithms/hierholzer.js
@@ -1,0 +1,123 @@
+import * as is from '../../is';
+import { defaults } from '../../util';
+
+const hierholzerDefaults = defaults({
+  root: false,
+  directed: false
+});
+
+let elesfn = ({
+  hierholzer: function( options ){
+    if (!is.plainObject(options)) {
+      let args = arguments;
+      options = { root: args[0],   directed: args[1] };
+    }
+    let { root, directed } = hierholzerDefaults(options);
+
+    let eles = this;
+    let dflag = false;
+    let oddIn; // first vertex found with ind-outd == 1
+    let oddOut; // first vertex found with outd-ind == 1
+    let startVertex;
+    if (root) startVertex = root.slice(1); // remove #
+    let degrees = {}; // id -> array of outgoing edges
+    let edges = {}; // nodeId -> {nodeId : Edge}
+    // ensure existence of circuit/path
+    eles.forEach(function(ele){
+      let id = ele.id();
+      if(ele.isNode()) {
+        let ind = ele.indegree(true);
+        let outd = ele.outdegree(true);
+        let d1 = ind - outd;
+        let d2 = outd - ind;
+        if (d1 == 1) {
+          if (oddIn) dflag = true;
+          else oddIn = id; // terminal node
+        } else if (d2 == 1) {
+          if (oddOut) dflag = true;
+          else oddOut = id; // startVertex
+        } else if ((d2 > 1) || (d1 > 1)) {
+          dflag = true;
+        }
+        // collect the ids of each nodes targets
+        let outgoing = [];
+        cy.$("#"+id).outgoers().forEach(function(v) {
+          if (v.isNode()) outgoing.push(v.id());
+        });
+
+        // only track non-isolated vertices
+        if (ele.degree(true) > 0) {
+          degrees[id] = outgoing;
+          if (!startVertex) startVertex = id;
+        }
+      } else {
+        // store map of edges by source -> target
+        let source = ele.source().id();
+        if (!(source in edges)) edges[source] = {};
+        edges[source][ele.target().id()] = ele;
+      }
+    });
+
+    let result = {
+      pathExists: false,
+      circuitExists: false,
+      connected: undefined,
+      trail: undefined
+    };
+
+    // eulerian path/circuit does not exist
+    if (dflag) return result;
+
+    // if eulerian path exists then oddOut has to be our starting node
+    // otherwise, eulerian circuit exists and any starting node can be used
+    if (oddOut && oddIn) {
+      result.pathExists = true;
+      // ensure root provided is oddOut
+      if (startVertex && (oddOut != startVertex)) {
+        return result;
+      }
+      startVertex = oddOut;
+    } else {
+      result.circuitExists = true;
+    }
+
+    const walk = (v) => {
+      let currentNode = v;
+      let subtour = [v];
+      while (degrees[currentNode].length) {
+        subtour.unshift(degrees[currentNode][0]);
+        currentNode = degrees[currentNode].shift();
+      }
+      return subtour;
+    }
+
+    // generate path/circuit
+    let trail = [];
+    let subtour = [];
+    subtour = walk(startVertex);
+    while (subtour.length != 1) {
+      if (degrees[subtour[0]].length == 0) {
+        let target = subtour.shift();
+        let source = subtour[0];
+        trail.unshift(cy.getElementById(target));
+        trail.unshift(edges[source][target]);
+      } else {
+        subtour = walk(subtour.shift()).concat(subtour);
+      }
+    }
+    trail.unshift(cy.getElementById(subtour.shift())); // final node
+
+    // check connectedness
+    for (let d in degrees) {
+      if (degrees[d].length) {
+        result.connected = false;
+        return result;
+      }
+    }
+    result.connected = true;
+    result.trail = this.spawn( trail );
+    return result;
+  },
+});
+
+export default elesfn;

--- a/src/collection/algorithms/hierholzer.js
+++ b/src/collection/algorithms/hierholzer.js
@@ -13,17 +13,15 @@ let elesfn = ({
       options = { root: args[0],   directed: args[1] };
     }
     let { root, directed } = hierholzerDefaults(options);
-
     let eles = this;
     let dflag = false;
     let oddIn;
     let oddOut;
     let startVertex;
-    if (root) startVertex = root.slice(1); // remove #
-    let nodes = {}; // nodeId -> [...edgeIds]
-    let edges = {}; // edgeId -> [source, target]
+    if (root) startVertex = root.slice(1);
+    let nodes = {};
+    let edges = {};
 
-    // setup ds for alg and check if not eulerian
     if (directed) {
       eles.forEach(function(ele){
         let id = ele.id();
@@ -32,44 +30,40 @@ let elesfn = ({
           let outd = ele.outdegree(true);
           let d1 = ind - outd;
           let d2 = outd - ind;
-          // ensure existence: either all nodes have ind==outd, or
-          // exactly one has ind-outd==1 and exactly one has outd-ind==1
           if (d1 == 1) {
             if (oddIn) dflag = true;
-            else oddIn = id; // terminal node
+            else oddIn = id;
           } else if (d2 == 1) {
             if (oddOut) dflag = true;
-            else oddOut = id; // startVertex
+            else oddOut = id;
           } else if ((d2 > 1) || (d1 > 1)) {
             dflag = true;
           }
-          // collect the ids of each outgoing edge
           nodes[id] = [];
           ele.outgoers().forEach(e => {
             if (e.isEdge()) nodes[id].push(e.id());
           });
         } else {
           edges[id] = [undefined, ele.target().id()];
-        };
+        }
       });
     } else {
       eles.forEach(function(ele){
         let id = ele.id();
         if(ele.isNode()) {
           let d = ele.degree(true);
-          // ensure existence: more than two vertices with odd degree => not eulerian
           if (d%2) {
             if (!oddIn) oddIn = id;
             else if (!oddOut) oddOut = id;
             else dflag = true;
-          };
+          }
           nodes[id] = [];
           ele.connectedEdges().forEach(e => nodes[id].push(e.id()));
         } else {
           edges[id] = [ele.source().id(), ele.target().id()];
-        };
+        }
       });
-    };
+    }
 
     let result = {
       pathExists: false,
@@ -78,30 +72,25 @@ let elesfn = ({
       trail: undefined
     };
 
-    // eulerian path/circuit does not exist
     if (dflag) return result;
-
-    // if only an eulerian path exists then oddOut has to be our starting node
-    // if an eulerian circuit exists then any starting node can be used
-    if (oddOut && oddIn) {
+    else if (oddOut && oddIn) {
       result.pathExists = true;
       if (directed) {
-        // ensure root provided is oddOut
         if (startVertex && (oddOut != startVertex)) {
           return result;
-        };
+        }
         startVertex = oddOut;
       } else {
         if (startVertex && (oddOut != startVertex) && (oddIn != startVertex)) {
           return result;
         } else if (!startVertex) {
           startVertex = oddOut;
-        };
-      };
+        }
+      }
     } else {
       result.circuitExists = true;
       if (!startVertex) startVertex = eles[0].id();
-    };
+    }
 
     const walk = (v) => {
       let currentNode = v;
@@ -111,35 +100,32 @@ let elesfn = ({
         adj = nodes[currentNode].shift();
         adjTail = edges[adj][0];
         adjHead = edges[adj][1];
-        // if adj is not loop, remove other ref to edge
         if (currentNode != adjHead) {
           nodes[adjHead] = nodes[adjHead].filter(e => e != adj);
           currentNode = adjHead;
         } else if (!directed && (currentNode != adjTail)) {
           nodes[adjTail] = nodes[adjTail].filter(e => e != adj);
           currentNode = adjTail;
-        };
+        }
         subtour.unshift(adj);
         subtour.unshift(currentNode);
       }
       return subtour;
-    }
+    };
 
-    // generate path/circuit
     let trail = [];
     let subtour = [];
     subtour = walk(startVertex);
     while (subtour.length != 1) {
       if (nodes[subtour[0]].length == 0) {
-        trail.unshift(cy.getElementById(subtour.shift()));
-        trail.unshift(cy.getElementById(subtour.shift()));
+        trail.unshift(eles.getElementById(subtour.shift()));
+        trail.unshift(eles.getElementById(subtour.shift()));
       } else {
         subtour = walk(subtour.shift()).concat(subtour);
       }
     }
-    trail.unshift(cy.getElementById(subtour.shift())); // final node
+    trail.unshift(eles.getElementById(subtour.shift())); // final node
 
-    // check connectedness
     for (let d in nodes) {
       if (nodes[d].length) {
         result.connected = false;

--- a/src/collection/algorithms/index.js
+++ b/src/collection/algorithms/index.js
@@ -14,6 +14,7 @@ import markovClustering from './markov-clustering';
 import kClustering from './k-clustering';
 import hierarchicalClustering from './hierarchical-clustering';
 import affinityPropagation from './affinity-propagation';
+import hierholzer from './hierholzer';
 
 var elesfn = {};
 
@@ -32,7 +33,8 @@ var elesfn = {};
   markovClustering,
   kClustering,
   hierarchicalClustering,
-  affinityPropagation
+  affinityPropagation,
+  hierholzer
 ].forEach(function(props) {
   util.extend(elesfn, props);
 });

--- a/test/collection-hierholzer.js
+++ b/test/collection-hierholzer.js
@@ -1,0 +1,79 @@
+var expect = require('chai').expect;
+var cytoscape = require('../src/test.js', cytoscape);
+
+describe('Algorithms', function(){
+  describe('eles.hierholzer()', function(){
+
+    var cy;
+
+    beforeEach(function(done) {
+      cytoscape({
+        elements: {
+          nodes: [
+            { data: { id: '0', name: '0' } },
+            { data: { id: '1', name: '1' } },
+            { data: { id: '2', name: '2' } },
+            { data: { id: '3', name: '3' } },
+            { data: { id: '4', name: '4' } },
+            { data: { id: '5', name: '5' } },
+            { data: { id: '6', name: '6' } },
+            { data: { id: '7', name: '7' } },
+          ],
+
+          edges: [
+            { data: { source: '0', target: '1' } },
+            { data: { source: '0', target: '1' } },
+            { data: { source: '1', target: '2' } },
+            { data: { source: '1', target: '2' } },
+            { data: { source: '2', target: '3' } },
+            { data: { source: '2', target: '3' } },
+            { data: { source: '0', target: '6' } },
+            { data: { source: '2', target: '0' } },
+            { data: { source: '3', target: '4' } },
+            { data: { source: '3', target: '4' } },
+            { data: { source: '4', target: '2' } },
+            { data: { source: '4', target: '5' } },
+            { data: { source: '4', target: '5' } },
+            { data: { source: '5', target: '0' } },
+            { data: { source: '5', target: '0' } },
+            { data: { source: '6', target: '4' } }
+          ]
+        },
+
+        ready: function(){
+          cy = this;
+          done();
+        }
+      });
+    });
+
+    function ele2id( ele ){
+      return ele.id();
+    }
+
+    function isNode( ele ){
+      return ele.isNode();
+    }
+
+    it('eles.hierholzer(): directed', function(){
+      var options = {
+        root: "#0",
+        directed: true
+      };
+      var res = cy.elements().hierholzer(options);
+      expect(res.found).to.equal(true);
+      expect(res.trail.stdFilter(isNode).map(ele2id)).to.deep.equal(["0", "1", "2", "3", "4", "5", "6"]);
+    });
+
+    it('eles.hierholzer(): undirected', function(){
+      var options = {
+        root: "#0",
+        directed: false
+      };
+      var res = cy.elements().hierholzer(options);
+      expect(res.found).to.equal(true);
+      expect(res.trail.stdFilter(isNode).map(ele2id)).to.deep.equal(["0", "1", "6", "4", "3", "2", "5"]);
+    });
+
+  });
+});


### PR DESCRIPTION
This pull request adds Hierholzer's algorithm as proposed in issue [#2186](https://github.com/cytoscape/cytoscape.js/issues/2186) (recently closed, presumably due to inactivity). In particular, it can find Eulerian trails and cycles in both directed and undirected multigraphs should they exist.

For the sake of transparency, it should be known that I am new to the PR game and as such am anticipating potentially extensive feedback for this contribution, although I've attempted to do my due diligence.