### PR TITLE
Add support for label background shade

### DIFF
--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -616,6 +616,14 @@ Border:
  * **`text-border-style`** : The style of the border around the label; may be `solid`, `dotted`, `dashed`, or `double`.
  * **`text-border-color`** : The colour of the border around the label.
 
+Shadow:
+
+* **`text-shadow-opacity`**: The opacity of the label shadow; the shadow is disabled for `0` (default value).
+* **`text-shadow-color`**: A colour to apply on the label shadow.
+* **`text-shadow-blur`**:  The blur level for the label shadow; no blurring occurs for `0` (default value).
+* **`text-shadow-offset-x`**: The horizontal offset of the label shadow relative to the label. Negative values move the shadow to the left, the shadow is horizontally centered behind the label for `0` (default value).
+* **`text-shadow-offset-y`**: The vertical offset of the label shadow relative to the label. Negative values move the shadow to the top, the shadow is vertically centered behind the label for `0` (default value).
+
 Interactivity:
 
  * **`min-zoomed-font-size`** : If zooming makes the effective font size of the label smaller than this, then no label is shown.  Note that because of performance optimisations, the label may be shown at font sizes slightly smaller than this value.  This effect is more pronounced at larger screen pixel ratios.  However, it is guaranteed that the label will be shown at sizes equal to or greater than the value specified.

--- a/src/extensions/renderer/canvas/drawing-label-text.js
+++ b/src/extensions/renderer/canvas/drawing-label-text.js
@@ -261,11 +261,26 @@ CRp.drawText = function( context, ele, prefix, applyRotation = true, useEleOpaci
         let textBackgroundColor = ele.pstyle( 'text-background-color' ).value;
 
         context.fillStyle = 'rgba(' + textBackgroundColor[ 0 ] + ',' + textBackgroundColor[ 1 ] + ',' + textBackgroundColor[ 2 ] + ',' + backgroundOpacity * parentOpacity + ')';
+        
+        let textShadowOpacity = ele.pstyle( 'text-shadow-opacity' ).value;
+        if ( textShadowOpacity > 0 ) {
+          let textShadowColor = ele.pstyle( 'text-shadow-color' ).value;
+
+          context.save();
+          context.shadowColor = 'rgba(' + textShadowColor[ 0 ] + ',' + textShadowColor[ 1 ] + ',' + textShadowColor[ 2 ] + ',' + textShadowOpacity * parentOpacity + ')';
+          context.shadowBlur = ele.pstyle( 'text-shadow-blur' ).value;
+          context.shadowOffsetX = ele.pstyle( 'text-shadow-offset-x' ).pfValue;
+          context.shadowOffsetY = ele.pstyle( 'text-shadow-offset-y' ).pfValue;
+        }
+        
         let styleShape = ele.pstyle( 'text-background-shape' ).strValue;
         if( styleShape.indexOf('round') === 0 ){
           roundRect( context, bgX, bgY, bgW, bgH, 2 );
         } else {
           context.fillRect( bgX, bgY, bgW, bgH );
+        }
+        if ( textShadowOpacity > 0 ) {
+          context.restore();
         }
         context.fillStyle = textFill;
       }

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -34,6 +34,7 @@ const styfn = {};
     number: { number: true, unitless: true },
     numbers: { number: true, unitless: true, multiple: true },
     positiveNumber: { number: true, unitless: true, min: 0, strictMin: true },
+    nonNegativeNumber: { number: true, min: 0, unitless: true },
     size: { number: true, min: 0 },
     bidirectionalSize: { number: true }, // allows negative
     bidirectionalSizes: { number: true, multiple: true }, // allows negative
@@ -215,6 +216,12 @@ const styfn = {};
     { name: 'text-border-width', type: t.size, triggersBounds: diff.any },
     { name: 'text-border-style', type: t.borderStyle, triggersBounds: diff.any },
     { name: 'text-background-shape', type: t.textBackgroundShape, triggersBounds: diff.any },
+    { name: 'text-shadow-opacity', type: t.zeroOneNumber },
+    { name: 'text-shadow-color', type: t.color },
+    { name: 'text-shadow-blur', type: t.nonNegativeNumber },
+    { name: 'text-shadow-offset-x', type: t.bidirectionalSize },
+    { name: 'text-shadow-offset-y', type: t.bidirectionalSize },
+    { name: 'text-border-width', type: t.size, triggersBounds: diff.any },
     { name: 'text-justification', type: t.justification }
   ];
 


### PR DESCRIPTION
This PR adds support for configuring shadows of label backgrounds.

Below is an example of an edge label using `circle` background shape (see #2640) and shadows:
![edge with circle shaped label background and shadow](https://user-images.githubusercontent.com/7543325/75519374-a965a980-5a35-11ea-89ae-f3b79765062b.png)

A limitation of this implementation is that the shadow gets cropped if it extends beyond the dimensions of the label box. Suggestions to overcome this would be welcome.