### PR TITLE
Update bundled beziers when setting display: none

### DIFF
--- a/src/style/apply.js
+++ b/src/style/apply.js
@@ -821,8 +821,10 @@ styfn.checkBoundsTrigger = function( ele, name, fromValue, toValue ){
     // if the prop change makes the bb of pll bezier edges invalid,
     // then dirty the pll edge bb cache as well
     if( // only for beziers -- so performance of other edges isn't affected
-      ( name === 'curve-style' && (fromValue === 'bezier' || toValue === 'bezier') )
-      && prop.triggersBoundsOfParallelBeziers
+      prop.triggersBoundsOfParallelBeziers
+      && ( ( name === 'curve-style' && (fromValue === 'bezier' || toValue === 'bezier') )
+        || ( name === 'display' && (fromValue === 'none' || toValue === 'none') )  
+      )
     ){
       ele.parallelEdges().forEach(pllEdge => {
         if( pllEdge.isBundledBezier() ){


### PR DESCRIPTION
Associated issues: #3012

- Invalidates the bounding box cache for bundled bezier edges if one of them is set to display: none, or if display: none is removed.

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.
- [ ] Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
