### PR TITLE
Fix typo in example code comment (letiation -> variation)

### DIFF
--- a/dist/cytoscape.cjs.js
+++ b/dist/cytoscape.cjs.js
@@ -19435,7 +19435,7 @@ var defaults$b = {
     return node.degree();
   },
   levelWidth: function levelWidth(nodes) {
-    // the letiation of concentric values in each level
+    // the variation of concentric values in each level
     return nodes.maxDegree() / 4;
   },
   animate: false,

--- a/dist/cytoscape.esm.js
+++ b/dist/cytoscape.esm.js
@@ -19431,7 +19431,7 @@ var defaults$b = {
     return node.degree();
   },
   levelWidth: function levelWidth(nodes) {
-    // the letiation of concentric values in each level
+    // the variation of concentric values in each level
     return nodes.maxDegree() / 4;
   },
   animate: false,

--- a/dist/cytoscape.umd.js
+++ b/dist/cytoscape.umd.js
@@ -20194,7 +20194,7 @@
       return node.degree();
     },
     levelWidth: function levelWidth(nodes) {
-      // the letiation of concentric values in each level
+      // the variation of concentric values in each level
       return nodes.maxDegree() / 4;
     },
     animate: false,

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -14197,7 +14197,7 @@ cy.layout( options );</code></pre>
   <span class="hljs-attr">concentric</span>: <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"> node </span>)</span>{ <span class="hljs-comment">// returns numeric value for each node, placing higher nodes in levels towards the centre</span>
   <span class="hljs-keyword">return</span> node.degree();
   },
-  <span class="hljs-attr">levelWidth</span>: <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"> nodes </span>)</span>{ <span class="hljs-comment">// the letiation of concentric values in each level</span>
+  <span class="hljs-attr">levelWidth</span>: <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"> nodes </span>)</span>{ <span class="hljs-comment">// the variation of concentric values in each level</span>
   <span class="hljs-keyword">return</span> nodes.maxDegree() / <span class="hljs-number">4</span>;
   },
   <span class="hljs-attr">animate</span>: <span class="hljs-literal">false</span>, <span class="hljs-comment">// whether to transition the node positions</span>

--- a/src/extensions/layout/concentric.js
+++ b/src/extensions/layout/concentric.js
@@ -18,7 +18,7 @@ let defaults = {
   concentric: function( node ){ // returns numeric value for each node, placing higher nodes in levels towards the centre
     return node.degree();
   },
-  levelWidth: function( nodes ){ // the letiation of concentric values in each level
+  levelWidth: function( nodes ){ // the variation of concentric values in each level
     return nodes.maxDegree() / 4;
   },
   animate: false, // whether to transition the node positions


### PR DESCRIPTION
I think what probably happened was someone originally wrote "variation" and then there was a search and replace for /^var/ to "let" 😂