### PR TITLE
Make built-in COSE make better use of the specified bounding box

### DIFF
--- a/src/extensions/layout/cose.js
+++ b/src/extensions/layout/cose.js
@@ -268,6 +268,9 @@ var createLayoutInfo = function( cy, layout, options ){
   // Shortcut
   var edges = options.eles.edges();
   var nodes = options.eles.nodes();
+  var bb = math.makeBoundingBox( options.boundingBox ? options.boundingBox : {
+    x1: 0, y1: 0, w: cy.width(), h: cy.height()
+  } );
 
   var layoutInfo   = {
     isCompound: cy.hasCompoundNodes(),
@@ -279,11 +282,9 @@ var createLayoutInfo = function( cy, layout, options ){
     layoutEdges: [],
     edgeSize: edges.size(),
     temperature: options.initialTemp,
-    clientWidth: cy.width(),
-    clientHeight: cy.width(),
-    boundingBox: math.makeBoundingBox( options.boundingBox ? options.boundingBox : {
-                     x1: 0, y1: 0, w: cy.width(), h: cy.height()
-                   } )
+    clientWidth: bb.w,
+    clientHeight: bb.h,
+    boundingBox: bb
   };
 
   var components = options.eles.components();


### PR DESCRIPTION
**Cross-references to related issues.**

Associated issues: #3121 

**Notes re. the content of the pull request.** 

The COSE layout internally uses two variables in addition to the bounding box, `clientWidth` and `clientHeight`.  They are set by default to the viewport extent.  COSE uses these variables in some places in lieu of the `boundingBox`.  Here, we set the `clientWidth` and `clientHeight` to be whatever is specified as the `boundingBox` so there is no inconsistency.

This makes the demo at https://jsbin.com/tuculav behave as expected, with a consistent result each time.

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.
- [x] Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
