### PR TITLE
panningWithRightMouseButton implemented

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -82,6 +82,10 @@
         User:
         <button id="enable-user-panning">on</button>
         <button id="disable-user-panning">off</button><br />
+        
+        Pan with Right Mouse Button
+        <button id="enable-panning-with-right-mouse-button">on</button>
+        <button id="disable-panning-with-right-mouse-button">off</button><br />
 
         Zooming:
         <button id="enable-zooming">on</button>

--- a/debug/view.js
+++ b/debug/view.js
@@ -34,6 +34,14 @@
 		cy.userPanningEnabled(false);
 	});
 
+	$("#enable-panning-with-right-mouse-button").addEventListener('click', function(){
+		cy.panningWithRightMouseButton(true);
+	});
+
+	$("#disable-panning-with-right-mouse-button").addEventListener('click', function(){
+		cy.panningWithRightMouseButton(false);
+	});
+
 	$("#enable-zooming").addEventListener('click', function(){
 		cy.zoomingEnabled(true);
 	});

--- a/documentation/docmaker.json
+++ b/documentation/docmaker.json
@@ -548,6 +548,24 @@
             },
 
             {
+              "name": "cy.panningWithRightMouseButton",
+              "descr": "Get or set whether panning by user should be done with left mouse button (default) or right mouse button.",
+              "formats": [
+                {
+                  "descr": "Get whether user panning is done with left mouse button (false) or right mouse button (true)."
+                },
+
+                {
+                  "descr": "Set whether user panning is done with left mouse button (false) or right mouse button (true)..",
+                  "args": [
+                    { "name": "bool", "descr": "A truthy value enables user panning with right mouse button; a falsey value enables user panning with left mouse button." }
+                  ]
+                }
+              ],
+              "md": "core/panningWithRightMouseButton"
+            },
+
+            {
               "name": "cy.zoom",
               "descr": "Get or set the zoom level of the graph.",
               "formats": [

--- a/documentation/md/core/init.md
+++ b/documentation/md/core/init.md
@@ -45,6 +45,7 @@ An instance of Cytoscape.js has a number of options that can be set on initialis
   <a href="#init-opts/userZoomingEnabled">userZoomingEnabled</a>: true,
   <a href="#init-opts/panningEnabled">panningEnabled</a>: true,
   <a href="#init-opts/userPanningEnabled">userPanningEnabled</a>: true,
+  <a href="#init-opts/panningWithRightMouseButton">panningWithRightMouseButton</a>: false,
   <a href="#init-opts/boxSelectionEnabled">boxSelectionEnabled</a>: true,
   <a href="#init-opts/selectionType">selectionType</a>: 'single',
   <a href="#init-opts/touchTapThreshold">touchTapThreshold</a>: 8,

--- a/documentation/md/core/panningWithRightMouseButton.md
+++ b/documentation/md/core/panningWithRightMouseButton.md
@@ -1,0 +1,11 @@
+## Examples
+
+Enable:
+```js
+cy.panningWithRightMouseButton( true );
+```
+
+Disable:
+```js
+cy.panningWithRightMouseButton( false );
+```

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -76,6 +76,7 @@ let Core = function( opts ){
     zoomingEnabled: defVal( true, options.zoomingEnabled ),
     userZoomingEnabled: defVal( true, options.userZoomingEnabled ),
     panningEnabled: defVal( true, options.panningEnabled ),
+    panningWithRightMouseButton: defVal( false, options.panningWithRightMouseButton ),
     userPanningEnabled: defVal( true, options.userPanningEnabled ),
     boxSelectionEnabled: defVal( true, options.boxSelectionEnabled ),
     autolock: defVal( false, options.autolock, options.autolockNodes ),
@@ -415,6 +416,7 @@ util.extend( corefn, {
       let fields = [
         'minZoom', 'maxZoom', 'zoomingEnabled', 'userZoomingEnabled',
         'panningEnabled', 'userPanningEnabled',
+        'panningWithRightMouseButton',
         'boxSelectionEnabled',
         'autolock', 'autoungrabify', 'autounselectify'
       ];
@@ -464,6 +466,7 @@ util.extend( corefn, {
       json.minZoom = _p.minZoom;
       json.maxZoom = _p.maxZoom;
       json.panningEnabled = _p.panningEnabled;
+      json.panningWithRightMouseButton = _p.panningWithRightMouseButton;
       json.userPanningEnabled = _p.userPanningEnabled;
       json.pan = util.copy( _p.pan );
       json.boxSelectionEnabled = _p.boxSelectionEnabled;

--- a/src/core/viewport.js
+++ b/src/core/viewport.js
@@ -74,6 +74,16 @@ let corefn = ({
     return this; // chaining
   },
 
+  panningWithRightMouseButton: function( bool ){
+    if( bool !== undefined ){
+      this._private.panningWithRightMouseButton = bool ? true : false;
+    } else {
+      return this._private.panningWithRightMouseButton;
+    }
+
+    return this; // chaining
+  },
+  
   zoomingEnabled: function( bool ){
     if( bool !== undefined ){
       this._private.zoomingEnabled = bool ? true : false;


### PR DESCRIPTION
<!--
If you do not have a separate GitHub issue for this PR, then fill out the following sections.  If you have created a separate issue for this PR, then please link to it instead of filling out the sections.
-->

**Issue type**
<!--
Are you submitting a bug report or a feature request?

When submitting a bug report, check the following:
- The report has a descriptive title.
- The bug still exists in most recent version of the library.
-->

<!-- Delete one option -->
Feature request





<!-- FEATURE REQUEST : Delete if reporting a bug -->

**Description of new feature**

<!-- What should the new feature do?  For visual features, include an image/mockup of the expected output. -->
Option for using the right mouse button for panning instead of the left mouse button.

**Motivation for new feature**

<!-- Describe your use case for this new feature. -->
In our use case, we have other graph tools and we want to keep the general behavior of the graphs the same. That means:
* LMB click should select
* LMB drag should be box selection
* RMB click should be menu
* RMB drag should be panning

This also simplifies the usage of the graph (no need for multiple keys at once), and at least from our point of view it seems to be a bit more inline of the user expectation.

The functionality has been implemented with the initialization option "panningWithRightMouseButton". It is default false (still using LMB) and no breakable changes.
Debug page and documentation has been updated too.

I dont know whether it is a feature you would want merged in, however it feels too core'ish to somehow put into an extension (it changes basic behavior, not adding new). Anyways, I would very much like to give you the option, now that it is already made :)

In any case, let me know of any questions, comments or issues.

Best regards,
Jeppe

<!-- END FEATURE REQUEST -->
