### PR TITLE
Fixes COSE TypeError by filtering the edges in the passed-in options

### DIFF
--- a/src/extensions/layout/cose.js
+++ b/src/extensions/layout/cose.js
@@ -105,8 +105,19 @@ var defaults = {
  */
 function CoseLayout( options ){
   this.options = util.extend( {}, defaults, options );
-
   this.options.layout = this;
+
+  // Exclude any edge that has a source or target node that is not in the set of passed-in nodes
+  const nodes = this.options.eles.nodes();
+  const edges = this.options.eles.edges();
+  const notEdges = edges.filter((e) => {
+    const sourceId = e.source().data('id');
+    const targetId = e.target().data('id');
+    const hasSource = nodes.some((n) => n.data('id') === sourceId);
+    const hasTarget = nodes.some((n) => n.data('id') === targetId);
+    return !hasSource || !hasTarget;
+  });
+  this.options.eles = this.options.eles.not(notEdges);
 }
 
 /**


### PR DESCRIPTION
Associated issues: #3170

- This PR filters the elements passed in the layout options to discard any edge that has a connected node (source or target) that is not in the passed-in node collection.

**Checklist**

Author:

- [X] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [X] The associated GitHub issues are included (above).
- [X] Notes have been included (above).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
