### PR TITLE
Add note re. z-index and layering -- not like CSS proper

### DIFF
--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -554,6 +554,7 @@ Endpoint modification is not supported for `curve-style: haystack` edges for per
 * **`z-index`** : A numeric value that affects the relative draw order of elements.  In general, an element with a higher `z-index` will be drawn on top of an element with a lower `z-index`.  
   * Note that edges are under nodes despite `z-index`, except when necessary for compound nodes.
   * Note that unlike CSS proper, the `z-index` is a floating point value.
+  * A negative value does not have special behaviour.  The element is layered according to `z-compound-depth` and `z-index-compare`, while `z-index` only sorts an element within a layer.
 
 Elements are drawn in a specific order based on compound depth (low to high), the element type (typically nodes above edges), and z-index (low to high).  These styles affect the ordering:
 

--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -554,7 +554,7 @@ Endpoint modification is not supported for `curve-style: haystack` edges for per
 * **`z-index`** : A numeric value that affects the relative draw order of elements.  In general, an element with a higher `z-index` will be drawn on top of an element with a lower `z-index`.  
   * Note that edges are under nodes despite `z-index`, except when necessary for compound nodes.
   * Note that unlike CSS proper, the `z-index` is a floating point value.
-  * A negative value does not have special behaviour.  The element is layered according to `z-compound-depth` and `z-index-compare`, while `z-index` only sorts an element within a layer.
+  * Also unlike CSS proper, a negative value does not have special behaviour.  The element is layered according to `z-compound-depth` and `z-index-compare`, while `z-index` only sorts an element within a layer.
 
 Elements are drawn in a specific order based on compound depth (low to high), the element type (typically nodes above edges), and z-index (low to high).  These styles affect the ordering:
 


### PR DESCRIPTION
**Cross-references to related issues.**  If there is no existing issue that describes your bug or feature request, then [create an issue](https://github.com/cytoscape/cytoscape.js/issues/new/choose) before making your pull request.

Associated issues:

- #3160

**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

- Add notes re. negative z-index values.
- See https://github.com/cytoscape/cytoscape.js/issues/3160#issuecomment-1776085849

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] N/A: Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
