### PR TITLE
Document `spacingFactor` for `preset` layout

### DIFF
--- a/src/extensions/layout/preset.js
+++ b/src/extensions/layout/preset.js
@@ -8,6 +8,7 @@ let defaults = {
   pan: undefined, // the pan level to set (prob want fit = false if set)
   fit: true, // whether to fit to viewport
   padding: 30, // padding on fit
+  spacingFactor: undefined, // Applies a multiplicative factor (>0) to expand or compress the overall area that the nodes take up
   animate: false, // whether to transition the node positions
   animationDuration: 500, // duration of animation in ms if enabled
   animationEasing: undefined, // easing of animation if enabled


### PR DESCRIPTION
Ref: Add official support for spacingFactor in the preset layout #3172

**Cross-references to related issues.**  If there is no existing issue that describes your bug or feature request, then [create an issue](https://github.com/cytoscape/cytoscape.js/issues/new/choose) before making your pull request.

Associated issues:

- #3172

**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

- This PR documents the existing support for the `spacingFactor` option within the `preset` layout.
- The `spacingFactor` can be used to compress or expand a preset layout, as required for bubble expanding/collapsing in [Enrichment Map Web](https://github.com/cytoscape/enrichment-map-webapp).

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [ ] N/A : Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
