### PR TITLE
Reverse deprecation of pie chart props

### DIFF
--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -338,6 +338,18 @@ The following is an example of valid background image styling using JSON. The ex
 ```
 
 
+## Pie chart background
+
+These properties allow you to create pie chart backgrounds on nodes ([demo](demos/pie-style)).  Note that 16 slices maximum are supported per node, so in the properties `1 <= i <= 16`.  Of course, you must specify a numerical value for each property in place of `i`.  Each nonzero sized slice is placed in order of `i`, starting from the 12 o'clock position and working clockwise.
+
+You may find it useful to reserve a number to a particular colour for all nodes in your stylesheet.  Then you can specify values for `pie-i-background-size` accordingly for each node via a [mapper](#style/mappers).  This would allow you to create consistently coloured pie charts in each node of the graph based on element data.
+
+ * **`pie-size`** : The diameter of the pie, measured as a percent of node size (e.g. `100%`) or an absolute length (e.g. `25px`).
+ * **`pie-i-background-color`** : The colour of the node's ith pie chart slice.
+ * **`pie-i-background-size`** : The size of the node's ith pie chart slice, measured in percent (e.g. `25%` or `25`).
+ * **`pie-i-background-opacity`** : The opacity of the node's ith pie chart slice.
+
+
 
 
 ## Edge line

--- a/src/style/apply.js
+++ b/src/style/apply.js
@@ -433,10 +433,6 @@ styfn.applyParsedProperty = function( ele, parsedProp ){
     self.checkTriggers( ele, prop.name, fromVal, toVal );
   };
 
-  if( prop && prop.name.substr(0, 3) === 'pie' ){
-    util.warn('The pie style properties are deprecated.  Create charts using background images instead.');
-  }
-
   // edge sanity checks to prevent the client from making serious mistakes
   if(
     parsedProp.name === 'curve-style'


### PR DESCRIPTION

**Cross-references to related issues.**  If there is no existing issue that describes your bug or feature request, then [create an issue](https://github.com/cytoscape/cytoscape.js/issues/new/choose) before making your pull request.

Associated issues: 

- #3196
- #2789

**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

- Adds back documentation for pie chart properties.
- Removes deprecation warning in the console when the pie chart properties are used.

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] N/A : Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
