### PR TITLE
Add cross-origin 'null' for background-image

### DIFF
--- a/documentation/index.html
+++ b/documentation/index.html
@@ -14014,7 +14014,7 @@ node {
 </li>
 </ul>
 </li>
-<li><strong><code>background-image-crossorigin</code></strong>: All images are loaded with a <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-crossorigin"><code>crossorigin</code></a> attribute which may be <code>anonymous</code> or <code>use-credentials</code>. The default is set to <code>anonymous</code>.</li>
+<li><strong><code>background-image-crossorigin</code></strong>: All images are loaded with a <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-crossorigin"><code>crossorigin</code></a> attribute which may be <code>anonymous</code> or <code>use-credentials</code> or <code>null</code>. The default is set to <code>anonymous</code>.</li>
 <li><strong><code>background-image-opacity</code></strong> : The opacity of the background image.</li>
 <li><strong><code>background-image-smoothing</code></strong> : Determines whether background image is smoothed (<code>yes</code>, default) or not (<code>no</code>). This is only a hint, and the browser may or may not respect the value set for this property.</li>
 <li><strong><code>background-image-containment</code></strong> : Determines whether background image is within (<code>inside</code>, default) or over top of the node(<code>over</code>).</li>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -14014,7 +14014,7 @@ node {
 </li>
 </ul>
 </li>
-<li><strong><code>background-image-crossorigin</code></strong>: All images are loaded with a <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-crossorigin"><code>crossorigin</code></a> attribute which may be <code>anonymous</code> or <code>use-credentials</code> or <code>null</code>. The default is set to <code>anonymous</code>.</li>
+<li><strong><code>background-image-crossorigin</code></strong>: All images are loaded with a <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-crossorigin"><code>crossorigin</code></a> attribute which may be <code>anonymous</code> or <code>use-credentials</code> or <code>null</code>. These values should be passed as a string (enclosed within single or double quotes). The default is set to <code>anonymous</code>.</li>
 <li><strong><code>background-image-opacity</code></strong> : The opacity of the background image.</li>
 <li><strong><code>background-image-smoothing</code></strong> : Determines whether background image is smoothed (<code>yes</code>, default) or not (<code>no</code>). This is only a hint, and the browser may or may not respect the value set for this property.</li>
 <li><strong><code>background-image-containment</code></strong> : Determines whether background image is within (<code>inside</code>, default) or over top of the node(<code>over</code>).</li>

--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -296,7 +296,7 @@ A background image may be applied to a node's body.  The following properties su
     * Using the `viewbox` attribute in SVG images may cause rendering problems in Firefox.
     * SVG images may not work consistently in Internet Explorer.
     * The [`cytoscape-sbgn-stylesheet`](https://github.com/PathwayCommons/cytoscape-sbgn-stylesheet) package serves as a good example for the use of SVG images in a stylesheet.  That stylesheet [creates decorations](https://pathwaycommons.github.io/cytoscape-sbgn-stylesheet/) on nodes in line with the [SBGN standard](https://sbgn.github.io).
-* **`background-image-crossorigin`**: All images are loaded with a [`crossorigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-crossorigin) attribute which may be `anonymous` or `use-credentials` or `null`. The default is set to `anonymous`.
+* **`background-image-crossorigin`**: All images are loaded with a [`crossorigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-crossorigin) attribute which may be `anonymous` or `use-credentials` or `null`. These values should be passed as a string (enclosed withing single or double quotes). The default is set to `anonymous`.
 * **`background-image-opacity`** : The opacity of the background image.
 * **`background-image-smoothing`** : Determines whether background image is smoothed (`yes`, default) or not (`no`). This is only a hint, and the browser may or may not respect the value set for this property.
 * **`background-image-containment`** : Determines whether background image is within (`inside`, default) or over top of the node(`over`).

--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -296,7 +296,7 @@ A background image may be applied to a node's body.  The following properties su
     * Using the `viewbox` attribute in SVG images may cause rendering problems in Firefox.
     * SVG images may not work consistently in Internet Explorer.
     * The [`cytoscape-sbgn-stylesheet`](https://github.com/PathwayCommons/cytoscape-sbgn-stylesheet) package serves as a good example for the use of SVG images in a stylesheet.  That stylesheet [creates decorations](https://pathwaycommons.github.io/cytoscape-sbgn-stylesheet/) on nodes in line with the [SBGN standard](https://sbgn.github.io).
-* **`background-image-crossorigin`**: All images are loaded with a [`crossorigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-crossorigin) attribute which may be `anonymous` or `use-credentials`. The default is set to `anonymous`.
+* **`background-image-crossorigin`**: All images are loaded with a [`crossorigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-crossorigin) attribute which may be `anonymous` or `use-credentials` or `null`. The default is set to `anonymous`.
 * **`background-image-opacity`** : The opacity of the background image.
 * **`background-image-smoothing`** : Determines whether background image is smoothed (`yes`, default) or not (`no`). This is only a hint, and the browser may or may not respect the value set for this property.
 * **`background-image-containment`** : Determines whether background image is within (`inside`, default) or over top of the node(`over`).

--- a/src/extensions/renderer/base/images.js
+++ b/src/extensions/renderer/base/images.js
@@ -24,6 +24,8 @@ BRp.getCachedImage = function( url, crossOrigin, onLoad ){
     var dataUriPrefix = 'data:';
     var isDataUri = url.substring( 0, dataUriPrefix.length ).toLowerCase() === dataUriPrefix;
     if( !isDataUri ){
+      // if crossorigin is 'null'(stringified), then manually set it to null 
+      crossOrigin = crossOrigin === 'null' ? null : crossOrigin;
       image.crossOrigin = crossOrigin; // prevent tainted canvas
     }
 

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -46,7 +46,7 @@ const styfn = {};
     bgRelativeTo: { enums: [ 'inner', 'include-padding' ], multiple: true },
     bgRepeat: { enums: [ 'repeat', 'repeat-x', 'repeat-y', 'no-repeat' ], multiple: true },
     bgFit: { enums: [ 'none', 'contain', 'cover' ], multiple: true },
-    bgCrossOrigin: { enums: [ 'anonymous', 'use-credentials' ], multiple: true },
+    bgCrossOrigin: { enums: [ 'anonymous', 'use-credentials', 'null' ], multiple: true },
     bgClip: { enums: [ 'none', 'node' ], multiple: true },
     bgContainment: { enums: [ 'inside', 'over' ], multiple: true },
     color: { color: true },


### PR DESCRIPTION
Associated issues: #3073

- This PR adds a feature to add the cross-origin value of 'null' for background-images.

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.
- [x] Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
