### PR TITLE
Add support for `edge-distances:endpoints`

### DIFF
--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -360,7 +360,13 @@ A bezier edge is bundled with all other parallel bezier edges.  Each bezier edge
  * **`control-point-step-size`** : Along the line perpendicular from source to target, this value specifies the distance between successive bezier edges.
  * **`control-point-distance`** : A single value that overrides `control-point-step-size` with a manual value.  Because it overrides the step size, bezier edges with the same value will overlap.  Thus, it's best to use this as a one-off value for particular edges if need be.
  * **`control-point-weight`** : A single value that weights control points along the line from source to target.  The value usually ranges on [0, 1], with 0 towards the source node and 1 towards the target node --- but larger or smaller values can also be used.
- * **`edge-distances`** : With value `intersection` (default), the line from source to target for `control-point-weight` is from the outside of the source node's shape to the outside of the target node's shape.  With value `node-position`, the line is from the source position to the target position.  The `node-position` option makes calculating edge points easier --- but it should be used carefully because you can create invalid points that `intersection` would have automatically corrected.
+* **`edge-distances`** : 
+  * With value `intersection` (default), the line from source to target for `segment-weights` is from the outside of the source node's shape to the outside of the target node's shape.  
+  * With value `node-position`, the line is from the source position to the target position.  
+  * The `node-position` option makes calculating edge points easier --- but it should be used carefully because you can create invalid points that `intersection` would have automatically corrected.
+  * With value `endpoints`, the line is from the manually-specified source endpoint (via `source-endpoint`) to the manually-specified target endpoint (via `target-endpoint`).
+    * A manual endpoint may be specified with a position, e.g. `source-endpoint: 20 10`.
+    * A manual endpoint may be alternatively specified with an angle, e.g. `target-endpoint: 90deg`.
 
 
 ## Loop edges
@@ -389,7 +395,13 @@ When two or more control points are specified for an unbundled bezier edge, each
 
 * **`control-point-distances`** : A series of values that specify for each control point the distance perpendicular to a line formed from source to target, e.g. `-20 20 -20`.
 * **`control-point-weights`** : A series of values that weights control points along a line from source to target, e.g. `0.25 0.5 0.75`.  A value usually ranges on [0, 1], with 0 towards the source node and 1 towards the target node --- but larger or smaller values can also be used.
-* **`edge-distances`** : With value `intersection` (default), the line from source to target for `control-point-weights` is from the outside of the source node's shape to the outside of the target node's shape.  With value `node-position`, the line is from the source position to the target position.  The `node-position` option makes calculating edge points easier --- but it should be used carefully because you can create invalid points that `intersection` would have automatically corrected.
+* **`edge-distances`** : 
+  * With value `intersection` (default), the line from source to target for `segment-weights` is from the outside of the source node's shape to the outside of the target node's shape.  
+  * With value `node-position`, the line is from the source position to the target position.  
+  * The `node-position` option makes calculating edge points easier --- but it should be used carefully because you can create invalid points that `intersection` would have automatically corrected.
+  * With value `endpoints`, the line is from the manually-specified source endpoint (via `source-endpoint`) to the manually-specified target endpoint (via `target-endpoint`).
+    * A manual endpoint may be specified with a position, e.g. `source-endpoint: 20 10`.
+    * A manual endpoint may be alternatively specified with an angle, e.g. `target-endpoint: 90deg`.
 
 
 ## Haystack edges
@@ -411,7 +423,13 @@ A segment edge is made of a series of one or more straight lines, using a co-ord
 
 * **`segment-distances`** : A series of values that specify for each segment point the distance perpendicular to a line formed from source to target, e.g. `-20 20 -20`.
 * **`segment-weights`** : A series of values that weights segment points along a line from source to target, e.g. `0.25 0.5 0.75`.  A value usually ranges on [0, 1], with 0 towards the source node and 1 towards the target node --- but larger or smaller values can also be used.
-* **`edge-distances`** : With value `intersection` (default), the line from source to target for `segment-weights` is from the outside of the source node's shape to the outside of the target node's shape.  With value `node-position`, the line is from the source position to the target position.  The `node-position` option makes calculating edge points easier --- but it should be used carefully because you can create invalid points that `intersection` would have automatically corrected.
+* **`edge-distances`** : 
+  * With value `intersection` (default), the line from source to target for `segment-weights` is from the outside of the source node's shape to the outside of the target node's shape.  
+  * With value `node-position`, the line is from the source position to the target position.  
+  * The `node-position` option makes calculating edge points easier --- but it should be used carefully because you can create invalid points that `intersection` would have automatically corrected.
+  * With value `endpoints`, the line is from the manually-specified source endpoint (via `source-endpoint`) to the manually-specified target endpoint (via `target-endpoint`).
+    * A manual endpoint may be specified with a position, e.g. `source-endpoint: 20 10`.
+    * A manual endpoint may be alternatively specified with an angle, e.g. `target-endpoint: 90deg`.
 
 
 ## Straight edges

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -96,7 +96,7 @@ const styfn = {};
     angle: { number: true, units: 'deg|rad', implicitUnits: 'rad' },
     textRotation: { number: true, units: 'deg|rad', implicitUnits: 'rad', enums: [ 'none', 'autorotate' ] },
     polygonPointList: { number: true, multiple: true, evenMultiple: true, min: -1, max: 1, unitless: true },
-    edgeDistances: { enums: ['intersection', 'node-position'] },
+    edgeDistances: { enums: ['intersection', 'node-position', 'endpoints'] },
     edgeEndpoint: {
       number: true, multiple: true, units: '%|px|em|deg|rad', implicitUnits: 'px',
       enums: [ 'inside-to-node', 'outside-to-node', 'outside-to-node-or-label', 'outside-to-line', 'outside-to-line-or-label' ], singleEnum: true,


### PR DESCRIPTION
**Cross-references to related issues.**  

Associated issues:

-  #3157

**Notes re. the content of the pull request.** 


- This change allows bundled bezier edges, unbundled bezier edges, and segment edges to use `edge-distances: endpoints`.
- The documentation has been updated accordingly.
- The change is minimally invasive by making a new function for the adjustment.
  - The adjustment alters the midpoint and the inverted normal vector used for middle-point calculations (e.g. bezier control points).
  - Limitation: The adjustment must happen at the middle-point phase, rather than the endpoint phase.  The endpoint phase happens after the middle point phase, because many edges have automatic endpoints based on the middle points.  This means that the endpoint calculations would be duplicated for `edge-distances: endpoints` edges.  In future, this could be optimised if needed.
- Limitation: For a bundled bezier, this implementation assumes that all beziers in the bundle have the same endpoint.  [Using different endpoints within a bundle] doesn't seem like a valid use case, anyway.

This PR allows for edges like this, even when the nodes vary in width:

<img width="178" alt="Screenshot 2023-09-05 at 19 01 54" src="https://github.com/cytoscape/cytoscape.js/assets/989043/c7698f55-7a53-452e-92a6-0f519ae49b46">


**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] N/A -- Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
