### PR TITLE
Add new label background shapes: circle and ellipse (fixed)

### DIFF
--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -607,12 +607,13 @@ Background:
 
  * **`text-background-color`** : A colour to apply on the text background.
  * **`text-background-opacity`** : The opacity of the label background; the background is disabled for `0` (default value).
- * **`text-background-shape`** : The shape to use for the label background, can be `rectangle` or `round-rectangle`.
+ * **`text-background-shape`** : The shape to use for the label background, can be `rectangle`, `round-rectangle`, `ellipse` or `circle`.
+ * **`text-background-shape-circle-size`** : Method for determining circle size (only applicable for `text-background-shape = 'circle'`). Can be `height`, `width`, `min` or `max` (default value).
  * **`text-background-padding`** : A padding on the background of the label (e.g `5px`); zero padding is used by default.
 
 Border:
 
- * **`text-border-opacity`** : The width of the border around the label; the border is disabled for `0` (default value).
+ * **`text-border-opacity`** : The width of the border around the label; the border is disabled for `0` (default value). The border is always rectangular, so this should not be combined non-rectangular background shapes.
  * **`text-border-width`** : The width of the border around the label.
  * **`text-border-style`** : The style of the border around the label; may be `solid`, `dotted`, `dashed`, or `double`.
  * **`text-border-color`** : The colour of the border around the label.

--- a/src/extensions/renderer/canvas/drawing-label-text.js
+++ b/src/extensions/renderer/canvas/drawing-label-text.js
@@ -145,6 +145,36 @@ function roundRect( ctx, x, y, width, height, radius = 5 ){
   ctx.fill();
 }
 
+function ellipse( ctx, x, y, width, height ) {
+  ctx.beginPath();
+  ctx.ellipse(x + width / 2, y + height / 2, width / 2, height / 2, 0, 0, 2 * Math.PI);
+  ctx.fill();
+}
+
+function circle( ctx, x, y, width, height, sizeMode = 'max' ) {
+  let diameter;
+  switch ( sizeMode ) {
+    case 'width':
+      diameter = width;
+      break;
+    case 'height':
+      diameter = height;
+      break;
+    case 'min':
+      diameter = Math.min(width, height);
+      break;
+    default:
+      diameter = Math.max(width, height);
+      break;
+  }
+  const centerX = x + diameter / 2 + (width - diameter) / 2;
+  const centerY = y + diameter / 2 + (height - diameter) / 2;
+
+  ctx.beginPath();
+  ctx.arc(centerX, centerY, diameter / 2, 0, 2 * Math.PI);
+  ctx.fill();
+}
+
 CRp.getTextAngle = function( ele, prefix ){
   let theta;
   let _p = ele._private;
@@ -264,6 +294,11 @@ CRp.drawText = function( context, ele, prefix, applyRotation = true, useEleOpaci
         let styleShape = ele.pstyle( 'text-background-shape' ).strValue;
         if( styleShape.indexOf('round') === 0 ){
           roundRect( context, bgX, bgY, bgW, bgH, 2 );
+        } else if ( styleShape == 'ellipse' ) {
+          ellipse( context, bgX, bgY, bgW, bgH );
+        } else if (styleShape === 'circle' ) {
+          let circleSize = ele.pstyle( 'text-background-shape-circle-size' ).strValue;
+          circle( context, bgX, bgY, bgW, bgH, circleSize );
         } else {
           context.fillRect( bgX, bgY, bgW, bgH );
         }

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -63,7 +63,8 @@ const styfn = {};
     textTransform: { enums: [ 'none', 'uppercase', 'lowercase' ] },
     textWrap: { enums: [ 'none', 'wrap', 'ellipsis' ] },
     textOverflowWrap: { enums: [ 'whitespace', 'anywhere' ] },
-    textBackgroundShape: { enums: [ 'rectangle', 'roundrectangle', 'round-rectangle' ]},
+    textBackgroundShape: { enums: [ 'rectangle', 'roundrectangle', 'round-rectangle', 'ellipse', 'circle' ]},
+    textBackgroundCircleSize: { enums: [ 'width', 'height', 'min', 'max' ]},
     nodeShape: { enums: [
       'rectangle', 'roundrectangle', 'round-rectangle', 'cutrectangle', 'cut-rectangle', 'bottomroundrectangle', 'bottom-round-rectangle', 'barrel',
       'ellipse', 'triangle', 'round-triangle', 'square', 'pentagon', 'round-pentagon', 'hexagon', 'round-hexagon', 'concavehexagon', 'concave-hexagon', 'heptagon', 'round-heptagon', 'octagon', 'round-octagon',
@@ -216,6 +217,7 @@ const styfn = {};
     { name: 'text-border-width', type: t.size, triggersBounds: diff.any },
     { name: 'text-border-style', type: t.borderStyle, triggersBounds: diff.any },
     { name: 'text-background-shape', type: t.textBackgroundShape, triggersBounds: diff.any },
+    { name: 'text-background-shape-circle-size', type: t.textBackgroundCircleSize, triggersBounds: diff.any },
     { name: 'text-justification', type: t.justification }
   ];
 
@@ -532,6 +534,7 @@ styfn.getDefaultProperties = function(){
     'text-background-color': '#000',
     'text-background-opacity': 0,
     'text-background-shape': 'rectangle',
+    'text-background-shape-circle-size': 'max',
     'text-background-padding': 0,
     'text-border-opacity': 0,
     'text-border-width': 0,


### PR DESCRIPTION
This is a fixed version of #2640. The PR adds two new options for text-background-shape: ellipse and circle. 

The diameter of the circle shape can be configured via the new option text-background-shape-circle-size to equal the label's width/height or the min/max of these.

The PR also extends the documentation for text-border-opacity, noting that the border is always rectangular (which also applies to text-background-shape = 'round-rectangle').