### PR TITLE
Update markovClustering.md

### DIFF
--- a/documentation/md/collection/markovClustering.md
+++ b/documentation/md/collection/markovClustering.md
@@ -7,7 +7,7 @@ This function returns an array, containing collections.  Each collection in the 
 ## Examples
 
 ```js
-var clusters = cy.elements().markovCluster({
+var clusters = cy.elements().markovClustering({
   attributes: [
     function( edge ){ return edge.data('closeness'); }
   ]


### PR DESCRIPTION
Documentation incorrectly refers to the method as `markovCluster` instead of `markovClustering`