### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/collection/algorithms/k-clustering.js
+++ b/src/collection/algorithms/k-clustering.js
@@ -284,7 +284,7 @@ let kMedoids = function( options ) {
     }
 
     isStillMoving = false;
-    // Step 3: For each medoid m, and for each node assciated with mediod m,
+    // Step 3: For each medoid m, and for each node associated with mediod m,
     // select the node with the lowest configuration cost as new medoid.
     for ( let m = 0; m < medoids.length; m++ ) {
 

--- a/src/extensions/layout/cose.js
+++ b/src/extensions/layout/cose.js
@@ -478,7 +478,7 @@ var findLCA = function( node1, node2, layoutInfo ){
  * @arg layoutInfo : layoutInfo object
  *
  * @return         : object of the form {count: X, graph: Y}, where:
- *                   X is the number of ancesters (max: 2) found in
+ *                   X is the number of ancestors (max: 2) found in
  *                   graphIx (and it's subgraphs),
  *                   Y is the graph index of the lowest graph containing
  *                   all X nodes

--- a/src/extensions/renderer/base/load-listeners.js
+++ b/src/extensions/renderer/base/load-listeners.js
@@ -1703,7 +1703,7 @@ BRp.load = function(){
           }
 
           r.redraw();
-        } else { // otherise keep track of drag delta for later
+        } else { // otherwise keep track of drag delta for later
           var dragDelta = r.touchData.dragDelta = r.touchData.dragDelta || [];
 
           if( dragDelta.length === 0 ){

--- a/src/extensions/renderer/canvas/layered-texture-cache.js
+++ b/src/extensions/renderer/canvas/layered-texture-cache.js
@@ -362,7 +362,7 @@ LTCp.validateLayersElesOrdering = function( lvl, eles ){
     }
 
     if( offset < 0 ){
-      // then the layer has nonexistant elements and is invalid
+      // then the layer has nonexistent elements and is invalid
       this.invalidateLayer( layer );
       continue;
     }


### PR DESCRIPTION
There are small typos in:
- src/collection/algorithms/k-clustering.js
- src/extensions/layout/cose.js
- src/extensions/renderer/base/load-listeners.js
- src/extensions/renderer/canvas/layered-texture-cache.js

Fixes:
- Should read `otherwise` rather than `otherise`.
- Should read `nonexistent` rather than `nonexistant`.
- Should read `associated` rather than `assciated`.
- Should read `ancestors` rather than `ancesters`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md