### PR TITLE
Add `nodes.parentNodes()` and `nodes.nonparentNodes()`.

### DIFF
--- a/documentation/docmaker.json
+++ b/documentation/docmaker.json
@@ -3664,6 +3664,31 @@
             },
 
             {
+              "name": "nodes.parentNodes",
+              "descr": "Get all parent nodes (i.e. has compound children) in the calling collection.",
+              "formats": [
+                {
+                  "args": [
+                    { "name": "selector", "descr": "A selector used to filter the resultant collection.", "optional": true }
+                  ]
+                }
+              ]
+            },
+
+            {
+              "name": "nodes.nonparentNodes",
+              "pureAliases": ["eles.childlessNodes"],
+              "descr": "Get all non-parent nodes (i.e. has no compound children) in the calling collection.",
+              "formats": [
+                {
+                  "args": [
+                    { "name": "selector", "descr": "A selector used to filter the resultant collection.", "optional": true }
+                  ]
+                }
+              ]
+            },
+
+            {
               "name": "nodes.children",
               "descr": "Get all compound child (i.e. direct descendant) nodes of each node in the collection.",
               "formats": [

--- a/src/collection/compounds.js
+++ b/src/collection/compounds.js
@@ -136,6 +136,14 @@ let elesfn = ({
     add( this.children() );
 
     return this.spawn( elements, true ).filter( selector );
+  },
+
+  parentNodes: function(selector) {
+    return this.filter(el => el.isParent()).filter(selector);
+  },
+
+  nonparentNodes: function(selector) {
+    return this.filter(el => el.isChildless()).filter(selector);
   }
 });
 
@@ -215,5 +223,6 @@ elesfn.forEachUpAndDown = function( fn, includeSelf = true ){
 
 // aliases
 elesfn.ancestors = elesfn.parents;
+elesfn.childlessNodes = elesfn.nonparentNodes;
 
 export default elesfn;

--- a/test/collection-compound-nodes.js
+++ b/test/collection-compound-nodes.js
@@ -113,6 +113,15 @@ describe('Collection compound nodes', function(){
     expect( cy.elements().nonorphans().same( n2.add(n3).add(n4) ) ).to.be.true;
   });
 
+  it('nodes.parentNodes()', function(){
+    expect( cy.elements().parentNodes().same( n1.add(n2) ) ).to.be.true;
+  });
+
+  it('nodes.nonparentNodes()', function(){
+    expect( cy.elements().nonparentNodes().same( n3.add(n4) ) ).to.be.true;
+    expect( cy.elements().childlessNodes().same( n3.add(n4) ) ).to.be.true; // alias
+  });
+
   it('child.position() moves parent', function(){
     var p1 = {
       x: n2.position().x,


### PR DESCRIPTION
Ref: Add a method for nodes.nonparentNodes() to get the childless nodes #3182

Associated issues:

- #3182

**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

- Add `nodes.parentNodes()` : gets the nodes in the calling collection that are parents.
- Add `nodes.nonparentNodes()` : gets the nodes in the calling collection that are NOT parents.
- Add `nodes.childlessNodes()` alias : alias of `nonParentnodes()`.
- Add documentation.
- Add tests.

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
