### PR TITLE
Using img.naturalWidth to fix Uncaught DOMException: Failed to execute 'drawImage'

### DIFF
--- a/src/extensions/renderer/canvas/drawing-images.js
+++ b/src/extensions/renderer/canvas/drawing-images.js
@@ -1,3 +1,5 @@
+import * as util from '../../../util';
+
 var CRp = {};
 
 CRp.safeDrawImage = function( context, img, ix, iy, iw, ih, x, y, w, h ){
@@ -6,7 +8,11 @@ CRp.safeDrawImage = function( context, img, ix, iy, iw, ih, x, y, w, h ){
     return;
   }
 
-  context.drawImage( img, ix, iy, iw, ih, x, y, w, h );
+  try {
+    context.drawImage( img, ix, iy, iw, ih, x, y, w, h );
+  } catch (e) {
+    util.warn(e);
+  }
 };
 
 CRp.drawInscribedImage = function( context, img, node, index, nodeOpacity ){

--- a/src/extensions/renderer/canvas/drawing-images.js
+++ b/src/extensions/renderer/canvas/drawing-images.js
@@ -1,5 +1,3 @@
-import * as util from '../../../util';
-
 var CRp = {};
 
 CRp.safeDrawImage = function( context, img, ix, iy, iw, ih, x, y, w, h ){
@@ -8,11 +6,7 @@ CRp.safeDrawImage = function( context, img, ix, iy, iw, ih, x, y, w, h ){
     return;
   }
 
-  try {
-    context.drawImage( img, ix, iy, iw, ih, x, y, w, h );
-  } catch (e) {
-    util.warn(e);
-  }
+  context.drawImage( img, ix, iy, iw, ih, x, y, w, h );
 };
 
 CRp.drawInscribedImage = function( context, img, node, index, nodeOpacity ){

--- a/src/extensions/renderer/canvas/drawing-nodes.js
+++ b/src/extensions/renderer/canvas/drawing-nodes.js
@@ -152,7 +152,7 @@ CRp.drawNode = function( context, node, shiftToOriginWithBb, drawLabel = true, s
         continue;
       }
 
-      if( urlDefined[i] && image[i].complete && !image[i].error ){
+      if( urlDefined[i] && image[i].complete && !image[i].error && image[i].naturalWidth !== 0 ){
         totalCompleted++;
         r.drawInscribedImage( context, image[i], node, i, nodeOpacity );
       }


### PR DESCRIPTION
Associated issues: [2949](https://github.com/cytoscape/cytoscape.js/issues/2949)

There are some cases when we get this error:
```
Uncaught DOMException: Failed to execute 'drawImage' on 'OffscreenCanvasRenderingContext2D': The HTMLImageElement provided is in the 'broken' state.
    at push.../../node_modules/cytoscape/dist/cytoscape.cjs.js.CRp$3.safeDrawImage
```
This happens when we try to draw images on canvas that are not properly loaded. 
This PR adds checking if `img.naturalWidth !== 0`, so we can assume that image is complete and is not corrupted.

HTMLImageElement .naturalWidth has [full browser support](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/naturalWidth) and similar approach with checking naturalWidth property is used in [imagesLoaded library](https://github.com/desandro/imagesloaded/blob/master/imagesloaded.js)

This PR is an alternative solution to the [PR 3035](https://github.com/cytoscape/cytoscape.js/pull/3035) to fix the same issue.
I think this one for sure will not affect performance.

**Checklist**

Author:

- [ ] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [ ] The associated GitHub issues are included (above).
- [ ] Notes have been included (above).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
