### PR TITLE
Add support for rendering cytoscape into WindowProxy document.

### DIFF
--- a/documentation/demos/multiple-windows/code.js
+++ b/documentation/demos/multiple-windows/code.js
@@ -1,0 +1,73 @@
+var elesJson = {
+  nodes: [
+    { data: { id: 'a', foo: 3, bar: 5, baz: 7 } },
+    { data: { id: 'b', foo: 7, bar: 1, baz: 3 } },
+    { data: { id: 'c', foo: 2, bar: 7, baz: 6 } },
+    { data: { id: 'd', foo: 9, bar: 5, baz: 2 } },
+    { data: { id: 'e', foo: 2, bar: 4, baz: 5 } }
+  ],
+
+  edges: [
+    { data: { id: 'ae', weight: 1, source: 'a', target: 'e' } },
+    { data: { id: 'ab', weight: 3, source: 'a', target: 'b' } },
+    { data: { id: 'be', weight: 4, source: 'b', target: 'e' } },
+    { data: { id: 'bc', weight: 5, source: 'b', target: 'c' } },
+    { data: { id: 'ce', weight: 6, source: 'c', target: 'e' } },
+    { data: { id: 'cd', weight: 2, source: 'c', target: 'd' } },
+    { data: { id: 'de', weight: 7, source: 'd', target: 'e' } }
+  ]
+};
+
+
+function createWindow() {
+  var openWindow = window.open("./windowIndex.html", "_blank", "popup")
+
+  openWindow.addEventListener("load", (event) => {
+    var container = openWindow.document.createElement("div")
+    container.className = "cy"  
+    openWindow.document.body.appendChild(container);
+
+    cytoscape({
+      container: container,
+      style: cytoscape.stylesheet()
+        .selector('node')
+          .css({
+            'background-color': '#B3767E',
+            'width': 'mapData(baz, 0, 10, 10, 40)',
+            'height': 'mapData(baz, 0, 10, 10, 40)',
+            'content': 'data(id)'
+          })
+        .selector('edge')
+          .css({
+            'line-color': '#F2B1BA',
+            'target-arrow-color': '#F2B1BA',
+            'width': 2,
+            'target-arrow-shape': 'circle',
+            'opacity': 0.8
+          })
+        .selector(':selected')
+          .css({
+            'background-color': 'black',
+            'line-color': 'black',
+            'target-arrow-color': 'black',
+            'source-arrow-color': 'black',
+            'opacity': 1
+          })
+        .selector('.faded')
+          .css({
+            'opacity': 0.25,
+            'text-opacity': 0
+          }),
+    
+      elements: elesJson,
+    
+      layout: {
+        name: 'circle',
+        padding: 10
+      }
+    });
+  });
+
+
+}
+

--- a/documentation/demos/multiple-windows/index.html
+++ b/documentation/demos/multiple-windows/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<!-- This code is for demonstration purposes only.  You should not hotlink to Github, Rawgit, or files from the Cytoscape.js documentation in your production apps. -->
+<html>
+<head>
+<link href="style.css" rel="stylesheet" />
+<meta charset=utf-8 />
+<meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
+<title>Multiple instances</title>
+<script src="../../js/cytoscape.min.js"></script>
+</head>
+<body>
+<button onclick="createWindow()">New window</button>
+<!-- Load application code at the end to ensure DOM is loaded -->
+<script src="code.js"></script>
+</body>
+</html>

--- a/documentation/demos/multiple-windows/style.css
+++ b/documentation/demos/multiple-windows/style.css
@@ -1,0 +1,12 @@
+body { 
+  font: 14px helvetica neue, helvetica, arial, sans-serif;
+}
+
+.cy {
+  height: 100%;
+  width: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
+  background-color: #FAEDEF;
+}

--- a/documentation/demos/multiple-windows/windowIndex.html
+++ b/documentation/demos/multiple-windows/windowIndex.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<!-- This code is for demonstration purposes only.  You should not hotlink to Github, Rawgit, or files from the Cytoscape.js documentation in your production apps. -->
+<html>
+<head>
+<link href="style.css" rel="stylesheet" />
+<meta charset=utf-8 />
+<meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
+<title>Graph windown</title>
+<script src="../../js/cytoscape.min.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/documentation/docmaker.json
+++ b/documentation/docmaker.json
@@ -67,13 +67,13 @@
         { "name": "Edge arrow types", "id": "edge-arrows" },
         { "name": "Labels", "id": "labels" },
         { "name": "Compound nodes", "id": "compound-nodes" },
-        { "name": "Linkout example", "id": "linkout-example" },
-        { "name": "Multiple windows", "id": "multiple-windows" }
+        { "name": "Linkout example", "id": "linkout-example" }
       ],
       "disabledDemos": [
         { "name": "Multiple instances", "id": "multiple-instances" },
         { "name": "Visual style", "id": "visual-style" },
-        { "name": "Initialisation", "id": "initialisation" }
+        { "name": "Initialisation", "id": "initialisation" },
+        { "name": "Multiple windows", "id": "multiple-windows" }
       ]
     },
 

--- a/documentation/docmaker.json
+++ b/documentation/docmaker.json
@@ -67,7 +67,8 @@
         { "name": "Edge arrow types", "id": "edge-arrows" },
         { "name": "Labels", "id": "labels" },
         { "name": "Compound nodes", "id": "compound-nodes" },
-        { "name": "Linkout example", "id": "linkout-example" }
+        { "name": "Linkout example", "id": "linkout-example" },
+        { "name": "Multiple windows", "id": "multiple-windows" }
       ],
       "disabledDemos": [
         { "name": "Multiple instances", "id": "multiple-instances" },

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -262,6 +262,19 @@ util.extend( corefn, {
     return this._private.container || null;
   },
 
+  window: function() {
+    let container = this._private.container;
+    if (container == null) return window;
+
+    let ownerDocument = this._private.container.ownerDocument;
+
+    if (ownerDocument === undefined || ownerDocument == null) {
+      return window;
+    }
+
+    return ownerDocument.defaultView || window;
+  },
+
   mount: function( container ){
     if( container == null ){ return; }
 

--- a/src/core/viewport.js
+++ b/src/core/viewport.js
@@ -535,7 +535,8 @@ let corefn = ({
     let container = _p.container;
 
     return ( _p.sizeCache = _p.sizeCache || ( container ? (function(){
-      let style = window.getComputedStyle( container );
+      let containerWindow = container.ownerDocument.defaultView || window
+      let style = containerWindow.getComputedStyle( container );
       let val = function( name ){ return parseFloat( style.getPropertyValue( name ) ); };
 
       return {

--- a/src/core/viewport.js
+++ b/src/core/viewport.js
@@ -535,8 +535,7 @@ let corefn = ({
     let container = _p.container;
 
     return ( _p.sizeCache = _p.sizeCache || ( container ? (function(){
-      let containerWindow = container.ownerDocument.defaultView || window
-      let style = containerWindow.getComputedStyle( container );
+      let style = this.cy.window().getComputedStyle( container );
       let val = function( name ){ return parseFloat( style.getPropertyValue( name ) ); };
 
       return {

--- a/src/core/viewport.js
+++ b/src/core/viewport.js
@@ -533,9 +533,10 @@ let corefn = ({
   size: function(){
     let _p = this._private;
     let container = _p.container;
+    let cy = this;
 
     return ( _p.sizeCache = _p.sizeCache || ( container ? (function(){
-      let style = this.cy.window().getComputedStyle( container );
+      let style = cy.window().getComputedStyle( container );
       let val = function( name ){ return parseFloat( style.getPropertyValue( name ) ); };
 
       return {

--- a/src/core/viewport.js
+++ b/src/core/viewport.js
@@ -1,5 +1,4 @@
 import * as is from '../is';
-import window from '../window';
 import * as math from '../math';
 
 let defaultSelectionType = 'single';

--- a/src/extensions/renderer/base/coord-ele-math/coords.js
+++ b/src/extensions/renderer/base/coord-ele-math/coords.js
@@ -26,9 +26,8 @@ BRp.findContainerClientCoords = function(){
   }
 
   var container = this.container;
-  var containerWindow = container.ownerDocument.defaultView || window
   var rect = container.getBoundingClientRect();
-  var style = containerWindow.getComputedStyle( container );
+  var style = this.cy.window().getComputedStyle( container );
   var styleValue = function( name ){ return parseFloat( style.getPropertyValue( name ) ); };
 
   var padding = {

--- a/src/extensions/renderer/base/coord-ele-math/coords.js
+++ b/src/extensions/renderer/base/coord-ele-math/coords.js
@@ -26,8 +26,9 @@ BRp.findContainerClientCoords = function(){
   }
 
   var container = this.container;
+  var containerWindow = container.ownerDocument.defaultView || window
   var rect = container.getBoundingClientRect();
-  var style = window.getComputedStyle( container );
+  var style = containerWindow.getComputedStyle( container );
   var styleValue = function( name ){ return parseFloat( style.getPropertyValue( name ) ); };
 
   var padding = {

--- a/src/extensions/renderer/base/coord-ele-math/coords.js
+++ b/src/extensions/renderer/base/coord-ele-math/coords.js
@@ -1,4 +1,3 @@
-import window from '../../../../window';
 import * as math from '../../../../math';
 import * as util from '../../../../util';
 

--- a/src/extensions/renderer/base/index.js
+++ b/src/extensions/renderer/base/index.js
@@ -23,10 +23,12 @@ BRp.init = function( options ){
   r.cy = options.cy;
 
   var ctr = r.container = options.cy.container();
+  var containerWindow = ctr.ownerDocument.defaultView || window;
+
 
   // prepend a stylesheet in the head such that
-  if( window ){
-    var document = window.document;
+  if( containerWindow ){
+    var document = containerWindow.document;
     var head = document.head;
     var stylesheetId = '__________cytoscape_stylesheet';
     var className =    '__________cytoscape_container';
@@ -45,7 +47,7 @@ BRp.init = function( options ){
       head.insertBefore( stylesheet, head.children[0] ); // first so lowest priority
     }
 
-    var computedStyle = window.getComputedStyle( ctr );
+    var computedStyle = containerWindow.getComputedStyle( ctr );
     var position = computedStyle.getPropertyValue('position');
 
     if( position === 'static' ){

--- a/src/extensions/renderer/base/index.js
+++ b/src/extensions/renderer/base/index.js
@@ -23,7 +23,7 @@ BRp.init = function( options ){
   r.cy = options.cy;
 
   var ctr = r.container = options.cy.container();
-  var containerWindow = ctr.ownerDocument.defaultView || window;
+  var containerWindow = r.cy.window();
 
 
   // prepend a stylesheet in the head such that

--- a/src/extensions/renderer/base/index.js
+++ b/src/extensions/renderer/base/index.js
@@ -1,6 +1,5 @@
 import * as util from '../../../util';
 import * as is from '../../../is';
-import window from '../../../window';
 
 import arrowShapes from './arrow-shapes';
 import coordEleMath from './coord-ele-math';

--- a/src/extensions/renderer/base/load-listeners.js
+++ b/src/extensions/renderer/base/load-listeners.js
@@ -15,8 +15,7 @@ BRp.registerBinding = function( target, event, handler, useCapture ){ // eslint-
 
 BRp.binder = function( tgt ){
   var r = this;
-  var container = r.container;
-  var containerWindow = container.ownerDocument.defaultView || window;
+  var containerWindow = r.cy.window();
 
   var tgtIsDom = tgt === containerWindow || tgt === containerWindow.document || tgt === containerWindow.document.body || is.domElement( tgt );
 
@@ -88,7 +87,7 @@ BRp.nodeIsGrabbable = function( node ){
 
 BRp.load = function(){
   var r = this;
-  var containerWindow = r.container.ownerDocument.defaultView || window;
+  var containerWindow = r.cy.window();
   var isSelected = ele => ele.selected();
 
   var triggerEvents = function( target, names, e, position ){

--- a/src/extensions/renderer/base/load-listeners.js
+++ b/src/extensions/renderer/base/load-listeners.js
@@ -15,8 +15,10 @@ BRp.registerBinding = function( target, event, handler, useCapture ){ // eslint-
 
 BRp.binder = function( tgt ){
   var r = this;
+  var container = r.container;
+  var containerWindow = container.ownerDocument.defaultView || window;
 
-  var tgtIsDom = tgt === window || tgt === document || tgt === document.body || is.domElement( tgt );
+  var tgtIsDom = tgt === containerWindow || tgt === containerWindow.document || tgt === containerWindow.document.body || is.domElement( tgt );
 
   if( r.supportsPassiveEvents == null ){
 
@@ -31,7 +33,7 @@ BRp.binder = function( tgt ){
         }
       } );
 
-      window.addEventListener( 'test', null, opts );
+      containerWindow.addEventListener( 'test', null, opts );
     } catch( err ){
       // not supported
     }
@@ -86,7 +88,7 @@ BRp.nodeIsGrabbable = function( node ){
 
 BRp.load = function(){
   var r = this;
-
+  var containerWindow = r.container.ownerDocument.defaultView || window;
   var isSelected = ele => ele.selected();
 
   var triggerEvents = function( target, names, e, position ){
@@ -315,7 +317,7 @@ BRp.load = function(){
   }
 
   // auto resize
-  r.registerBinding( window, 'resize', onResize ); // eslint-disable-line no-undef
+  r.registerBinding( containerWindow, 'resize', onResize ); // eslint-disable-line no-undef
 
   if( haveResizeObserverApi ){
     r.resizeObserver = new ResizeObserver(onResize); // eslint-disable-line no-undef
@@ -554,7 +556,7 @@ BRp.load = function(){
 
   }, false );
 
-  r.registerBinding( window, 'mousemove', function mousemoveHandler( e ){ // eslint-disable-line no-undef
+  r.registerBinding( containerWindow, 'mousemove', function mousemoveHandler( e ){ // eslint-disable-line no-undef
     var capture = r.hoverData.capture;
 
     if( !capture && !eventInContainer(e) ){ return; }
@@ -831,7 +833,7 @@ BRp.load = function(){
   }, false );
 
   let clickTimeout, didDoubleClick, prevClickTimeStamp;
-  r.registerBinding( window, 'mouseup', function mouseupHandler( e ){ // eslint-disable-line no-undef
+  r.registerBinding( containerWindow, 'mouseup', function mouseupHandler( e ){ // eslint-disable-line no-undef
     var capture = r.hoverData.capture;
     if( !capture ){ return; }
     r.hoverData.capture = false;
@@ -1106,7 +1108,7 @@ BRp.load = function(){
   // r.registerBinding(r.container, 'DOMMouseScroll', wheelHandler, true);
   // r.registerBinding(r.container, 'MozMousePixelScroll', wheelHandler, true); // older firefox
 
-  r.registerBinding( window, 'scroll', function scrollHandler( e ){ // eslint-disable-line no-unused-vars
+  r.registerBinding( containerWindow, 'scroll', function scrollHandler( e ){ // eslint-disable-line no-unused-vars
     r.scrollingPage = true;
 
     clearTimeout( r.scrollingPageTimeout );
@@ -1790,7 +1792,7 @@ BRp.load = function(){
 
   }, false );
   var touchcancelHandler;
-  r.registerBinding( window, 'touchcancel', touchcancelHandler = function( e ){ // eslint-disable-line no-unused-vars
+  r.registerBinding( containerWindow, 'touchcancel', touchcancelHandler = function( e ){ // eslint-disable-line no-unused-vars
     var start = r.touchData.start;
 
     r.touchData.capture = false;
@@ -1801,7 +1803,7 @@ BRp.load = function(){
   } );
 
   var touchendHandler, didDoubleTouch, touchTimeout, prevTouchTimeStamp;
-  r.registerBinding( window, 'touchend', touchendHandler = function( e ){ // eslint-disable-line no-unused-vars
+  r.registerBinding( containerWindow, 'touchend', touchendHandler = function( e ){ // eslint-disable-line no-unused-vars
     var start = r.touchData.start;
 
     var capture = r.touchData.capture;

--- a/src/style/container.js
+++ b/src/style/container.js
@@ -17,7 +17,7 @@ styfn.getEmSizeInPixels = function(){
 styfn.containerCss = function( propName ){
   let cy = this._private.cy;
   let domElement = cy.container();
-  let containerWindow = domElement.ownerDocument.defaultView || window;
+  let containerWindow = cy.window();
 
   if( containerWindow && domElement && containerWindow.getComputedStyle ){
     return containerWindow.getComputedStyle( domElement ).getPropertyValue( propName );

--- a/src/style/container.js
+++ b/src/style/container.js
@@ -1,5 +1,3 @@
-import window from '../window';
-
 let styfn = {};
 
 // gets what an em size corresponds to in pixels relative to a dom element

--- a/src/style/container.js
+++ b/src/style/container.js
@@ -17,9 +17,10 @@ styfn.getEmSizeInPixels = function(){
 styfn.containerCss = function( propName ){
   let cy = this._private.cy;
   let domElement = cy.container();
+  let containerWindow = domElement.ownerDocument.defaultView || window;
 
-  if( window && domElement && window.getComputedStyle ){
-    return window.getComputedStyle( domElement ).getPropertyValue( propName );
+  if( containerWindow && domElement && containerWindow.getComputedStyle ){
+    return containerWindow.getComputedStyle( domElement ).getPropertyValue( propName );
   }
 };
 


### PR DESCRIPTION
Associated issues: #3129

- This PR changes reference to `window` into reference to `window` of the container into which is the cytoscape rendered. This is done via changing the `window` reference into `container.ownerDocument.defaultView`. 
- This adds a demo page which demonstrates the behaviour for multiple windows. 

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.
- [x] N/A : For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
