### PR TITLE
"npm run benchmark" runs all benchmarks

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "docs:js": "cpy build/cytoscape.min.js documentation/js",
     "docs:build": "node documentation/docmaker.js",
     "docs:push": "gh-pages -d documentation",
-    "benchmark": "run-s benchmark:single",
+    "benchmark": "run-s benchmark:all",
     "benchmark:download": "download https://raw.githubusercontent.com/cytoscape/cytoscape.js/master/dist/cytoscape.cjs.js --out build --filename cytoscape.benchmark.js",
     "benchmark:all:exec": "node benchmark/all",
     "benchmark:all": "run-s benchmark:download benchmark:all:exec",


### PR DESCRIPTION
https://github.com/cytoscape/cytoscape.js/blob/unstable/README.md#build-instructions

According to docs "npm run benchmark" should run all benchmarks, but currently only runs single benchmark.
This was changed so that it aligns with the docs.