### PR TITLE
Concentric layout: check data fields before falling back to node degree

### DIFF
--- a/src/extensions/layout/concentric.js
+++ b/src/extensions/layout/concentric.js
@@ -16,7 +16,7 @@ let defaults = {
   width: undefined, // width of layout area (overrides container width)
   spacingFactor: undefined, // Applies a multiplicative factor (>0) to expand or compress the overall area that the nodes take up
   concentric: function( node ){ // returns numeric value for each node, placing higher nodes in levels towards the centre
-    return node.degree();
+    return node.data('concentricLevelValue') || node.degree();
   },
   levelWidth: function( nodes ){ // the variation of concentric values in each level
     return nodes.maxDegree() / 4;


### PR DESCRIPTION

<!--
If you do not have a separate GitHub issue for this PR, then fill out the following sections.  If you have created a separate issue for this PR, then please link to it instead of filling out the sections.
-->

**Issue type**

Feature request



<!-- FEATURE REQUEST : Delete if reporting a bug -->

**Description of new feature**

[Concentric layout](https://js.cytoscape.org/#layouts/concentric) would allow the user by default to set the node level from a data field `concentricLevelValue` before falling back to the node degree. The same is for the `levelWidth` value and the `concentricLevelWidth` field

**Motivation for new feature**

<!-- Describe your use case for this new feature. -->
Documented in #2945 

<!-- END FEATURE REQUEST -->
