### PR TITLE
Change rollup.config to bundle deps in esm.js

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -105,9 +105,9 @@ const configs = [
   {
     input,
     output: { file: 'build/cytoscape.esm.js', format: 'es' },
-    external: isExternal,
     plugins: [
       nodeResolve(),
+      commonjs({ include: '**/node_modules/**' }),
       BABEL ? babel(getBabelOptions()) : {},
       replace(envVariables),
       license(licenseHeaderOptions)


### PR DESCRIPTION
https://github.com/cytoscape/cytoscape.js/issues/3217

This pull request changes rollup config to bundle deps into the non min version of ESM.

why:

* browsers can't import cjs, so all deps must be esm
* not all deps to cytoscape are served as esm
