### PR TITLE
Change ellipsis label logic

### DIFF
--- a/src/extensions/renderer/base/coord-ele-math/labels.js
+++ b/src/extensions/renderer/base/coord-ele-math/labels.js
@@ -415,6 +415,10 @@ BRp.getLabelText = function( ele, prefix ){
     let ellipsis = '\u2026';
     let incLastCh = false;
 
+    if (this.calculateLabelDimensions(ele, text).width < maxW) { // the label already fits
+      return text;
+    }
+
     for( let i = 0; i < text.length; i++ ){
       let widthWithNextCh = this.calculateLabelDimensions( ele, ellipsized + text[i] + ellipsis ).width;
 


### PR DESCRIPTION
 - Fixes cytoscape/cytoscape.js#2761
 - New logic will first test if the full label fits in the node, if it does, use the full label. Otherwise, the old logic will apply since we know we are going to be using ellipsis (label doesn't fit).

<!--
If you do not have a separate GitHub issue for this PR, then fill out the following sections.  If you have created a separate issue for this PR, then please link to it instead of filling out the sections.
-->
