### PR TITLE
Bugfix touch interaction - adds correct reset value to startPosition

### DIFF
--- a/src/extensions/renderer/base/load-listeners.js
+++ b/src/extensions/renderer/base/load-listeners.js
@@ -1359,7 +1359,7 @@ BRp.load = function(){
     }
 
     if( e.touches.length >= 1 ){
-      var sPos = r.touchData.startPosition = [];
+      var sPos = r.touchData.startPosition = [null, null, null, null, null, null];
 
       for( var i = 0; i < now.length; i++ ){
         sPos[i] = earlier[i] = now[i];

--- a/src/extensions/renderer/base/load-listeners.js
+++ b/src/extensions/renderer/base/load-listeners.js
@@ -2019,7 +2019,7 @@ BRp.load = function(){
 
     if( e.touches.length === 0 ){
       r.touchData.dragDelta = [];
-      r.touchData.startPosition = null;
+      r.touchData.startPosition = [null, null, null, null, null, null];
       r.touchData.startGPosition = null;
       r.touchData.didSelect = false;
     }


### PR DESCRIPTION
**Cross-references to related issues.**  
Associated issues: #3137

**Notes re. the content of the pull request.** 

This PR fixes an issue which occurs when using touch devices.   
- The originally occurring error originated in an array access (ie [`if( r.touchData.startPosition[0] == earlier[0] ...`](https://github.com/cytoscape/cytoscape.js/blob/a46764fd7acd91fdd93ce9efcc624e67354290e4/src/extensions/renderer/base/load-listeners.js#L1689C44-L1689C44), [`if(... && startPosition[i] && ...)`](https://github.com/cytoscape/cytoscape.js/blob/a46764fd7acd91fdd93ce9efcc624e67354290e4/src/extensions/renderer/base/load-listeners.js#L1726C46-L1726C46) while startPosition was set to null instead of its initial value [null, null, null, null, ...]
- The correct initial value for `startPosition` is defined in [this codeline](https://github.com/cytoscape/cytoscape.js/blob/a46764fd7acd91fdd93ce9efcc624e67354290e4/src/extensions/renderer/base/index.js#L73)


**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [ ] N/A -- Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
