### PR TITLE
Add support for negative `taxi-turn` values

### DIFF
--- a/debug/init.js
+++ b/debug/init.js
@@ -42,7 +42,9 @@ var cy, defaultSty, options;
       .selector('[source = "b"][target = "f"]')
         .style({
           'curve-style': 'taxi',
-          'taxi-direction': 'vertical'
+          'taxi-direction': 'vertical',
+          'taxi-turn': '-30px',
+          'edge-distances': 'node-position'
         })
   ;
 

--- a/debug/init.js
+++ b/debug/init.js
@@ -43,7 +43,7 @@ var cy, defaultSty, options;
         .style({
           'curve-style': 'taxi',
           'taxi-direction': 'vertical',
-          'taxi-turn': '-30px',
+          'taxi-turn': '-50%',
           'edge-distances': 'node-position'
         })
   ;

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -13589,7 +13589,7 @@ Sets the subject of the selector (e.g. <code>$node &gt; node</code> to select th
 </ul>
 </li>
 <li><strong><code>taxi-turn</code></strong> : The distance along the primary axis where the first turn is applied.<ul>
-<li>This value may be an absolute distance - positive number (e.g. <code>20px</code>) to indicate distance from the source or negative number (e.g. <code>-20px</code>) to indicate distance from the target or it may be a relative distance between the source and target (e.g. <code>50%</code>).</li>
+<li>This value may be an absolute distance (e.g. <code>20px</code>) or it may be a relative distance between the source and target (e.g. <code>50%</code>).</li>
 <li>Note that bundling may not work with an explicit direction (<code>upward</code>, <code>downward</code>, <code>leftward</code>, or <code>rightward</code>) in tandem with a turn distance specified in percent units.</li>
 </ul>
 </li>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -13589,7 +13589,7 @@ Sets the subject of the selector (e.g. <code>$node &gt; node</code> to select th
 </ul>
 </li>
 <li><strong><code>taxi-turn</code></strong> : The distance along the primary axis where the first turn is applied.<ul>
-<li>This value may be an absolute distance (e.g. <code>20px</code>) or it may be a relative distance between the source and target (e.g. <code>50%</code>).</li>
+<li>This value may be an absolute distance - positive number (e.g. <code>20px</code>) to indicate distance from the source or negative number (e.g. <code>-20px</code>) to indicate distance from the target or it may be a relative distance between the source and target (e.g. <code>50%</code>).</li>
 <li>Note that bundling may not work with an explicit direction (<code>upward</code>, <code>downward</code>, <code>leftward</code>, or <code>rightward</code>) in tandem with a turn distance specified in percent units.</li>
 </ul>
 </li>

--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -449,7 +449,7 @@ When a taxi edge would be impossible to draw along the regular turning plan --- 
   * `rightward` : Bundle outgoers righwards.
   * `leftward` : Bundle outgoers leftwards.
 * **`taxi-turn`** : The distance along the primary axis where the first turn is applied.
-  * This value may be an absolute distance (e.g. `20px`) or it may be a relative distance between the source and target (e.g. `50%`).
+  * This value may be an absolute distance - positive number (e.g. `20px`) to indicate distance from the source or negative number (e.g. `-20px`) to indicate distance from the target or it may be a relative distance between the source and target (e.g. `50%`).
   * Note that bundling may not work with an explicit direction (`upward`, `downward`, `leftward`, or `rightward`) in tandem with a turn distance specified in percent units.
 * **`taxi-turn-min-distance`** : The minimum distance along the primary axis that is maintained between the nodes and the turns.
   * This value only takes on absolute values (e.g. `5px`).

--- a/src/extensions/renderer/base/coord-ele-math/edge-control-points.js
+++ b/src/extensions/renderer/base/coord-ele-math/edge-control-points.js
@@ -265,9 +265,9 @@ BRp.findTaxiPoints = function( edge, pairInfo ){
   let taxiDir = edge.pstyle('taxi-direction').value;
   let rawTaxiDir = taxiDir; // unprocessed value
   const taxiTurn = edge.pstyle('taxi-turn');
-  const taxiTurnPfVal = taxiTurn.pfValue;
-  let minD = edge.pstyle('taxi-turn-min-distance').pfValue;
   const turnIsPercent = taxiTurn.units === '%';
+  const taxiTurnPfVal = turnIsPercent && taxiTurn.pfValue < 0 ? 1 + taxiTurn.pfValue : taxiTurn.pfValue;
+  let minD = edge.pstyle('taxi-turn-min-distance').pfValue;
   const dw = (dIncludesNodeBody ? (srcW + tgtW)/2 : 0);
   const dh = (dIncludesNodeBody ? (srcH + tgtH)/2 : 0);
   const pdx = posPts.x2 - posPts.x1;

--- a/src/extensions/renderer/base/coord-ele-math/edge-control-points.js
+++ b/src/extensions/renderer/base/coord-ele-math/edge-control-points.js
@@ -322,7 +322,7 @@ BRp.findTaxiPoints = function( edge, pairInfo ){
 
   const getIsTooClose = d => Math.abs(d) < minD || Math.abs(d) >= Math.abs(l);
   const isTooCloseSrc = getIsTooClose(d);
-  const isTooCloseTgt =  getIsTooClose(l - d);
+  const isTooCloseTgt =  getIsTooClose(l - Math.abs(d));
   const isTooClose = isTooCloseSrc || isTooCloseTgt;
 
   if( isTooClose && !forcedDir ){ // non-ideal routing
@@ -381,7 +381,7 @@ BRp.findTaxiPoints = function( edge, pairInfo ){
     }
   } else { // ideal routing
     if( isVert ){
-      let y = posPts.y1 + d + (dIncludesNodeBody ? srcH/2 * sgnL : 0);
+      let y = (d < 0 ? posPts.y2 : posPts.y1) + d + (dIncludesNodeBody ? srcH/2 * sgnL : 0);
       let { x1, x2 } = posPts;
 
       rs.segpts = [
@@ -389,7 +389,7 @@ BRp.findTaxiPoints = function( edge, pairInfo ){
         x2, y
       ];
     } else { // horizontal
-      let x = posPts.x1 + d + (dIncludesNodeBody ? srcW/2 * sgnL : 0);
+      let x = (d < 0 ? posPts.x2 : posPts.x1) + d + (dIncludesNodeBody ? srcW/2 * sgnL : 0);
       let { y1, y2 } = posPts;
 
       rs.segpts = [

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -36,6 +36,7 @@ const styfn = {};
     positiveNumber: { number: true, unitless: true, min: 0, strictMin: true },
     size: { number: true, min: 0 },
     bidirectionalSize: { number: true }, // allows negative
+    bidirectionalSizeMaybePercent: { number: true, allowPercent: true }, // allows negative
     bidirectionalSizes: { number: true, multiple: true }, // allows negative
     sizeMaybePercent: { number: true, min: 0, allowPercent: true },
     axisDirection: { enums: ['horizontal', 'leftward', 'rightward', 'vertical', 'upward', 'downward', 'auto'] },
@@ -325,7 +326,7 @@ const styfn = {};
     { name: 'control-point-weights', type: t.numbers, triggersBounds: diff.any },
     { name: 'segment-distances', type: t.bidirectionalSizes, triggersBounds: diff.any },
     { name: 'segment-weights', type: t.numbers, triggersBounds: diff.any },
-    { name: 'taxi-turn', type: t.sizeMaybePercent, triggersBounds: diff.any },
+    { name: 'taxi-turn', type: t.bidirectionalSizeMaybePercent, triggersBounds: diff.any },
     { name: 'taxi-turn-min-distance', type: t.size, triggersBounds: diff.any },
     { name: 'taxi-direction', type: t.axisDirection, triggersBounds: diff.any },
     { name: 'edge-distances', type: t.edgeDistances, triggersBounds: diff.any },


### PR DESCRIPTION
A negative value specifies a distance relative to the target side (from target to source) rather than the default source side (from source to target).