### PR TITLE
Add edge-style property

### DIFF
--- a/debug/init.js
+++ b/debug/init.js
@@ -30,6 +30,15 @@ var cy, defaultSty, options;
           'segment-distances': [ 20, -80 ],
           'segment-weights': [ 0.25, 0.5 ],
         })
+      .selector('#ef')
+        .style({
+          'curve-style': 'straight-triangle',
+          'source-arrow-shape': 'none',
+          'target-arrow-shape': 'none',
+          'mid-target-arrow-shape': 'none',
+          'mid-source-arrow-shape': 'none',
+          'width': 6,
+        })
       .selector('[source = "c"][target = "e"]')
         .style({
           'curve-style': 'haystack',
@@ -86,7 +95,8 @@ var cy, defaultSty, options;
         { data: { id: 'de3', weight: 7, source: 'd', target: 'e' } },
         { data: { id: 'de4', weight: 7, source: 'd', target: 'e' } },
         { data: { id: 'de5', weight: 7, source: 'd', target: 'e' } },
-        { data: { id: 'bf', weight: 3, source: 'b', target: 'f' } }
+        { data: { id: 'bf', weight: 3, source: 'b', target: 'f' } },
+        { data: { id: 'ef', weight: 3, source: 'e', target: 'f' } }
       ]
     }
   };

--- a/documentation/demos/edge-types/cy-style.json
+++ b/documentation/demos/edge-types/cy-style.json
@@ -60,4 +60,10 @@
     "taxi-turn": 20,
     "taxi-turn-min-distance": 5
   }
+}, {
+  "selector": "edge.straight-triangle",
+  "style": {
+    "curve-style": "straight-triangle",
+    "width": 10
+  }
 }]

--- a/documentation/demos/edge-types/data.json
+++ b/documentation/demos/edge-types/data.json
@@ -159,4 +159,19 @@
     "target": "n16"
   },
   "classes": "loop"
+}, {
+  "data": {
+    "id": "n17",
+    "type": "straight-triangle"
+  }
+}, {
+  "data": {
+    "id": "n18"
+  }
+}, {
+  "data": {
+    "source": "n17",
+    "target": "n18"
+  },
+  "classes": "straight-triangle"
 }]

--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -424,7 +424,9 @@ A straight edge (`curve-style: straight`) is drawn as a single straight line fro
 
 For straight triangle edges (`curve-style: straight-triangle`, [demo](demos/edge-types)):
 
-A straight triangle edge (`curve-style: straight-triangle`) is drawn as a single straight triangle from the outside of the source node shape to the outside of the target node shape.  `width` defines triangle width at the source. Arrows are not supported on triangle edges.
+A straight triangle edge (`curve-style: straight-triangle`) is drawn as a single straight isosceles triangle in the direction from the source to the target.
+
+Property `width` defines line width at the triangle base, line width is `0` at the triangle apex.  Properties `line-style`, `line-cap`, `line-dash-pattern`, `line-dash-offset` are not supported.
 
 
 ## Taxi edges

--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -424,9 +424,9 @@ A straight edge (`curve-style: straight`) is drawn as a single straight line fro
 
 For straight triangle edges (`curve-style: straight-triangle`, [demo](demos/edge-types)):
 
-A straight triangle edge (`curve-style: straight-triangle`) is drawn as a single straight isosceles triangle in the direction from the source to the target.
+A straight triangle edge (`curve-style: straight-triangle`) is drawn as a single straight isosceles triangle in the direction from the source to the target, with a triangle base at the source and a triangle apex (a point) at the target.
 
-Property `width` defines line width at the triangle base, line width is `0` at the triangle apex.  Properties `line-style`, `line-cap`, `line-dash-pattern`, `line-dash-offset` are not supported.
+Property `width` defines width of the triangle base.  Properties `line-style`, `line-cap`, `line-dash-pattern`, `line-dash-offset` are not supported.
 
 
 ## Taxi edges

--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -336,7 +336,7 @@ The following is an example of valid background image styling using JSON. The ex
 These properties affect the styling of an edge's line:
 
  * **`width`** : The width of an edge's line.
- * **`curve-style`** : The curving method used to separate two or more edges between two nodes ([demo](demos/edge-types)); may be [`haystack`](#style/haystack-edges) (default, very fast, bundled straight edges for which loops and compounds are unsupported), [`straight`](#style/straight-edges) (straight edges with all arrows supported), [`bezier`](#style/bezier-edges) (bundled curved edges), [`unbundled-bezier`](#style/unbundled-bezier-edges) (curved edges for use with manual control points),  [`segments`](#style/segments-edges) (a series of straight lines), [`taxi`](#style/taxi-edges) (right-angled lines, hierarchically bundled).  Note that `haystack` edges work best with `ellipse`, `rectangle`, or similar nodes.  Smaller node shapes, like `triangle`, will not be as aesthetically pleasing.  Also note that edge endpoint arrows are unsupported for `haystack` edges.
+ * **`curve-style`** : The curving method used to separate two or more edges between two nodes ([demo](demos/edge-types)); may be [`haystack`](#style/haystack-edges) (default, very fast, bundled straight edges for which loops and compounds are unsupported), [`straight`](#style/straight-edges) (straight edges with all arrows supported), [`straight-triangle`](#style/straight-triangle-edges) (straight triangle edges), [`bezier`](#style/bezier-edges) (bundled curved edges), [`unbundled-bezier`](#style/unbundled-bezier-edges) (curved edges for use with manual control points),  [`segments`](#style/segments-edges) (a series of straight lines), [`taxi`](#style/taxi-edges) (right-angled lines, hierarchically bundled).  Note that `haystack` edges work best with `ellipse`, `rectangle`, or similar nodes.  Smaller node shapes, like `triangle`, will not be as aesthetically pleasing.  Also note that edge endpoint arrows are unsupported for `haystack` edges.
  * **`line-color`** : The colour of the edge's line.
  * **`line-style`** : The style of the edge's line; may be `solid`, `dotted`, or `dashed`.
  * **`line-cap`** : The cap style of the edge's line; may be `butt` (default), `round`, or `square`.  The cap may or may not be visible, depending on the shape of the node and the relative size of the node and edge.  Caps other than `butt` extend beyond the specified endpoint of the edge.
@@ -418,6 +418,13 @@ A segment edge is made of a series of one or more straight lines, using a co-ord
 For straight line edges (`curve-style: straight`, [demo](demos/edge-types)):
 
 A straight edge (`curve-style: straight`) is drawn as a single straight line from the outside of the source node shape to the outside of the target node shape.  Endpoint and midpoint arrows are supported on straight edges.  Straight edges are not generally suitable for multigraphs.
+
+
+## Straight triangle edges
+
+For straight triangle edges (`curve-style: straight-triangle`, [demo](demos/edge-types)):
+
+A straight triangle edge (`curve-style: straight-triangle`) is drawn as a single straight triangle from the outside of the source node shape to the outside of the target node shape.  `width` defines triangle width at the source. Arrows are not supported on triangle edges.
 
 
 ## Taxi edges

--- a/src/extensions/renderer/base/coord-ele-math/edge-control-points.js
+++ b/src/extensions/renderer/base/coord-ele-math/edge-control-points.js
@@ -650,7 +650,7 @@ BRp.findEdgeControlPoints = function( edges ){
       continue;
     }
 
-    let edgeIsUnbundled = curveStyle === 'unbundled-bezier' || curveStyle === 'segments' || curveStyle === 'straight' || curveStyle === 'taxi';
+    let edgeIsUnbundled = curveStyle === 'unbundled-bezier' || curveStyle === 'segments' || curveStyle === 'straight' || curveStyle === 'straight-triangle' || curveStyle === 'taxi';
     let edgeIsBezier = curveStyle === 'unbundled-bezier' || curveStyle === 'bezier';
     let src = _p.source;
     let tgt = _p.target;

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -57,7 +57,7 @@ const styfn = {};
     lineStyle: { enums: [ 'solid', 'dotted', 'dashed' ] },
     lineCap: { enums: [ 'butt', 'round', 'square' ] },
     borderStyle: { enums: [ 'solid', 'dotted', 'dashed', 'double' ] },
-    curveStyle: { enums: [ 'bezier', 'unbundled-bezier', 'haystack', 'segments', 'straight', 'taxi' ] },
+    curveStyle: { enums: [ 'bezier', 'unbundled-bezier', 'haystack', 'segments', 'straight', 'straight-triangle', 'taxi' ] },
     fontFamily: { regex: '^([\\w- \\"]+(?:\\s*,\\s*[\\w- \\"]+)*)$' },
     fontStyle: { enums: [ 'italic', 'normal', 'oblique' ] },
     fontWeight: { enums: [ 'normal', 'bold', 'bolder', 'lighter', '100', '200', '300', '400', '500', '600', '800', '900', 100, 200, 300, 400, 500, 600, 700, 800, 900 ] },


### PR DESCRIPTION
Adds a new `edge-style` property, may be `line` (default), or `triangle`.

![Screen Shot 2021-06-28 at 9 47 56](https://user-images.githubusercontent.com/173585/123599505-f3ab9600-d7f5-11eb-8f8d-fd4b8e1edce2.png)

Closes #2883