### PR TITLE
Fix hierholzer example

### DIFF
--- a/documentation/md/collection/hierholzer.md
+++ b/documentation/md/collection/hierholzer.md
@@ -20,7 +20,7 @@ Regarding optional options:
 ## Examples
 
 ```js
-var hierholzer = cy.elements().hierholzer({ root: "#j", directed: true });
+var hierholzer = cy.elements().hierholzer({ root: "#k", directed: true });
 
 hierholzer.trail.select();
 ```


### PR DESCRIPTION
When I wrote the hierholzer example in the documentation I was unaware of the fact that, on the official js.cytoscape.org page, the user could actually run this code snippet in their browser (neat!) 

Unfortunately the selector I arbitrarily chose here causes an error to be thrown in the console (which is to be expected since no eulerian trail exists starting from this node). 

The good news however is that this was easily rectified. My apologies.