### PR TITLE
add acyclic option to breadthfirst layout

### DIFF
--- a/src/extensions/layout/breadthfirst.js
+++ b/src/extensions/layout/breadthfirst.js
@@ -15,6 +15,7 @@ const defaults = {
   nodeDimensionsIncludeLabels: false, // Excludes the label when calculating node bounding boxes for the layout algorithm
   roots: undefined, // the roots of the trees
   maximal: false, // whether to shift nodes down their natural BFS depths in order to avoid upwards edges (DAGS only)
+  acyclic: false, // whether the tree is acyclic and thus a node could be shifted (due to the maximal option) multiple times without causing an infinite loop; if you are uncertain whether a tree is acyclic, set to false to avoid potential infinite loops
   depthSort: undefined, // a sorting function to order nodes at equal depth. e.g. function(a, b){ return a.data('weight') - b.data('weight') }
   animate: false, // whether to transition the node positions
   animationDuration: 500, // duration of animation in ms if enabled
@@ -22,8 +23,7 @@ const defaults = {
   animateFilter: function ( node, i ){ return true; }, // a function that determines whether the node should be animated.  All nodes animated by default on animate enabled.  Non-animated nodes are positioned immediately when the layout starts
   ready: undefined, // callback on layoutready
   stop: undefined, // callback on layoutstop
-  transform: function (node, position ){ return position; }, // transform a given node position. Useful for changing flow direction in discrete layouts
-  acyclic: false // whether the tree is acyclic; if uncertain, set to false to avoid potential infinite loops
+  transform: function (node, position ){ return position; } // transform a given node position. Useful for changing flow direction in discrete layouts
 };
 /* eslint-enable */
 

--- a/src/extensions/layout/breadthfirst.js
+++ b/src/extensions/layout/breadthfirst.js
@@ -14,8 +14,8 @@ const defaults = {
   avoidOverlap: true, // prevents node overlap, may overflow boundingBox if not enough space
   nodeDimensionsIncludeLabels: false, // Excludes the label when calculating node bounding boxes for the layout algorithm
   roots: undefined, // the roots of the trees
-  maximal: false, // whether to shift nodes down their natural BFS depths in order to avoid upwards edges (DAGS only)
-  acyclic: false, // whether the tree is acyclic and thus a node could be shifted (due to the maximal option) multiple times without causing an infinite loop; if you are uncertain whether a tree is acyclic, set to false to avoid potential infinite loops
+  maximal: false, // whether to shift nodes down their natural BFS depths in order to avoid upwards edges (DAGS only); setting acyclic to true sets maximal to true also
+  acyclic: false, // whether the tree is acyclic and thus a node could be shifted (due to the maximal option) multiple times without causing an infinite loop; setting to true sets maximal to true also; if you are uncertain whether a tree is acyclic, set to false to avoid potential infinite loops
   depthSort: undefined, // a sorting function to order nodes at equal depth. e.g. function(a, b){ return a.data('weight') - b.data('weight') }
   animate: false, // whether to transition the node positions
   animationDuration: 500, // duration of animation in ms if enabled
@@ -43,7 +43,7 @@ BreadthFirstLayout.prototype.run = function(){
   let nodes = eles.nodes().filter( n => !n.isParent() );
   let graph = eles;
   let directed = options.directed;
-  let maximal = options.maximal || options.maximalAdjustments > 0; // maximalAdjustments for compat. w/ old code
+  let maximal = options.acyclic || options.maximal || options.maximalAdjustments > 0; // maximalAdjustments for compat. w/ old code; also, setting acyclic to true sets maximal to true
 
   let bb = math.makeBoundingBox( options.boundingBox ? options.boundingBox : {
     x1: 0, y1: 0, w: cy.width(), h: cy.height()

--- a/src/extensions/layout/breadthfirst.js
+++ b/src/extensions/layout/breadthfirst.js
@@ -22,7 +22,8 @@ const defaults = {
   animateFilter: function ( node, i ){ return true; }, // a function that determines whether the node should be animated.  All nodes animated by default on animate enabled.  Non-animated nodes are positioned immediately when the layout starts
   ready: undefined, // callback on layoutready
   stop: undefined, // callback on layoutstop
-  transform: function (node, position ){ return position; } // transform a given node position. Useful for changing flow direction in discrete layouts
+  transform: function (node, position ){ return position; }, // transform a given node position. Useful for changing flow direction in discrete layouts
+  acyclic: false // whether the tree is acyclic; if uncertain, set to false to avoid potential infinite loops
 };
 /* eslint-enable */
 
@@ -176,12 +177,13 @@ BreadthFirstLayout.prototype.run = function(){
     }
 
     if( eInfo.depth <= maxDepth ){
-      if( shifted[id] ){
+      if( !options.acyclic && shifted[id] ){
         return null;
       }
 
-      changeDepth( ele, maxDepth + 1 );
-      shifted[id] = true;
+      let newDepth = maxDepth + 1;
+      changeDepth( ele, newDepth );
+      shifted[id] = newDepth;
 
       return true;
     }


### PR DESCRIPTION
Associated issue: https://github.com/cytoscape/cytoscape.js/issues/3099

Implement a solution to above-linked issue.

Author:

- [X] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [X] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [X] The associated GitHub issues are included (above).
- [X] Notes have been included (above).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
