### PR TITLE
Optimize cose performance when no gravity is requested

### DIFF
--- a/src/extensions/layout/cose.js
+++ b/src/extensions/layout/cose.js
@@ -993,6 +993,10 @@ var calculateEdgeForces = function( layoutInfo, options ){
  * @brief : Computes gravity forces for all nodes
  */
 var calculateGravityForces = function( layoutInfo, options ){
+  if (options.gravity === 0) {
+    return;
+  }
+
   var distThreshold = 1;
 
   // var s = 'calculateGravityForces';


### PR DESCRIPTION
<!--
If you do not have a separate GitHub issue for this PR, then fill out the following sections.  If you have created a separate issue for this PR, then please link to it instead of filling out the sections.
-->

**Issue type**
This PR is related to the https://github.com/cytoscape/cytoscape.js/issues/2898

<!--
Are you submitting a bug report or a feature request?

When submitting a bug report, check the following:
- The report has a descriptive title.
- The bug still exists in most recent version of the library.
-->

<!-- Delete one option -->


<!-- BUG REPORT : Delete if requesting a feature -->

**Environment info**

- Cytoscape.js version: any
- Browser/Node.js & version: all browsers, all nodejs versions

**Current (buggy) behaviour**
When the cose gravity is configured to 0 (zero), the cose `calculateGravityForces` can be omitted as the result is known before it's execution. Please note, the `calculateGravityForces` can take really long time in graphs with huge number of nodes and/or edges.

<!-- What does the bug do? -->


**Desired behaviour**
Skip the `calculateGravityForces` when gravity is configured to 0 (zero).
<!-- What do you expect Cytoscape.js to do instead? -->


**Minimum steps to reproduce**
see the https://github.com/cytoscape/cytoscape.js/issues/2898

<!--
Write out an overview of what you need to do to reproduce the issue.

Fork/clone this JSBin demo and reproduce your issue so that your issue can be addressed quickly:
http://jsbin.com/fiqugiq

If your code to reproduce is only two or three lines, you can write it in the issue instead.  Format your code in backtick code blocks like this:

```js
my.code();
```
-->

<!-- END BUG REPORT -->


