### PR TITLE
Add curve-style: bezier to the tutorial example

### DIFF
--- a/documentation/index.html
+++ b/documentation/index.html
@@ -1261,8 +1261,7 @@
         <span class="hljs-string">'width'</span>: <span class="hljs-number">3</span>,
         <span class="hljs-string">'line-color'</span>: <span class="hljs-string">'#ccc'</span>,
         <span class="hljs-string">'target-arrow-color'</span>: <span class="hljs-string">'#ccc'</span>,
-        <span class="hljs-string">'target-arrow-shape'</span>: <span class="hljs-string">'triangle'</span>,
-	<span class="hljs-string">'curve-style'</span>: <span class="hljs-string">'bezier'</span>
+        <span class="hljs-string">'target-arrow-shape'</span>: <span class="hljs-string">'triangle'</span>
       }
     }
   ],

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -1261,7 +1261,8 @@
         <span class="hljs-string">'width'</span>: <span class="hljs-number">3</span>,
         <span class="hljs-string">'line-color'</span>: <span class="hljs-string">'#ccc'</span>,
         <span class="hljs-string">'target-arrow-color'</span>: <span class="hljs-string">'#ccc'</span>,
-        <span class="hljs-string">'target-arrow-shape'</span>: <span class="hljs-string">'triangle'</span>
+        <span class="hljs-string">'target-arrow-shape'</span>: <span class="hljs-string">'triangle'</span>,
+	<span class="hljs-string">'curve-style'</span>: <span class="hljs-string">'bezier'</span>
       }
     }
   ],

--- a/documentation/md/getting-started.md
+++ b/documentation/md/getting-started.md
@@ -145,7 +145,8 @@ var cy = cytoscape({
         'width': 3,
         'line-color': '#ccc',
         'target-arrow-color': '#ccc',
-        'target-arrow-shape': 'triangle'
+        'target-arrow-shape': 'triangle',
+        'curve-style': 'bezier'
       }
     }
   ],


### PR DESCRIPTION
**Issue type**

Documentation bug report


**Current (buggy) behaviour**

Since version 2.7.0, edges are haystack by default, which only support midpoint arrows. The example is supposed to show an arrow and it doesn't.

**Desired behaviour**

I have added a curve style that allows it to be shown.
