### PR TITLE
Add new label background shapes: circle and ellipse

### DIFF
--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -618,6 +618,14 @@ Border:
  * **`text-border-style`** : The style of the border around the label; may be `solid`, `dotted`, `dashed`, or `double`.
  * **`text-border-color`** : The colour of the border around the label.
 
+Shadow:
+
+* **`text-shadow-opacity`**: The opacity of the label shadow; the shadow is disabled for `0` (default value).
+* **`text-shadow-color`**: A colour to apply on the label shadow.
+* **`text-shadow-blur`**:  The blur level for the label shadow; no blurring occurs for `0` (default value).
+* **`text-shadow-offset-x`**: The horizontal offset of the label shadow relative to the label. Negative values move the shadow to the left, the shadow is horizontally centered behind the label for `0` (default value).
+* **`text-shadow-offset-y`**: The vertical offset of the label shadow relative to the label. Negative values move the shadow to the top, the shadow is vertically centered behind the label for `0` (default value).
+
 Interactivity:
 
  * **`min-zoomed-font-size`** : If zooming makes the effective font size of the label smaller than this, then no label is shown.  Note that because of performance optimisations, the label may be shown at font sizes slightly smaller than this value.  This effect is more pronounced at larger screen pixel ratios.  However, it is guaranteed that the label will be shown at sizes equal to or greater than the value specified.

--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -607,12 +607,13 @@ Background:
 
  * **`text-background-color`** : A colour to apply on the text background.
  * **`text-background-opacity`** : The opacity of the label background; the background is disabled for `0` (default value).
- * **`text-background-shape`** : The shape to use for the label background, can be `rectangle` or `round-rectangle`.
+ * **`text-background-shape`** : The shape to use for the label background, can be `rectangle`, `round-rectangle`, `ellipse` or `circle`.
+ * **`text-background-shape-circle-size`** : Method for determining circle size (only applicable for `text-background-shape = 'circle'`). Can be `height`, `width`, `min` or `max` (default value).
  * **`text-background-padding`** : A padding on the background of the label (e.g `5px`); zero padding is used by default.
 
 Border:
 
- * **`text-border-opacity`** : The width of the border around the label; the border is disabled for `0` (default value).
+ * **`text-border-opacity`** : The width of the border around the label; the border is disabled for `0` (default value). The border is always rectangular, so this should not be combined non-rectangular background shapes.
  * **`text-border-width`** : The width of the border around the label.
  * **`text-border-style`** : The style of the border around the label; may be `solid`, `dotted`, `dashed`, or `double`.
  * **`text-border-color`** : The colour of the border around the label.

--- a/src/extensions/renderer/canvas/drawing-label-text.js
+++ b/src/extensions/renderer/canvas/drawing-label-text.js
@@ -291,6 +291,18 @@ CRp.drawText = function( context, ele, prefix, applyRotation = true, useEleOpaci
         let textBackgroundColor = ele.pstyle( 'text-background-color' ).value;
 
         context.fillStyle = 'rgba(' + textBackgroundColor[ 0 ] + ',' + textBackgroundColor[ 1 ] + ',' + textBackgroundColor[ 2 ] + ',' + backgroundOpacity * parentOpacity + ')';
+        
+        let textShadowOpacity = ele.pstyle( 'text-shadow-opacity' ).value;
+        if ( textShadowOpacity > 0 ) {
+          let textShadowColor = ele.pstyle( 'text-shadow-color' ).value;
+
+          context.save();
+          context.shadowColor = 'rgba(' + textShadowColor[ 0 ] + ',' + textShadowColor[ 1 ] + ',' + textShadowColor[ 2 ] + ',' + textShadowOpacity * parentOpacity + ')';
+          context.shadowBlur = ele.pstyle( 'text-shadow-blur' ).value;
+          context.shadowOffsetX = ele.pstyle( 'text-shadow-offset-x' ).pfValue;
+          context.shadowOffsetY = ele.pstyle( 'text-shadow-offset-y' ).pfValue;
+        }
+        
         let styleShape = ele.pstyle( 'text-background-shape' ).strValue;
         if( styleShape.indexOf('round') === 0 ){
           roundRect( context, bgX, bgY, bgW, bgH, 2 );
@@ -301,6 +313,9 @@ CRp.drawText = function( context, ele, prefix, applyRotation = true, useEleOpaci
           circle( context, bgX, bgY, bgW, bgH, circleSize );
         } else {
           context.fillRect( bgX, bgY, bgW, bgH );
+        }
+        if ( textShadowOpacity > 0 ) {
+          context.restore();
         }
         context.fillStyle = textFill;
       }

--- a/src/extensions/renderer/canvas/drawing-label-text.js
+++ b/src/extensions/renderer/canvas/drawing-label-text.js
@@ -145,6 +145,36 @@ function roundRect( ctx, x, y, width, height, radius = 5 ){
   ctx.fill();
 }
 
+function ellipse( ctx, x, y, width, height ) {
+  ctx.beginPath();
+  ctx.ellipse(x + width / 2, y + height / 2, width / 2, height / 2, 0, 0, 2 * Math.PI);
+  ctx.fill();
+}
+
+function circle( ctx, x, y, width, height, sizeMode = 'max' ) {
+  let diameter;
+  switch ( sizeMode ) {
+    case 'width':
+      diameter = width;
+      break;
+    case 'height':
+      diameter = height;
+      break;
+    case 'min':
+      diameter = Math.min(width, height);
+      break;
+    default:
+      diameter = Math.max(width, height);
+      break;
+  }
+  const centerX = x + diameter / 2 + (width - diameter) / 2;
+  const centerY = y + diameter / 2 + (height - diameter) / 2;
+
+  ctx.beginPath();
+  ctx.arc(centerX, centerY, diameter / 2, 0, 2 * Math.PI);
+  ctx.fill();
+}
+
 CRp.getTextAngle = function( ele, prefix ){
   let theta;
   let _p = ele._private;
@@ -264,6 +294,11 @@ CRp.drawText = function( context, ele, prefix, applyRotation = true, useEleOpaci
         let styleShape = ele.pstyle( 'text-background-shape' ).strValue;
         if( styleShape.indexOf('round') === 0 ){
           roundRect( context, bgX, bgY, bgW, bgH, 2 );
+        } else if ( styleShape == 'ellipse' ) {
+          ellipse( context, bgX, bgY, bgW, bgH );
+        } else if (styleShape === 'circle' ) {
+          let circleSize = ele.pstyle( 'text-background-shape-circle-size' ).strValue;
+          circle( context, bgX, bgY, bgW, bgH, circleSize );
         } else {
           context.fillRect( bgX, bgY, bgW, bgH );
         }

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -63,7 +63,8 @@ const styfn = {};
     textTransform: { enums: [ 'none', 'uppercase', 'lowercase' ] },
     textWrap: { enums: [ 'none', 'wrap', 'ellipsis' ] },
     textOverflowWrap: { enums: [ 'whitespace', 'anywhere' ] },
-    textBackgroundShape: { enums: [ 'rectangle', 'roundrectangle', 'round-rectangle' ]},
+    textBackgroundShape: { enums: [ 'rectangle', 'roundrectangle', 'round-rectangle', 'ellipse', 'circle' ]},
+    textBackgroundCircleSize: { enums: [ 'width', 'height', 'min', 'max' ]},
     nodeShape: { enums: [
       'rectangle', 'roundrectangle', 'round-rectangle', 'cutrectangle', 'cut-rectangle', 'bottomroundrectangle', 'bottom-round-rectangle', 'barrel',
       'ellipse', 'triangle', 'round-triangle', 'square', 'pentagon', 'round-pentagon', 'hexagon', 'round-hexagon', 'concavehexagon', 'concave-hexagon', 'heptagon', 'round-heptagon', 'octagon', 'round-octagon',
@@ -216,6 +217,7 @@ const styfn = {};
     { name: 'text-border-width', type: t.size, triggersBounds: diff.any },
     { name: 'text-border-style', type: t.borderStyle, triggersBounds: diff.any },
     { name: 'text-background-shape', type: t.textBackgroundShape, triggersBounds: diff.any },
+    { name: 'text-background-shape-circle-size', type: t.textBackgroundCircleSize, triggersBounds: diff.any },
     { name: 'text-justification', type: t.justification }
   ];
 
@@ -532,6 +534,7 @@ styfn.getDefaultProperties = function(){
     'text-background-color': '#000',
     'text-background-opacity': 0,
     'text-background-shape': 'rectangle',
+    'text-background-shape-circle-size': 'max',
     'text-background-padding': 0,
     'text-border-opacity': 0,
     'text-border-width': 0,

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -34,6 +34,7 @@ const styfn = {};
     number: { number: true, unitless: true },
     numbers: { number: true, unitless: true, multiple: true },
     positiveNumber: { number: true, unitless: true, min: 0, strictMin: true },
+    nonNegativeNumber: { number: true, min: 0, unitless: true },
     size: { number: true, min: 0 },
     bidirectionalSize: { number: true }, // allows negative
     bidirectionalSizeMaybePercent: { number: true, allowPercent: true }, // allows negative
@@ -218,6 +219,12 @@ const styfn = {};
     { name: 'text-border-style', type: t.borderStyle, triggersBounds: diff.any },
     { name: 'text-background-shape', type: t.textBackgroundShape, triggersBounds: diff.any },
     { name: 'text-background-shape-circle-size', type: t.textBackgroundCircleSize, triggersBounds: diff.any },
+    { name: 'text-shadow-opacity', type: t.zeroOneNumber },
+    { name: 'text-shadow-color', type: t.color },
+    { name: 'text-shadow-blur', type: t.nonNegativeNumber },
+    { name: 'text-shadow-offset-x', type: t.bidirectionalSize },
+    { name: 'text-shadow-offset-y', type: t.bidirectionalSize },
+    { name: 'text-border-width', type: t.size, triggersBounds: diff.any },
     { name: 'text-justification', type: t.justification }
   ];
 


### PR DESCRIPTION
This PR adds two new options for `text-background-shape`: `ellipse` and `circle`.

The diameter of the circle shape can be configured via the new option `text-background-shape-circle-size` to equal the label's width/height or the min/max of these.

The PR also extends the documentation for `text-border-opacity`, noting that the border is always rectangular (which also applies to `text-background-shape = 'round-rectangle'`).
