### PR TITLE
Keep original separator instead of using space when text-wrapping

### DIFF
--- a/debug/init.js
+++ b/debug/init.js
@@ -27,7 +27,10 @@ var cy, defaultSty, options;
           'shape': 'round-rectangle',
           'width': 220,
           'height': 60,
-          'corner-radius': 30
+          'corner-radius': 30,
+          "label": "I am a long label over-\u200bflowing my max    width,\n but spa\u200bces are ke\u200bpt",
+          "text-max-width": 100,
+          "text-wrap": "wrap",
         })
       .selector('node#b')
       .style({
@@ -110,7 +113,7 @@ var cy, defaultSty, options;
       .selector('#eh')
         .style({
           'curve-style': 'round-segments',
-          'segment-distances': [ 0  , 50 , 0  , -50, 0  , 0  , 100 ],
+          'segment-distances': [ 0  , 0 , 0  , -50, 0  , 0  , 100 ],
           'segment-weights': [   0.5, 0.6, 0.7, 0.6, 0.5, 0.8, 0.85],
           'segment-radii': [ 50, 100 ],
         })

--- a/src/extensions/renderer/base/coord-ele-math/labels.js
+++ b/src/extensions/renderer/base/coord-ele-math/labels.js
@@ -362,8 +362,7 @@ BRp.getLabelText = function( ele, prefix ){
     let overflow = ele.pstyle('text-overflow-wrap').value;
     let overflowAny = overflow === 'anywhere';
     let wrappedLines = [];
-    let wordsRegex = /[\s\u200b]+/;
-    let wordSeparator = overflowAny ? '' : ' ';
+    let separatorRegex = /[\s\u200b]+|$/g; // Include end of string to add last word
 
     for( let l = 0; l < lines.length; l++ ){
       let line = lines[ l ];
@@ -378,12 +377,17 @@ BRp.getLabelText = function( ele, prefix ){
       }
 
       if( lineW > maxW ){ // line is too long
-        let words = line.split(wordsRegex);
+        let separatorMatches = line.matchAll(separatorRegex);
         let subline = '';
 
-        for( let w = 0; w < words.length; w++ ){
-          let word = words[ w ];
-          let testLine = subline.length === 0 ? word : subline + wordSeparator + word;
+        let previousIndex = 0;
+        // Add fake match
+        for( let separatorMatch of separatorMatches ){
+          let wordSeparator = separatorMatch[ 0 ];
+          let word = line.substring( previousIndex, separatorMatch.index );
+          previousIndex = separatorMatch.index + wordSeparator.length;
+
+          let testLine = subline.length === 0 ? word : subline + word + wordSeparator;
           let testDims = this.calculateLabelDimensions( ele, testLine );
           let testW = testDims.width;
 


### PR DESCRIPTION
**Cross-references to related issues.** 

Associated issues: 

- #3235 

**Notes re. the content of the pull request.** 

- This PR ensure that separators from the original labels are kept when wrapping

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
