### PR TITLE
Add functions to convert bend(anchor) points to relative positions

### DIFF
--- a/documentation/docmaker.json
+++ b/documentation/docmaker.json
@@ -950,6 +950,58 @@
         },
 
         {
+          "name": "Edge points",
+          "fns": [
+            {
+              "name": "cy.segmentsToRelativePositions",
+              "descr": "Convert segment points in absolute positions into segment distances and weights and return them.",
+              "formats": [
+                {
+                  "args": [
+                    {
+                      "name": "segmentPoints",
+                      "descr": "The segment points to be converted"
+                    },
+                    {
+                      "name": "sourcePoint",
+                      "descr": "The source point of the edge."
+                    },
+                    {
+                      "name": "targetPoint",
+                      "descr": "The target point of the edge."
+                    }                                       
+                  ]
+                }
+              ],
+              "md": "core/segmentsToRelativePositions"
+            },
+            {
+              "name": "cy.controlsToRelativePositions",
+              "descr": "Convert control points in absolute positions into control point distances and weights and return them.",
+              "formats": [
+                {
+                  "args": [
+                    {
+                      "name": "controlPoints",
+                      "descr": "The control points to be converted"
+                    },
+                    {
+                      "name": "sourcePoint",
+                      "descr": "The source point of the edge."
+                    },
+                    {
+                      "name": "targetPoint",
+                      "descr": "The target point of the edge."
+                    }                                       
+                  ]
+                }
+              ],
+              "md": "core/controlsToRelativePositions"
+            }            
+          ]
+        },        
+
+        {
           "name": "Style",
 
           "fns": [

--- a/documentation/md/core/controlsToRelativePositions.md
+++ b/documentation/md/core/controlsToRelativePositions.md
@@ -1,0 +1,18 @@
+## Details
+
+This function converts given `controlPoints` for an edge with `sourcePoint` and `targetPoint` into corresponding `control-point-distances` and `control-point-weights` and returns them.
+
+`sourcePoint` and `targetPoint` can be either the source and target node positions as in the case of `edge-distances: 'node-position'` or the ends of the line from source to target which is from the outside of the source node’s shape to the outside of the target node’s shape as in the case of `edge-distances: 'intersection'`.
+
+## Examples
+
+```js
+var je = cy.$('#je');
+var controlPoints = je.controlPoints();
+var jPos = je.source().position();
+var ePos = je.target().position();
+
+var result = cy.controlsToRelativePositions(controlPoints, jPos, ePos);
+var controlPointDistances = result.distances;
+var controlPointWeights = result.weights;
+```

--- a/documentation/md/core/segmentsToRelativePositions.md
+++ b/documentation/md/core/segmentsToRelativePositions.md
@@ -1,0 +1,18 @@
+## Details
+
+This function converts given `segmentPoints` for an edge with `sourcePoint` and `targetPoint` into corresponding `segment-distances` and `segment-weights` and returns them.
+
+`sourcePoint` and `targetPoint` can be either the source and target node positions as in the case of `edge-distances: 'node-position'` or the ends of the line from source to target which is from the outside of the source node’s shape to the outside of the target node’s shape as in the case of `edge-distances: 'intersection'`.
+
+## Examples
+
+```js
+var je = cy.$('#je');
+var segmentPoints = je.segmentPoints();
+var jPos = je.source().position();
+var ePos = je.target().position();
+
+var result = cy.segmentsToRelativePositions(segmentPoints, jPos, ePos);
+var segmentDistances = result.distances;
+var segmentWeights = result.weights;
+```

--- a/src/core/edgePoints.js
+++ b/src/core/edgePoints.js
@@ -1,0 +1,151 @@
+let corefn = ({
+
+  segmentsToRelativePositions: function( segmentPoints, sourcePoint, targetPoint ){
+    let result = convertToRelativePositions( segmentPoints, sourcePoint, targetPoint );
+
+    return { distances: result.distances, weights: result.weights };
+  },
+
+  controlsToRelativePositions: function( controlPoints, sourcePoint, targetPoint ){
+    let result = convertToRelativePositions( controlPoints, sourcePoint, targetPoint );
+    
+    return { distances: result.distances, weights: result.weights };
+  }
+
+});
+
+/** functions required to convert bend(anchor) points to segment/control points **/
+
+function getSrcTgtPointsAndTangents(srcPoint, tgtPoint) {
+  let m1 = (tgtPoint.y - srcPoint.y) / (tgtPoint.x - srcPoint.x);
+  let m2 = -1 / m1;
+
+  return {
+    m1: m1,
+    m2: m2,
+    srcPoint: srcPoint,
+    tgtPoint: tgtPoint
+  };
+};
+
+function getIntersection( anchor, srcTgtPointsAndTangents ){
+  let srcPoint = srcTgtPointsAndTangents.srcPoint;
+  let tgtPoint = srcTgtPointsAndTangents.tgtPoint;
+  let m1 = srcTgtPointsAndTangents.m1;
+  let m2 = srcTgtPointsAndTangents.m2;
+
+  let intersectX;
+  let intersectY;
+
+  if(m1 == Infinity || m1 == -Infinity){
+    intersectX = srcPoint.x;
+    intersectY = anchor.y;
+  }
+  else if(m1 == 0){
+    intersectX = anchor.x;
+    intersectY = srcPoint.y;
+  }
+  else {
+    let a1 = srcPoint.y - m1 * srcPoint.x;
+    let a2 = anchor.y - m2 * anchor.x;
+
+    intersectX = (a2 - a1) / (m1 - m2);
+    intersectY = m1 * intersectX + a1;
+  }
+
+  // intersection point is the intersection of the lines passing through the nodes and
+  // passing through the bend or control point and perpendicular to the other line
+  let intersectionPoint = {
+    x: intersectX,
+    y: intersectY
+  };
+  
+  return intersectionPoint;
+};
+
+function getLineDirection( srcPoint, tgtPoint ){
+  if(srcPoint.y == tgtPoint.y && srcPoint.x < tgtPoint.x){
+    return 1;
+  }
+  if(srcPoint.y < tgtPoint.y && srcPoint.x < tgtPoint.x){
+    return 2;
+  }
+  if(srcPoint.y < tgtPoint.y && srcPoint.x == tgtPoint.x){
+    return 3;
+  }
+  if(srcPoint.y < tgtPoint.y && srcPoint.x > tgtPoint.x){
+    return 4;
+  }
+  if(srcPoint.y == tgtPoint.y && srcPoint.x > tgtPoint.x){
+    return 5;
+  }
+  if(srcPoint.y > tgtPoint.y && srcPoint.x > tgtPoint.x){
+    return 6;
+  }
+  if(srcPoint.y > tgtPoint.y && srcPoint.x == tgtPoint.x){
+    return 7;
+  }
+  return 8; // if srcPoint.y > tgtPoint.y and srcPoint.x < tgtPoint.x
+};
+
+function convertToRelativePosition( anchor, srcTgtPointsAndTangents ){
+  let intersectionPoint = getIntersection(anchor, srcTgtPointsAndTangents);
+  let intersectX = intersectionPoint.x;
+  let intersectY = intersectionPoint.y;
+  
+  let srcPoint = srcTgtPointsAndTangents.srcPoint;
+  let tgtPoint = srcTgtPointsAndTangents.tgtPoint;
+  
+  let weight;
+  
+  if( intersectX != srcPoint.x ) {
+    weight = (intersectX - srcPoint.x) / (tgtPoint.x - srcPoint.x);
+  }
+  else if( intersectY != srcPoint.y ) {
+    weight = (intersectY - srcPoint.y) / (tgtPoint.y - srcPoint.y);
+  }
+  else {
+    weight = 0;
+  }
+  
+  let distance = Math.sqrt(Math.pow((intersectY - anchor.y), 2)
+      + Math.pow((intersectX - anchor.x), 2));
+  
+  // get the direction of the line form source point to target point
+  let direction1 = getLineDirection(srcPoint, tgtPoint);
+  // get the direction of the line from intesection point to the point
+  let direction2 = getLineDirection(intersectionPoint, anchor);
+  
+  // if the difference is not -2 and not 6 then the direction of the distance is negative
+  if(direction1 - direction2 != -2 && direction1 - direction2 != 6){
+    if(distance != 0)
+      distance = -1 * distance;
+  }
+  
+  return {
+    weight: weight,
+    distance: distance
+  };
+};
+
+function convertToRelativePositions( anchorPoints, srcPoint, tgtPoint ){
+  let srcTgtPointsAndTangents = getSrcTgtPointsAndTangents(srcPoint, tgtPoint);
+
+  let weights = [];
+  let distances = [];
+
+  for (let i = 0; anchorPoints && i < anchorPoints.length; i++) {
+    let anchor = anchorPoints[i];
+    let relativeAnchorPosition = convertToRelativePosition(anchor, srcTgtPointsAndTangents);
+
+    weights.push(relativeAnchorPosition.weight);
+    distances.push(relativeAnchorPosition.distance);
+  }
+
+  return {
+    weights: weights,
+    distances: distances
+  };
+};
+
+export default corefn;

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -15,6 +15,7 @@ import search from './search';
 import style from './style';
 import viewport from './viewport';
 import data from './data';
+import edgePoints from './edgePoints';
 
 let Core = function( opts ){
   let cy = this;
@@ -501,7 +502,8 @@ corefn.$id = corefn.getElementById;
   search,
   style,
   viewport,
-  data
+  data,
+  edgePoints
 ].forEach( function( props ){
   util.extend( corefn, props );
 } );


### PR DESCRIPTION
Add `segmentsToRelativePositions` and `controlsToRelativePositions` functions to core (cytoscape/cytoscape.js-elk#38)

<!-- FEATURE REQUEST : Delete if reporting a bug -->

**Description of new feature**

The below two functions convert given segment/control points in absolute coordinates to segment/control distances and weights:

```
cy.segmentsToRelativePositions( segmentPoints, sourcePoint, targetPoint )
cy.controlsToRelativePositions( controlPoints, sourcePoint, targetPoint )
```
and returns:
`{distances: [distance1, distance2, ...], weights: [weight1, weight2, ...]}`

**Motivation for new feature**

Currently a user can set relative segment/control point distances and weight via style properties such as `segment-distances` and `segment-weights` etc. and then can reach absolute coordinates of these points via `edge.segmentPoints()` and `edge.controlPoints()` functions. However, conversion from absolute coordinates to relative positions is currently not possible. With the help of these functions, user who has absolute coordinates can achieve this conversion and assign relative coordinates to corresponding edge styles.


<!-- END FEATURE REQUEST -->
