### PR TITLE
New Shape - Right Slanting Rhomboid

### DIFF
--- a/documentation/demos/node-types/data.json
+++ b/documentation/demos/node-types/data.json
@@ -36,6 +36,10 @@
   }
 }, {
   "data": {
+    "type": "right-rhomboid"
+  }
+}, {
+  "data": {
     "type": "diamond"
   }
 }, {

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -13886,6 +13886,7 @@ node {
 <li><code>cut-rectangle</code></li>
 <li><code>barrel</code></li>
 <li><code>rhomboid</code></li>
+<li><code>right-rhomboid</code></li>
 <li><code>diamond</code></li>
 <li><code>round-diamond</code></li>
 <li><code>pentagon</code></li>

--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -175,6 +175,7 @@ Shape:
     * `cut-rectangle`
     * `barrel`
     * `rhomboid`
+    * `right-rhomboid`
     * `diamond`
     * `round-diamond`
     * `pentagon`

--- a/src/extensions/renderer/base/node-shapes.js
+++ b/src/extensions/renderer/base/node-shapes.js
@@ -590,6 +590,13 @@ BRp.registerNodeShapes = function(){
     -0.333, 1
   ] );
 
+  this.generatePolygon( 'right-rhomboid', [
+    -0.333, -1,
+    1, -1,
+    0.333, 1,
+    -1, 1
+  ] );
+
   this.nodeShapes['concavehexagon'] = this.generatePolygon( 'concave-hexagon', [
     -1, -0.95,
     -0.75, 0,

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -69,7 +69,7 @@ const styfn = {};
     nodeShape: { enums: [
       'rectangle', 'roundrectangle', 'round-rectangle', 'cutrectangle', 'cut-rectangle', 'bottomroundrectangle', 'bottom-round-rectangle', 'barrel',
       'ellipse', 'triangle', 'round-triangle', 'square', 'pentagon', 'round-pentagon', 'hexagon', 'round-hexagon', 'concavehexagon', 'concave-hexagon', 'heptagon', 'round-heptagon', 'octagon', 'round-octagon',
-      'tag', 'round-tag', 'star', 'diamond', 'round-diamond', 'vee', 'rhomboid', 'polygon',
+      'tag', 'round-tag', 'star', 'diamond', 'round-diamond', 'vee', 'rhomboid', 'right-rhomboid', 'polygon',
     ] },
     overlayShape: { enums: [ 'roundrectangle', 'round-rectangle', 'ellipse' ] },
     compoundIncludeLabels: { enums: [ 'include', 'exclude' ] },


### PR DESCRIPTION

Associated issues: #[3123](https://github.com/cytoscape/cytoscape.js/issues/3123)

**Notes re. the content of the pull request.** 

- This PR adds a new shaped called `right-rhomboid`

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.
- [x] Bug fixes only:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
