### PR TITLE
Clear z-order cache on style change.

### DIFF
--- a/debug/tests.js
+++ b/debug/tests.js
@@ -766,4 +766,35 @@
       de.move({ source: 'd', target: 'e' });
     }
   });
+
+  test({
+    name: "events:no",
+    displayName: "events: no",
+    description: "Apply events:no style to all nodes. Clicking on nodes should no longer affect the node.",
+    
+    setup: function(){
+      cy.nodes().style(
+        { events: 'no' }
+      );
+    },
+    teardown: function(){
+      cy.nodes().removeStyle();
+    }
+  });
+
+  test({
+    name: "text-events:yes",
+    displayName: "text-events: yes",
+    description: "Apply text-events:yes style to all nodes. Clicking on node labels should select the node.",
+    
+    setup: function(){
+      cy.nodes().style(
+        { 'text-events': 'yes' }
+      );
+    },
+    teardown: function(){
+      cy.nodes().removeStyle();
+    }
+  });
+  
 })();

--- a/src/extensions/renderer/base/index.js
+++ b/src/extensions/renderer/base/index.js
@@ -140,7 +140,6 @@ BRp.notify = function( eventName, eles ){
     || eventName === 'load'
     || eventName === 'zorder'
     || eventName === 'mount'
-    || eventName === 'style'
   ){
     r.invalidateCachedZSortedEles();
   }

--- a/src/extensions/renderer/base/index.js
+++ b/src/extensions/renderer/base/index.js
@@ -134,11 +134,13 @@ BRp.notify = function( eventName, eles ){
   }
 
   if(
-    eventName === 'add' || eventName === 'remove'
+    eventName === 'add' 
+    || eventName === 'remove'
     || (eventName === 'move' && cy.hasCompoundNodes())
     || eventName === 'load'
     || eventName === 'zorder'
     || eventName === 'mount'
+    || eventName === 'style'
   ){
     r.invalidateCachedZSortedEles();
   }

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -229,8 +229,8 @@ const styfn = {};
   ];
 
   let behavior = [
-    { name: 'events', type: t.bool },
-    { name: 'text-events', type: t.bool }
+    { name: 'events', type: t.bool, triggersZOrder: diff.any },
+    { name: 'text-events', type: t.bool, triggersZOrder: diff.any }
   ];
 
   let visibility = [


### PR DESCRIPTION
Associated issues: #3021

The pull request fixes issue #3021 

The base renderer keeps a cache of "interactive" elements along with the z-order cache. Changing 'events' style property of an element changes its interactivity, but this cache is not updated. This pull request clears the cache when the 'style' event occurs.

The cache is created here: https://github.com/cytoscape/cytoscape.js/blob/658aed7234ef9d66e546af23c5134b3571c3c502/src/extensions/renderer/base/coord-ele-math/z-ordering.js#L43

Its used here:
https://github.com/cytoscape/cytoscape.js/blob/658aed7234ef9d66e546af23c5134b3571c3c502/src/extensions/renderer/base/coord-ele-math/coords.js#L94

And affects this return value:
https://github.com/cytoscape/cytoscape.js/blob/658aed7234ef9d66e546af23c5134b3571c3c502/src/extensions/renderer/base/load-listeners.js#L412

That's why the tap event fires when it shouldn't.

Note: I'm not sure how to write a unit test for this. The cache is internal to the base renderer and I don't see a way through the API to check the state of that cache. Any advice on how to write a test for this is appreciated.

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
