### PR TITLE
Use only https assets in tokyo-railways demo

### DIFF
--- a/documentation/demos/tokyo-railways/index.html
+++ b/documentation/demos/tokyo-railways/index.html
@@ -6,7 +6,7 @@
 <meta charset=utf-8 />
 <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
 <title>Tokyo railways</title>
-  <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet" />
+  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="https://unpkg.com/tippy.js@2.0.9/dist/tippy.css" />
   <link href="style.css" rel="stylesheet">
 </head>
@@ -17,7 +17,7 @@
   </div>
   <button id="clear">CLEAR</button>
 
-  <script src="http://cdnjs.cloudflare.com/ajax/libs/bluebird/1.2.2/bluebird.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/1.2.2/bluebird.min.js"></script>
   <script src="https://unpkg.com/whatwg-fetch@3.0.0/dist/fetch.umd.js"></script>
   <script src="https://unpkg.com/popper.js@1.14.4/dist/umd/popper.js"></script>
   <script src="https://unpkg.com/tippy.js@2.0.9/dist/tippy.all.js"></script>


### PR DESCRIPTION
Firefox blocks loading of http scripts on  https pages by default, resulting in a broken demo.

See https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content#Types_of_mixed_content

**Issue type**
Issue on the website

**Current (buggy) behaviour**
Demo doesn't load in firefox

**Desired behaviour**

Demo should load in firefox

**Minimum steps to reproduce**

1. Open https://js.cytoscape.org/demos/tokyo-railways/ in firefox
2. Open console and see the warning about mixed content
