### PR TITLE
fix(umd): exported cytoscape.umd, closes #3239

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "./dist/cytoscape.esm.min": {
       "import": "./dist/cytoscape.esm.min.mjs"
     },
+    "./dist/cytoscape.umd.js": {
+      "import": "./dist/cytoscape.umd.js"
+    },
     "./dist/*": {
       "import": "./dist/*.js",
       "require": "./dist/*.js"


### PR DESCRIPTION
Associated issues: 

- #3239

**Notes re. the content of the pull request.** 

Mermaid.js imports Cytoscape.js as follows (see [source](https://www.npmjs.com/package/mermaid/v/9.4.3?activeTab=code), line 3):
```ts
import cytoscape from "cytoscape/dist/cytoscape.umd.js";
```

Cytoscape version `3.29.0` introduced an [explicit `exports` field](https://github.com/cytoscape/cytoscape.js/compare/v3.28.1...v3.29.0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), which misses the required `umd` export, and prevents Mermaid from loading Cytoscape.

While Cytoscape version `3.29.1` [corrected the ESM and CJS exports](https://github.com/cytoscape/cytoscape.js/compare/v3.29.0...v3.29.1#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), the UMD export was still missing.

This PR adds the missing UMD export.

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
