### PR TITLE
docs: Fix a typo

### DIFF
--- a/documentation/docmaker.json
+++ b/documentation/docmaker.json
@@ -745,7 +745,7 @@
 
             {
               "name": "cy.autoungrabify",
-              "descr": "Get or set whether nodes are automatically ungrabified (i.e. if `true`, nodes are ungrabbale despite their individual state).",
+              "descr": "Get or set whether nodes are automatically ungrabified (i.e. if `true`, nodes are ungrabbable despite their individual state).",
               "formats": [
                 {
                   "descr": "Get whether autoungrabifying is enabled."


### PR DESCRIPTION
See issue
- https://github.com/cytoscape/cytoscape.js/issues/3169

Associated issues: #3169

**Summary Notes**

- This PR changes one word in **docmaker.json** (`ungrabbale ` to `ungrabbable`)
- Since this PR modify documents, tests are not neccesary. 

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.
- [x] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
