### PR TITLE
Iterable support for collections

### DIFF
--- a/documentation/md/collection/collection.md
+++ b/documentation/md/collection/collection.md
@@ -8,4 +8,4 @@ console.log( cy.nodes()[0].data("weight") + ' == ' + weight ); // weight is the 
 
 You can ensure that you're reading from the element you want by using a [selector](#selectors) to narrow down the collection to one element (i.e. `eles.size() === 1`) or the [`eles.eq()`](#collection/iteration/eles.eq) function.
 
-Collections are iterable for modern browsers which support the [iteration protocols](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols). This allows for the use of features such as the spread operator, for-of loops, and destructuring. For more in-depth information about the protocols see [here](https://exploringjs.com/es6/ch_iteration.html).
+Also note that collections are iterable for modern browsers which support the [iteration protocols](https://exploringjs.com/es6/ch_iteration.html). This enables the use of features such as the spread operator, for-of loops, and destructuring.

--- a/documentation/md/collection/collection.md
+++ b/documentation/md/collection/collection.md
@@ -7,3 +7,5 @@ console.log( cy.nodes()[0].data("weight") + ' == ' + weight ); // weight is the 
 ```
 
 You can ensure that you're reading from the element you want by using a [selector](#selectors) to narrow down the collection to one element (i.e. `eles.size() === 1`) or the [`eles.eq()`](#collection/iteration/eles.eq) function.
+
+Collections are iterable for modern browsers which support the [iteration protocols](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols). This allows for the use of features such as the spread operator, for-of loops, and destructuring. For more in-depth information about the protocols see [here](https://exploringjs.com/es6/ch_iteration.html).

--- a/src/collection/index.js
+++ b/src/collection/index.js
@@ -105,6 +105,20 @@ let Collection = function( cy, elements, options ){
   if( createdElements ){
     this.restore();
   }
+
+  // define an iterable behaviour, e.g. for...of, spread syntax
+  this[Symbol.iterator] = function() {
+    return {
+      next: function() {
+        this._values = this._valueIterator.next();
+        !this._values.done ? this._values.value = this._values.value.ele : null;
+        return this._values;
+      },
+      _valueIterator: map.values(),
+      _values: undefined
+    };
+  };
+
 };
 
 // Functions

--- a/src/collection/index.js
+++ b/src/collection/index.js
@@ -105,20 +105,6 @@ let Collection = function( cy, elements, options ){
   if( createdElements ){
     this.restore();
   }
-
-  // define an iterable behaviour, e.g. for...of, spread syntax
-  this[Symbol.iterator] = function() { // eslint-disable-line no-undef
-    return {
-      next: function() {
-        this._values = this._valueIterator.next();
-        !this._values.done ? this._values.value = this._values.value.ele : null;
-        return this._values;
-      },
-      _valueIterator: map.values(),
-      _values: undefined
-    };
-  };
-
 };
 
 // Functions

--- a/src/collection/index.js
+++ b/src/collection/index.js
@@ -107,7 +107,7 @@ let Collection = function( cy, elements, options ){
   }
 
   // define an iterable behaviour, e.g. for...of, spread syntax
-  this[Symbol.iterator] = function() {
+  this[Symbol.iterator] = function() { // eslint-disable-line no-undef
     return {
       next: function() {
         this._values = this._valueIterator.next();

--- a/src/collection/iteration.js
+++ b/src/collection/iteration.js
@@ -122,4 +122,29 @@ let elesfn = ({
 
 elesfn.each = elesfn.forEach;
 
+// implement an iterator only for those instances which support Symbol.iterator
+if (typeof Symbol != "undefined" && typeof Symbol.iterator != "undefined") { // eslint-disable-line no-undef
+  elesfn[Symbol.iterator] = function() { // eslint-disable-line no-undef
+    let entry = { value: undefined, done: false };
+    let i = 0;
+    let length = this.length;
+
+    return {
+      next: () => {
+        if ( i < length ) {
+          entry.value = this[i++];
+        } else {
+          entry.value = undefined;
+          entry.done = true;
+        }
+
+        return entry;
+      },
+      [Symbol.iterator]: function() { // eslint-disable-line no-undef
+        return this;
+      }
+    };
+  };
+}
+
 export default elesfn;

--- a/src/collection/iteration.js
+++ b/src/collection/iteration.js
@@ -122,29 +122,34 @@ let elesfn = ({
 
 elesfn.each = elesfn.forEach;
 
-// implement an iterator only for those instances which support Symbol.iterator
-if (typeof Symbol != "undefined" && typeof Symbol.iterator != "undefined") { // eslint-disable-line no-undef
-  elesfn[Symbol.iterator] = function() { // eslint-disable-line no-undef
-    let entry = { value: undefined, done: false };
-    let i = 0;
-    let length = this.length;
+const defineSymbolIterator = () => {
+  const typeofUndef = typeof undefined;
+  const isIteratorSupported = typeof Symbol != typeofUndef && typeof Symbol.iterator != typeofUndef; // eslint-disable-line no-undef
 
-    return {
-      next: () => {
-        if ( i < length ) {
-          entry.value = this[i++];
-        } else {
-          entry.value = undefined;
-          entry.done = true;
+  if (isIteratorSupported) {
+    elesfn[Symbol.iterator] = function() { // eslint-disable-line no-undef
+      let entry = { value: undefined, done: false };
+      let i = 0;
+      let length = this.length;
+
+      return {
+        next: () => {
+          if ( i < length ) {
+            entry.value = this[i++];
+          } else {
+            entry.value = undefined;
+            entry.done = true;
+          }
+
+          return entry;
+        },
+        [Symbol.iterator]: function() { // eslint-disable-line no-undef
+          return this;
         }
-
-        return entry;
-      },
-      [Symbol.iterator]: function() { // eslint-disable-line no-undef
-        return this;
-      }
+      };
     };
-  };
-}
+  }
+};
+defineSymbolIterator();
 
 export default elesfn;

--- a/test/collection-iteration.js
+++ b/test/collection-iteration.js
@@ -77,7 +77,7 @@ describe('Collection iteration', function(){
     eles.forEach(function( ele, i ){
       ele.data( 'foo', vals[i] );
     });
-    
+
     var callback = function( prev, ele, i, eles ){
       expect( index++, 'i' ).to.equal( i );
 
@@ -112,6 +112,11 @@ describe('Collection iteration', function(){
     expect( [ ...cy.elements() ].map( ele => ele.id() ) ).to.deep.equal( [ "n1", "n2", "n3", "n1n2", "n2n3" ] );
     expect( [ ...cy.nodes() ].map( ele => ele.id() ) ).to.deep.equal( [ "n1", "n2", "n3" ] );
     expect( [ ...cy.edges() ].map( ele => ele.id() ) ).to.deep.equal( [ "n1n2", "n2n3" ] );
+
+    const it = cy.elements()[Symbol.iterator]();
+    for (let entry of it) if (entry.id() === "n3") break;
+    expect( [ ...it ].map( ele => ele.id() ) ).to.deep.equal( [ "n1n2", "n2n3" ] );
+    expect( [ ...it ] ).to.deep.equal( [] );
   });
 
 });

--- a/test/collection-iteration.js
+++ b/test/collection-iteration.js
@@ -107,4 +107,11 @@ describe('Collection iteration', function(){
     expect( cy.nodes().slice(1, -1).same( cy.$('#n2') ) ).to.be.true;
   });
 
+  it('eles [Symbol.iterator]', function() {
+    expect( [ ...cy.collection() ] ).to.deep.equal( [] );
+    expect( [ ...cy.elements() ].map( ele => ele.id() ) ).to.deep.equal( [ "n1", "n2", "n3", "n1n2", "n2n3" ] );
+    expect( [ ...cy.nodes() ].map( ele => ele.id() ) ).to.deep.equal( [ "n1", "n2", "n3" ] );
+    expect( [ ...cy.edges() ].map( ele => ele.id() ) ).to.deep.equal( [ "n1n2", "n2n3" ] );
+  });
+
 });


### PR DESCRIPTION
This PR implements an iterable behaviour for collections, as proposed in issue [#1365](https://github.com/cytoscape/cytoscape.js/issues/1365).

In terms of writing documentation for this some soft guidance would be greatly appreciated, as this falls a bit outside of the eles.method(...) convention.