### PR TITLE
Skip invalid edges

### DIFF
--- a/src/collection/index.js
+++ b/src/collection/index.js
@@ -394,13 +394,13 @@ elesfn.restore = function( notifyRenderer = true, addToPool = true ){
       data.id = '' + data.id; // now it's a string
 
     } else if( is.emptyString( data.id ) || !is.string( data.id ) ){
-      util.error( 'Can not create element with invalid string ID `' + data.id + '`' );
+      util.warn( 'Can not create element with invalid string ID `' + data.id + '`' );
 
       // can't create element if it has empty string as id or non-string id
       removeFromElements();
       continue;
     } else if( cy.hasElementWithId( data.id ) ){
-      util.error( 'Can not create second element with ID `' + data.id + '`' );
+      util.warn( 'Can not create second element with ID `' + data.id + '`' );
 
       // can't create element if one already has that id
       removeFromElements();
@@ -440,11 +440,11 @@ elesfn.restore = function( notifyRenderer = true, addToPool = true ){
 
         if( val == null || val === '' ){
           // can't create if source or target is not defined properly
-          util.error( 'Can not create edge `' + id + '` with unspecified ' + field );
+          util.warn( 'Can not create edge `' + id + '` with unspecified ' + field );
           badSourceOrTarget = true;
         } else if( !cy.hasElementWithId( val ) ){
           // can't create edge if one of its nodes doesn't exist
-          util.error( 'Can not create edge `' + id + '` with nonexistant ' + field + ' `' + val + '`' );
+          util.warn( 'Can not create edge `' + id + '` with nonexistant ' + field + ' `' + val + '`' );
           badSourceOrTarget = true;
         }
       }

--- a/test/core-init.js
+++ b/test/core-init.js
@@ -40,33 +40,42 @@ describe('Core initialisation', function(){
     });
   });
 
-  it('does not create an edge with bad source and target', function(){
-    var init = function(){
-      cytoscape({
-        headless: true,
+  it('does not create an edge with bad source and target', function (done) {
+    cytoscape({
+      headless: true,
 
-        elements: {
-          edges: [ { data: { source: "n1", target: "n2" } } ]
-        }
-      });
-    };
+      elements: {
+        nodes: [ { data: { id: "n1" } }, { data: { id: "n2" } } ],
+        edges: [ { data: { id: "n1->n2", source: "n1", target: "n2" } }, { data: { id: "n2->n3", source: "n2", target: "n3" } } ]
+      },
+      ready: function(){
+        var cy = this;
 
-    expect(init).to.throw();
+        expect( cy.nodes().size() ).to.equal(2);
+        expect( cy.edges().map((el) => el.id()) ).to.eql(["n1->n2"]);
+
+        done();
+      }
+    });
   });
 
-  it('does not create an edge with bad target', function(){
-    var init = function(){
-      cytoscape({
-        headless: true,
+  it('does not create an edge with bad target', function (done) {
+    cytoscape({
+      headless: true,
 
-        elements: {
-          nodes: [ { data: { id: "n1" } } ],
-          edges: [ { data: { source: "n1", target: "n2" } } ]
-        }
-      });
-    };
+      elements: {
+        nodes: [ { data: { id: "n1" } }, { data: { id: "n2" } } ],
+        edges: [ { data: { id: "n1->n2", source: "n1", target: "n2" } }, { data: { id: "n1->n3", source: "n1", target: "n3" } } ]
+      },
+      ready: function(){
+        var cy = this;
 
-    expect(init).to.throw();
+        expect( cy.nodes().size() ).to.equal(2);
+        expect( cy.edges().map((el) => el.id()) ).to.eql(["n1->n2"]);
+
+        done();
+      }
+    });
   });
 
   it('creates an edge that specifies good source and target', function(done){


### PR DESCRIPTION
I assume the original intention was to ignore invalid edges instead of breaking with an error.
This commit introduced the breaking change: https://github.com/cytoscape/cytoscape.js/commit/1f1b5be35f5d576172a9c7855b84303e304dc0da