### PR TITLE
Node outlines

### DIFF
--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -223,6 +223,14 @@ Border:
  * **`border-color`** : The colour of the node's border.
  * **`border-opacity`** : The opacity of the node's border.
 
+ Outline:
+
+ * **`outline-width`** : The size of the node's outline.
+ * **`outline-style`** : The style of the node's outline; may be `solid`, `dotted`, `dashed`, or `double`.
+ * **`outline-color`** : The colour of the node's outline.
+ * **`outline-opacity`** : The opacity of the node's outline.
+ * **`outline-offset`** : The offset of the node's outline, measured in percent (e.g. `50%`) or pixels (e.g. `10px`).
+
 Padding:
 
 A padding defines an addition to a node's dimension.  For example, `padding` adds to a node's outer (i.e. total) width and height.  This can be used to add spacing between a compound node parent and its children.

--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -226,9 +226,10 @@ Border:
  Outline:
 
  * **`outline-width`** : The size of the node's outline.
- * **`outline-style`** : The style of the node's outline; may be `solid`, `dotted`, or `dashed`.
+ * **`outline-style`** : The style of the node's outline; may be `solid`, `dotted`, `dashed`, or `double`.
  * **`outline-color`** : The colour of the node's outline.
  * **`outline-opacity`** : The opacity of the node's outline.
+ * **`outline-offset`** : The offset of the node's outline.
 
 Padding:
 

--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -229,7 +229,6 @@ Border:
  * **`outline-style`** : The style of the node's outline; may be `solid`, `dotted`, `dashed`, or `double`.
  * **`outline-color`** : The colour of the node's outline.
  * **`outline-opacity`** : The opacity of the node's outline.
- * **`outline-offset`** : The offset of the node's outline, measured in percent (e.g. `50%`) or pixels (e.g. `10px`).
 
 Padding:
 

--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -226,7 +226,7 @@ Border:
  Outline:
 
  * **`outline-width`** : The size of the node's outline.
- * **`outline-style`** : The style of the node's outline; may be `solid`, `dotted`, `dashed`, or `double`.
+ * **`outline-style`** : The style of the node's outline; may be `solid`, `dotted`, or `dashed`.
  * **`outline-color`** : The colour of the node's outline.
  * **`outline-opacity`** : The opacity of the node's outline.
 

--- a/src/collection/dimensions/bounds.js
+++ b/src/collection/dimensions/bounds.js
@@ -432,25 +432,21 @@ let updateBoundsFromOutline = function( bounds, ele ){
   if( ele.cy().headless() ){ return; }
 
   let outlineOpacity = ele.pstyle('outline-opacity').value;
-  
-  if (outlineOpacity > 0) {
-    let outlineWidth = ele.pstyle( 'outline-width' ).pfValue;
-    let shape = ele.pstyle('shape').strValue;
-    let size = outlineWidth * 2;
+  let outlineWidth = ele.pstyle('outline-width').value;
 
-    if (shape === "vee" || shape === "triangle") {
-      size *= 1.5;
-    }
+  if (outlineOpacity > 0 && outlineWidth > 0) {
+    let outlineOffset = ele.pstyle('outline-offset').value;
+    // apply an multiplier to arrive at a bounding box that 
+    // exceeds the outline in the absence of a more accurate 
+    // way to calculate bounds
+    let size = (outlineWidth + outlineOffset) * 3;
+    let x1 = bounds.x1 - size;
+    let y1 = bounds.y1 - size;
+    let x2 = bounds.x2 + size;
+    let y2 = bounds.y2 + size;
 
-    let ex1 = bounds.x1 - size;
-    let ex2 = bounds.x2 + size;
-    let ey1 = bounds.y1 - size;
-    let ey2 = bounds.y2 + size;
-
-    updateBounds(bounds, ex1, ey1, ex2, ey2);
+    updateBounds( bounds, x1, y1, x2, y2 );
   }
-
-  return bounds;
 };
 
 // get the bounding box of the elements (in raw model position)
@@ -763,6 +759,7 @@ let getKey = function( opts ){
   key += tf( opts.includeSourceLabels );
   key += tf( opts.includeTargetLabels );
   key += tf( opts.includeOverlays );
+  key += tf( opts.includeOutlines );
 
   return key;
 };

--- a/src/collection/dimensions/bounds.js
+++ b/src/collection/dimensions/bounds.js
@@ -428,6 +428,31 @@ let updateBoundsFromLabel = function( bounds, ele, prefix ){
   return bounds;
 };
 
+let updateBoundsFromOutline = function( bounds, ele ){
+  if( ele.cy().headless() ){ return; }
+
+  let outlineOpacity = ele.pstyle('outline-opacity').value;
+  
+  if (outlineOpacity > 0) {
+    let outlineWidth = ele.pstyle( 'outline-width' ).pfValue;
+    let shape = ele.pstyle('shape').strValue;
+    let size = outlineWidth * 2;
+
+    if (shape === "vee" || shape === "triangle") {
+      size *= 1.5;
+    }
+
+    let ex1 = bounds.x1 - size;
+    let ex2 = bounds.x2 + size;
+    let ey1 = bounds.y1 - size;
+    let ey2 = bounds.y2 + size;
+
+    updateBounds(bounds, ex1, ey1, ex2, ey2);
+  }
+
+  return bounds;
+};
+
 // get the bounding box of the elements (in raw model position)
 let boundingBoxImpl = function( ele, options ){
   let cy = ele._private.cy;
@@ -510,6 +535,9 @@ let boundingBoxImpl = function( ele, options ){
 
       updateBounds( bounds, ex1, ey1, ex2, ey2 );
 
+      if( styleEnabled && options.includeOutlines ){
+        updateBoundsFromOutline( bounds, ele );
+      }
     } else if( isEdge && options.includeEdges ){
 
       if( styleEnabled && !headless ){
@@ -824,6 +852,7 @@ let defBbOpts = {
   includeTargetLabels: true,
   includeOverlays: true,
   includeUnderlays: true,
+  includeOutlines: true,
   useCache: true
 };
 

--- a/src/collection/dimensions/bounds.js
+++ b/src/collection/dimensions/bounds.js
@@ -438,31 +438,34 @@ let updateBoundsFromOutline = function( bounds, ele ){
     let outlineOffset = ele.pstyle('outline-offset').value;
     let nodeShape = ele.pstyle( 'shape' ).value;
 
-    let scaleX = (bounds.w + (outlineWidth + outlineOffset)) / bounds.w;
-    let scaleY = (bounds.h + (outlineWidth + outlineOffset)) / bounds.h;
+    let outlineSize = outlineWidth + outlineOffset;
+    let scaleX = (bounds.w + outlineSize * 2) / bounds.w;
+    let scaleY = (bounds.h + outlineSize * 2) / bounds.h;
     let xOffset = 0;
     let yOffset = 0;
 
-    if (["diamond", "pentagon", "polygon", "round-triangle", "star", "triangle"].includes(nodeShape)) {
-      scaleX = (bounds.w + (outlineWidth + outlineOffset) * 2) / bounds.w;
-      scaleY = (bounds.h + (outlineWidth + outlineOffset) * 2) / bounds.h;
+    if (["diamond", "pentagon", "round-triangle"].includes(nodeShape)) {
+      scaleX = (bounds.w + outlineSize * 2.4) / bounds.w;
+      yOffset = -outlineSize/3.6;
     } else if (["concave-hexagon", "rhomboid", "right-rhomboid"].includes(nodeShape)) {
-      scaleX *= 1.2;
-    } else if (nodeShape === "tag") {
-      scaleX *= 1.15;
+      scaleX = (bounds.w + outlineSize * 2.4) / bounds.w;
+    } else if (nodeShape === "star") {
+      scaleX = (bounds.w + outlineSize * 2.8) / bounds.w;
+      scaleY = (bounds.h + outlineSize * 2.6) / bounds.h;
+      yOffset = -outlineSize / 3.8;
     } else if (nodeShape === "triangle") {
-      yOffset = -(outlineWidth + outlineOffset);
-    } 
-
-    if (nodeShape === "vee") {
-      scaleX = (bounds.w + (outlineWidth + outlineOffset) * 2.5) / bounds.w;
-      scaleY = (bounds.h + (outlineWidth + outlineOffset) * 2.5) / bounds.h;
-      yOffset = -(outlineWidth + outlineOffset);
+      scaleX = (bounds.w + outlineSize * 2.8) / bounds.w;
+      scaleY = (bounds.h + outlineSize * 2.4) / bounds.h;
+      yOffset = -outlineSize/1.4;
+    } else if (nodeShape === "vee") {
+      scaleX = (bounds.w + outlineSize * 4.4) / bounds.w;
+      scaleY = (bounds.h + outlineSize * 3.8) / bounds.h;
+      yOffset = -outlineSize * .5;
     }
 
     let hDelta = (bounds.h * scaleY) - bounds.h;
     let wDelta = (bounds.w * scaleX) - bounds.w;
-    expandBoundingBoxSides(bounds, [hDelta, wDelta]);
+    expandBoundingBoxSides(bounds, [Math.ceil(hDelta/2), Math.ceil(wDelta/2)]);
 
     if (xOffset != 0 || yOffset !== 0) {
       let oBounds = shiftBoundingBox(bounds, xOffset, yOffset);

--- a/src/extensions/renderer/canvas/drawing-nodes.js
+++ b/src/extensions/renderer/canvas/drawing-nodes.js
@@ -305,9 +305,10 @@ CRp.drawNode = function( context, node, shiftToOriginWithBb, drawLabel = true, s
 
       let shape = r.getNodeShape( node );
       
-      let scale = (nodeWidth + borderWidth + (outlineWidth + outlineOffset)) / nodeWidth;
-      let sWidth = nodeWidth * scale;
-      let sHeight = nodeHeight * scale;
+      let scaleX = (nodeWidth + borderWidth + (outlineWidth + outlineOffset)) / nodeWidth;
+      let scaleY = (nodeHeight + borderWidth + (outlineWidth + outlineOffset)) / nodeHeight;
+      let sWidth = nodeWidth * scaleX;
+      let sHeight = nodeHeight * scaleY;
       
       let points = r.nodeShapes[ shape ].points;
       let path;
@@ -325,7 +326,33 @@ CRp.drawNode = function( context, node, shiftToOriginWithBb, drawLabel = true, s
         'round-diamond', 'round-heptagon', 'round-hexagon', 'round-octagon', 
         'round-pentagon', 'round-polygon', 'round-triangle', 'round-tag'
       ].includes(shape)) {
-        r.drawRoundPolygonPath(path || context, npos.x, npos.y, sWidth, sHeight, points);
+        let sMult = 0;
+        let offsetX = 0;
+        let offsetY = 0;
+        if (shape === 'round-diamond') {
+          sMult = (borderWidth + outlineOffset + outlineWidth) * 1.4;
+        } else if (shape === 'round-heptagon') {
+          sMult = (borderWidth + outlineOffset + outlineWidth) * 1.075;
+          offsetY = -(borderWidth/2 + outlineOffset + outlineWidth) / 35;
+        } else if (shape === 'round-hexagon') {
+          sMult = (borderWidth + outlineOffset + outlineWidth) * 1.12;
+        } else if (shape === 'round-pentagon') {
+          sMult = (borderWidth + outlineOffset + outlineWidth) * 1.13;
+          offsetY = -(borderWidth/2 + outlineOffset + outlineWidth) / 15;
+        } else if (shape === 'round-tag') {
+          sMult = (borderWidth + outlineOffset + outlineWidth) * 1.12;
+          offsetX = (borderWidth/2 + outlineWidth + outlineOffset) * .07;
+        } else if (shape === 'round-triangle') {
+          sMult = (borderWidth + outlineOffset + outlineWidth) * (Math.PI/2);
+          offsetY = -(borderWidth + outlineOffset/2 + outlineWidth) / Math.PI;
+        }
+
+        if (sMult !== 0) {
+          scaleX = (nodeWidth + sMult)/nodeWidth;
+          scaleY = (nodeHeight + sMult)/nodeHeight;
+        }
+
+        r.drawRoundPolygonPath(path || context, npos.x + offsetX, npos.y + offsetY, nodeWidth * scaleX, nodeHeight * scaleY, points);
       } else if (['roundrectangle', 'round-rectangle'].includes(shape)) {
         r.drawRoundRectanglePath(path || context, npos.x, npos.y, sWidth, sHeight);
       } else if (['cutrectangle', 'cut-rectangle'].includes(shape)) {

--- a/src/extensions/renderer/canvas/drawing-nodes.js
+++ b/src/extensions/renderer/canvas/drawing-nodes.js
@@ -113,7 +113,6 @@ CRp.drawNode = function( context, node, shiftToOriginWithBb, drawLabel = true, s
   let outlineColor = node.pstyle('outline-color').value;
   let outlineStyle = node.pstyle('outline-style').value;
   let outlineOpacity = node.pstyle('outline-opacity').value * eleOpacity;
-  let outlineOffset = node.pstyle('outline-offset').value;
 
   context.lineJoin = 'miter'; // so borders are square with the node shape
 

--- a/src/extensions/renderer/canvas/drawing-nodes.js
+++ b/src/extensions/renderer/canvas/drawing-nodes.js
@@ -292,7 +292,6 @@ CRp.drawNode = function( context, node, shiftToOriginWithBb, drawLabel = true, s
             break;
 
           case 'solid':
-          case 'double':
             context.setLineDash( [ ] );
             break;
         }

--- a/src/style/apply.js
+++ b/src/style/apply.js
@@ -357,9 +357,9 @@ styfn.updateStyleHints = function(ele){
   //
 
   if( isNode ){
-    let { nodeBody, nodeBorder, backgroundImage, compound, pie } = _p.styleKeys;
+    let { nodeBody, nodeBorder, nodeOutline, backgroundImage, compound, pie } = _p.styleKeys;
 
-    let nodeKeys = [ nodeBody, nodeBorder, backgroundImage, compound, pie ].filter(k => k != null).reduce(util.hashArrays, [
+    let nodeKeys = [ nodeBody, nodeBorder, nodeOutline, backgroundImage, compound, pie ].filter(k => k != null).reduce(util.hashArrays, [
       util.DEFAULT_HASH_SEED,
       util.DEFAULT_HASH_SEED_ALT
     ]);

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -302,7 +302,6 @@ const styfn = {};
     { name: 'outline-opacity', type: t.zeroOneNumber },
     { name: 'outline-width', type: t.size, triggersBounds: diff.any },
     { name: 'outline-style', type: t.borderStyle },
-    { name: 'outline-offset', type: t.size, triggersBounds: diff.any },
   ];
 
   let backgroundImage = [
@@ -636,7 +635,6 @@ styfn.getDefaultProperties = function(){
     'outline-opacity': 1,
     'outline-width': 0,
     'outline-style': 'solid',
-    'outline-offset': 0,
     'height': 30,
     'width': 30,
     'shape': 'ellipse',

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -143,7 +143,6 @@ const styfn = {};
         return length === 1 || length === 2 || length === 4;
       }
     },
-    outlineStyle: { enums: [ 'solid', 'dotted', 'dashed' ] },
   };
 
   let diff = {
@@ -302,7 +301,8 @@ const styfn = {};
     { name: 'outline-color', type: t.color },
     { name: 'outline-opacity', type: t.zeroOneNumber },
     { name: 'outline-width', type: t.size, triggersBounds: diff.any },
-    { name: 'outline-style', type: t.outlineStyle },
+    { name: 'outline-style', type: t.borderStyle },
+    { name: 'outline-offset', type: t.size },
   ];
 
   let backgroundImage = [
@@ -635,6 +635,7 @@ styfn.getDefaultProperties = function(){
     'outline-color': '#999',
     'outline-opacity': 1,
     'outline-width': 0,
+    'outline-offset': 0,
     'outline-style': 'solid',
     'height': 30,
     'width': 30,

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -297,6 +297,14 @@ const styfn = {};
     { name: 'border-style', type: t.borderStyle }
   ];
 
+  let nodeOutline = [
+    { name: 'outline-color', type: t.color },
+    { name: 'outline-opacity', type: t.zeroOneNumber },
+    { name: 'outline-width', type: t.size, triggersBounds: diff.any },
+    { name: 'outline-style', type: t.borderStyle },
+    { name: 'outline-offset', type: t.size, triggersBounds: diff.any },
+  ];
+
   let backgroundImage = [
     { name: 'background-image', type: t.urls },
     { name: 'background-image-crossorigin', type: t.bgCrossOrigin },
@@ -421,6 +429,7 @@ const styfn = {};
     // node props
     ...nodeBody,
     ...nodeBorder,
+    ...nodeOutline,
     ...backgroundImage,
     ...pie,
     ...compound,
@@ -451,6 +460,7 @@ const styfn = {};
     // node props
     nodeBody,
     nodeBorder,
+    nodeOutline,
     backgroundImage,
     pie,
     compound,
@@ -622,6 +632,11 @@ styfn.getDefaultProperties = function(){
     'border-opacity': 1,
     'border-width': 0,
     'border-style': 'solid',
+    'outline-color': '#999',
+    'outline-opacity': 1,
+    'outline-width': 0,
+    'outline-style': 'solid',
+    'outline-offset': 0,
     'height': 30,
     'width': 30,
     'shape': 'ellipse',

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -142,7 +142,8 @@ const styfn = {};
 
         return length === 1 || length === 2 || length === 4;
       }
-    }
+    },
+    outlineStyle: { enums: [ 'solid', 'dotted', 'dashed' ] },
   };
 
   let diff = {
@@ -301,7 +302,7 @@ const styfn = {};
     { name: 'outline-color', type: t.color },
     { name: 'outline-opacity', type: t.zeroOneNumber },
     { name: 'outline-width', type: t.size, triggersBounds: diff.any },
-    { name: 'outline-style', type: t.borderStyle },
+    { name: 'outline-style', type: t.outlineStyle },
   ];
 
   let backgroundImage = [

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -302,7 +302,7 @@ const styfn = {};
     { name: 'outline-opacity', type: t.zeroOneNumber },
     { name: 'outline-width', type: t.size, triggersBounds: diff.any },
     { name: 'outline-style', type: t.borderStyle },
-    { name: 'outline-offset', type: t.size },
+    { name: 'outline-offset', type: t.size, triggersBounds: diff.any }
   ];
 
   let backgroundImage = [


### PR DESCRIPTION
Associated issues: https://github.com/cytoscape/cytoscape.js/issues/3156

Adds node outlines as described in #3156. Pushed this one up a bit early, but will be monitoring the associated issue and integrate any feedback that comes in.

Reiterating the feature as laid out in the issue description, node outlines support the same properties as borders, but with the addition of an `outline-offset` prop, and are drawn outside the border/node shape. 

Much of the implementation mirrors how borders are rendered, but because outlines are drawn outside the border/node, the node shape needs to be redrawn at a slightly larger size than the core, filled shape. For that reason, I opted to move the path caching to a `getPath` method that both the shape rendering and `drawOutline` function can use, rather than duplicating that caching logic. 

_10px, dashed outline:_

<img width="264" alt="Screen Shot 2023-08-22 at 6 40 24 PM" src="https://github.com/cytoscape/cytoscape.js/assets/1434577/6dfd52ab-4a42-46a1-960f-7297108c510d">

_10px double outline w/ 4px offset:_

<img width="335" alt="Screen Shot 2023-08-22 at 6 41 06 PM" src="https://github.com/cytoscape/cytoscape.js/assets/1434577/10dd0e5d-fbdd-4401-892f-4eadbbb5fcf4">

_Triangular node w/ 10px outline:_

<img width="375" alt="Screen Shot 2023-08-22 at 6 37 51 PM" src="https://github.com/cytoscape/cytoscape.js/assets/1434577/d7d3c935-c72b-4f9d-8c15-2ccc36d7b78f">

_Rhomboid w/ 10px outline, 8px offset:_

<img width="370" alt="Screen Shot 2023-08-22 at 6 44 33 PM" src="https://github.com/cytoscape/cytoscape.js/assets/1434577/1b866ccf-7d69-4b91-a029-edecc808f82f">

TODO: 
- [ ] Check offset rendering for other node shapes (noticed offsets seem off for some of the tests above)
- [ ] Update node bound calculation to account for outline if present (right now larger outlines get clipped if they exceed bounds)

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.

Closes #3156