### PR TITLE
Clarify that cy.json requires element IDs(#2805)

### DIFF
--- a/debug/FileSaver.js
+++ b/debug/FileSaver.js
@@ -30,7 +30,7 @@
     if (typeof opts === 'undefined') opts = {
       autoBom: false
     };else if (typeof opts !== 'object') {
-      console.warn('Depricated: Expected third argument to be a object');
+      console.warn('Deprecated: Expected third argument to be a object');
       opts = {
         autoBom: !opts
       };

--- a/documentation/md/core/json.md
+++ b/documentation/md/core/json.md
@@ -12,6 +12,8 @@ When setting `cy.json({ elements: ... })`
 * the included elements not in the graph are added, and
 * the not included elements are removed from the graph.
 
+Note that updating the Graph elements using `cy.json()` requires all elements to have an ID attribute. Elements that do not have an ID will be ignored.
+
 When setting `cy.json({ style: ... })`
 
 * the entire stylesheet is replaced, and

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -332,6 +332,12 @@ util.extend( corefn, {
 
           for( let i = 0; i < jsons.length; i++ ){
             let json = jsons[ i ];
+
+            if( !json.data.id ){
+              util.warn( 'cy.json() cannot handle elements without an ID attribute' );
+              continue;
+            }
+
             let id = '' + json.data.id; // id must be string
             let ele = cy.getElementById( id );
 


### PR DESCRIPTION
Closes #2805. Also fixes a typo in `debug/FileSaver.js` i randomly stumbled upon.

(I added an continue statement to skip elements without IDs, as they were previously added just to be removed again)