### PR TITLE
Add support for float numbers (positive & negative) in the z-index style property

### DIFF
--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -533,7 +533,9 @@ Endpoint modification is not supported for `curve-style: haystack` edges for per
     * An `opacity: 0` element is considered normally by layouts.
     * An `opacity: 0` element is taken into consideration for viewport fitting.
   * An `opacity: 0` element is interactive.
-* **`z-index`** : An integer value that affects the relative draw order of elements.  In general, an element with a higher `z-index` will be drawn on top of an element with a lower `z-index`.  Note that edges are under nodes despite `z-index`, except when necessary for compound nodes.
+* **`z-index`** : A numeric value that affects the relative draw order of elements.  In general, an element with a higher `z-index` will be drawn on top of an element with a lower `z-index`.  
+  * Note that edges are under nodes despite `z-index`, except when necessary for compound nodes.
+  * Note that unlike CSS proper, the `z-index` is a floating point value.  Like CSS, the value is non-negative.
 
 Elements are drawn in a specific order based on compound depth (low to high), the element type (typically nodes above edges), and z-index (low to high).  These styles affect the ordering:
 

--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -535,7 +535,7 @@ Endpoint modification is not supported for `curve-style: haystack` edges for per
   * An `opacity: 0` element is interactive.
 * **`z-index`** : A numeric value that affects the relative draw order of elements.  In general, an element with a higher `z-index` will be drawn on top of an element with a lower `z-index`.  
   * Note that edges are under nodes despite `z-index`, except when necessary for compound nodes.
-  * Note that unlike CSS proper, the `z-index` is a floating point value.  Like CSS, the value is non-negative.
+  * Note that unlike CSS proper, the `z-index` is a floating point value.
 
 Elements are drawn in a specific order based on compound depth (low to high), the element type (typically nodes above edges), and z-index (low to high).  These styles affect the ordering:
 

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -29,6 +29,7 @@ const styfn = {};
     zeroOneNumbers: { number: true, min: 0, max: 1, unitless: true, multiple: true },
     nOneOneNumber: { number: true, min: -1, max: 1, unitless: true },
     nonNegativeInt: { number: true, min: 0, integer: true, unitless: true },
+    nonNegativeNumber: { number: true, min: 0, unitless: true },
     position: { enums: [ 'parent', 'origin' ] },
     nodeSize: { number: true, min: 0, enums: [ 'label' ] },
     number: { number: true, unitless: true },
@@ -241,7 +242,7 @@ const styfn = {};
     { name: 'min-zoomed-font-size', type: t.size },
     { name: 'z-compound-depth', type: t.zCompoundDepth, triggersZOrder: diff.any },
     { name: 'z-index-compare', type: t.zIndexCompare, triggersZOrder: diff.any },
-    { name: 'z-index', type: t.nonNegativeInt, triggersZOrder: diff.any }
+    { name: 'z-index', type: t.nonNegativeNumber, triggersZOrder: diff.any }
   ];
 
   let overlay = [

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -242,7 +242,7 @@ const styfn = {};
     { name: 'min-zoomed-font-size', type: t.size },
     { name: 'z-compound-depth', type: t.zCompoundDepth, triggersZOrder: diff.any },
     { name: 'z-index-compare', type: t.zIndexCompare, triggersZOrder: diff.any },
-    { name: 'z-index', type: t.nonNegativeNumber, triggersZOrder: diff.any }
+    { name: 'z-index', type: t.number, triggersZOrder: diff.any }
   ];
 
   let overlay = [


### PR DESCRIPTION
**Cross-references to related issues.**  If there is no existing issue that describes your bug or feature request, then [create an issue](https://github.com/cytoscape/cytoscape.js/issues/new/choose) before making your pull request.

Associated issues: 
- #3160

**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

- Revise `z-index` property to use a `nonNegativeNumber` type rather than `nonNegativeInt`.
- Revise documentation accordingly.
- N.b. this does not change the non-negative constraint on the z-index values.
- This has been manually verified on the debug page.

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] N/A : Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
