### PR TITLE
Bugfix in Betweenness Centrality

### DIFF
--- a/src/collection/algorithms/betweenness-centrality.js
+++ b/src/collection/algorithms/betweenness-centrality.js
@@ -136,10 +136,10 @@ let elesfn = ({
           let v = P[w][j];
 
           e[v] = e[v] + (g[v] / g[w]) * (1 + e[w]);
+        }
 
-          if( w != V[s].id() ){
-            C.set( w, C.get( w ) + e[w] );
-          }
+        if( w != V[s].id() ){
+          C.set( w, C.get( w ) + e[w] );
         }
       }
     }

--- a/test/collection-algorithms.js
+++ b/test/collection-algorithms.js
@@ -995,4 +995,25 @@ describe('Algorithms', function(){
     expect( res.betweenness(d) ).to.equal(0);
     expect( res.betweenness(e) ).to.equal(0);
   });
+
+  it('eles.betweennessCentrality() unweighted directed: multiple shortest paths', function(){
+    cy.remove(ae);
+    cy.remove(bc);
+    cy.remove(cd);
+    cy.remove(ce);
+    cy.add([
+      { group: 'edges', data: { id: 'ad', source: 'a', target: 'd' } },
+      { group: 'edges', data: { id: 'ec', source: 'e', target: 'c' } }
+    ]);
+
+    var res = cy.elements().betweennessCentrality({
+      directed:true
+    });
+
+    expect( res.betweenness(a) ).to.equal(0);
+    expect( res.betweenness(b) ).to.equal(1);
+    expect( res.betweenness(c) ).to.equal(0);
+    expect( res.betweenness(d) ).to.equal(1);
+    expect( res.betweenness(e) ).to.equal(3);
+  });
 });


### PR DESCRIPTION
**Issue type**
Bug report

I have noticed a bug in the part of Betweenness Centrality when shortest paths are aggregated. For the graph as in this example:
https://jsbin.com/rijavenodo/1/edit?html,css,js,console,output
(this is also the graph I put in a new test) calculated value for node `e` (red one) is 4, but it should be 3 (because `e` lies on all shortest paths between pairs `(a, c)`, `(b, c)` and `(d, c)`). 
