### PR TITLE
initialize edgeType when calling getSegmentPoints or getControlPoints

### DIFF
--- a/src/extensions/renderer/base/coord-ele-math/edge-control-points.js
+++ b/src/extensions/renderer/base/coord-ele-math/edge-control-points.js
@@ -1014,22 +1014,22 @@ function getPts( pts ){
 
 BRp.getSegmentPoints = function( edge ){
   let rs = edge[0]._private.rscratch;
+  
+  this.recalculateRenderedStyle( edge );
+
   let type = rs.edgeType;
-
   if( type === 'segments' ){
-    this.recalculateRenderedStyle( edge );
-
     return getPts( rs.segpts );
   }
 };
 
 BRp.getControlPoints = function( edge ){
   let rs = edge[0]._private.rscratch;
+
+  this.recalculateRenderedStyle( edge );
+  
   let type = rs.edgeType;
-
   if( type === 'bezier' || type === 'multibezier' || type === 'self' || type === 'compound' ){
-    this.recalculateRenderedStyle( edge );
-
     return getPts( rs.ctrlpts );
   }
 };


### PR DESCRIPTION
Associated issues: 

- #3267

**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

- Fixes the getSegmentPoints ()and getControlPoints() functions.
- There's a bit of a chicken-and-egg problem with the way those functions were written. It checks the edgeType field before calling recalculateRenderedStyle(), but recalculateRenderedStyle() initializes the edgeType field.
- The fix moves the call to recalculateRenderedStyle() to before the edgeType check, so it always gets called. The getEdgeMidpoint() function works that way so I assume its fine. I opened a PR for this simple fix because I'm not entirely sure.

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
