### PR TITLE
:sparkles: Add <position>-arrow-width property for hollow shapes

### DIFF
--- a/debug/init.js
+++ b/debug/init.js
@@ -17,22 +17,25 @@ var cy, defaultSty, options;
           'target-arrow-shape': 'triangle',
           'mid-target-arrow-shape': 'triangle',
           'mid-source-arrow-shape': 'triangle-backcurve',
-          'target-arrow-fill': 'hollow',
-          'source-arrow-fill': 'hollow',
-          'source-arrow-width': 2,
-          'target-arrow-width': '50%',
         })
       .selector('#ab')
         .style({
           'curve-style': 'unbundled-bezier',
           'control-point-distances': [ 20, -100, 20 ],
           'control-point-weights': [ 0.25, 0.5, 0.75 ],
+          'source-arrow-fill': 'hollow',
+          'source-arrow-width': 2,
+          'target-arrow-fill': 'hollow',
+          'target-arrow-width': 'match-line',
         })
       .selector('#bc')
         .style({
           'curve-style': 'segments',
           'segment-distances': [ 20, -80 ],
           'segment-weights': [ 0.25, 0.5 ],
+          'source-arrow-fill': 'hollow',
+          'source-arrow-width': '50%',
+          'target-arrow-fill': 'hollow',
         })
       .selector('#ef')
         .style({

--- a/debug/init.js
+++ b/debug/init.js
@@ -16,7 +16,11 @@ var cy, defaultSty, options;
           'source-arrow-shape': 'triangle-backcurve',
           'target-arrow-shape': 'triangle',
           'mid-target-arrow-shape': 'triangle',
-          'mid-source-arrow-shape': 'triangle-backcurve'
+          'mid-source-arrow-shape': 'triangle-backcurve',
+          'target-arrow-fill': 'hollow',
+          'source-arrow-fill': 'hollow',
+          'source-arrow-width': 2,
+          'target-arrow-width': '50%',
         })
       .selector('#ab')
         .style({

--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -503,6 +503,7 @@ When a taxi edge would be impossible to draw along the regular turning plan --- 
   * `chevron`
   * `none`
 * **`<pos>-arrow-fill`** : The fill state of the edge's source arrow; may be `filled` or `hollow`.
+* **`<pos>-arrow-width`** : The width of the edge's source arrow shape; may be `match-line`, a number (pixel), or a string with units (`px` | `%` | `em`). The `%` unit is based on the edge `width`.
 * **`arrow-scale`** : Scaling for the arrow size; may be any number >= 0.
 
 For each edge arrow property above, replace `<pos>` with one of

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "cytoscape",
-      "version": "3.27.0-unstable",
+      "version": "3.28.0-unstable",
       "license": "MIT",
       "dependencies": {
         "heap": "^0.2.6",

--- a/src/extensions/renderer/canvas/drawing-edges.js
+++ b/src/extensions/renderer/canvas/drawing-edges.js
@@ -278,6 +278,11 @@ CRp.drawArrowhead = function( context, edge, prefix, x, y, angle, opacity ){
   let arrowClearFill = edge.pstyle( prefix + '-arrow-fill' ).value === 'hollow' ? 'both' : 'filled';
   let arrowFill = edge.pstyle( prefix + '-arrow-fill' ).value;
   let edgeWidth = edge.pstyle( 'width' ).pfValue;
+
+  let pArrowWidth = edge.pstyle( prefix + '-arrow-width' );
+  let arrowWidth = pArrowWidth.value === 'match-line' ? edgeWidth : pArrowWidth.pfValue;
+  if (pArrowWidth.units === '%') arrowWidth *= edgeWidth;
+
   let edgeOpacity = edge.pstyle( 'opacity' ).value;
 
   if( opacity === undefined ){
@@ -293,7 +298,7 @@ CRp.drawArrowhead = function( context, edge, prefix, x, y, angle, opacity ){
     self.colorStrokeStyle( context, 255, 255, 255, 1 );
 
     self.drawArrowShape( edge, context,
-      arrowClearFill, edgeWidth, arrowShape, x, y, angle
+      arrowClearFill, edgeWidth, arrowShape, arrowWidth, x, y, angle
     );
 
     context.globalCompositeOperation = gco;
@@ -304,11 +309,11 @@ CRp.drawArrowhead = function( context, edge, prefix, x, y, angle, opacity ){
   self.colorStrokeStyle( context, color[0], color[1], color[2], opacity );
 
   self.drawArrowShape( edge, context,
-    arrowFill, edgeWidth, arrowShape, x, y, angle
+    arrowFill, edgeWidth, arrowShape, arrowWidth, x, y, angle
   );
 };
 
-CRp.drawArrowShape = function( edge, context, fill, edgeWidth, shape, x, y, angle ){
+CRp.drawArrowShape = function( edge, context, fill, edgeWidth, shape, shapeWidth, x, y, angle ){
   let r = this;
   let usePaths = this.usePaths() && shape !== 'triangle-cross';
   let pathCacheHit = false;
@@ -360,7 +365,7 @@ CRp.drawArrowShape = function( edge, context, fill, edgeWidth, shape, x, y, angl
   }
 
   if( fill === 'hollow' || fill === 'both' ){
-    context.lineWidth = ( shapeImpl.matchEdgeWidth ? edgeWidth : 1 ) / ( usePaths ? size : 1 );
+    context.lineWidth = shapeWidth / (usePaths ? size : 1);
     context.lineJoin = 'miter';
 
     if( usePaths ){

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -716,7 +716,7 @@ styfn.getDefaultProperties = function(){
     { name: 'arrow-shape', value: 'none' },
     { name: 'arrow-color', value: '#999' },
     { name: 'arrow-fill', value: 'filled' },
-    { name: 'arrow-width', value: 'match-line' },
+    { name: 'arrow-width', value: 1 },
   ].reduce( function( css, prop ){
     styfn.arrowPrefixes.forEach( function( prefix ){
       let name = prefix + '-' + prop.name;

--- a/src/style/properties.js
+++ b/src/style/properties.js
@@ -76,6 +76,7 @@ const styfn = {};
     compoundIncludeLabels: { enums: [ 'include', 'exclude' ] },
     arrowShape: { enums: [ 'tee', 'triangle', 'triangle-tee', 'circle-triangle', 'triangle-cross', 'triangle-backcurve', 'vee', 'square', 'circle', 'diamond', 'chevron', 'none' ] },
     arrowFill: { enums: [ 'filled', 'hollow' ] },
+    arrowWidth: { number: true, units: '%|px|em', implicitUnits: 'px', enums: [ 'match-line' ] },
     display: { enums: [ 'element', 'none' ] },
     visibility: { enums: [ 'hidden', 'visible' ] },
     zCompoundDepth: { enums: [ 'bottom', 'orphan', 'auto', 'top' ] },
@@ -401,7 +402,8 @@ const styfn = {};
   [
     { name: 'arrow-shape', type: t.arrowShape, triggersBounds: diff.any },
     { name: 'arrow-color', type: t.color },
-    { name: 'arrow-fill', type: t.arrowFill }
+    { name: 'arrow-fill', type: t.arrowFill },
+    { name: 'arrow-width', type: t.arrowWidth }
   ].forEach( function( prop ){
     arrowPrefixes.forEach( function( prefix ){
       let name = prefix + '-' + prop.name;
@@ -713,7 +715,8 @@ styfn.getDefaultProperties = function(){
   }, [
     { name: 'arrow-shape', value: 'none' },
     { name: 'arrow-color', value: '#999' },
-    { name: 'arrow-fill', value: 'filled' }
+    { name: 'arrow-fill', value: 'filled' },
+    { name: 'arrow-width', value: 'match-line' },
   ].reduce( function( css, prop ){
     styfn.arrowPrefixes.forEach( function( prefix ){
       let name = prefix + '-' + prop.name;


### PR DESCRIPTION
Associated issues: #3191 

- This PR adds a new style property on edges `<position>-arrow-width` which allow user to customise the thickness of the hollowed arrow shapes stroke. 
  - default value : 'match-line' ==> the stroke width is the same as the edge width
  - number value ==> considered as a px width
  - string value ==> `${number}${unit}` where unit can either be `px`, `em` or `%`. 
    - `%` value is based on edge width. e.g. 100% ahas the same behaviour as 'match-line'
- This PR includes modifications to the documentation to present the new property
- This PR includes modifications to the debug to easily visualise the impact of the property

![Screenshot 2023-12-02 at 13 09 20](https://github.com/cytoscape/cytoscape.js/assets/42945601/4e5eeac2-6c3e-4ac5-9893-8e5b1551927d)

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
