### PR TITLE
Add padding to getLabelRotationOffset()

### DIFF
--- a/src/collection/dimensions/bounds.js
+++ b/src/collection/dimensions/bounds.js
@@ -341,10 +341,15 @@ let updateBoundsFromLabel = function( bounds, ele, prefix ){
     }
 
     // shift by margin and expand by outline and border
-    lx1 += marginX - Math.max( outlineWidth, halfBorderWidth ) - padding - marginOfError;
-    lx2 += marginX + Math.max( outlineWidth, halfBorderWidth ) + padding + marginOfError;
-    ly1 += marginY - Math.max( outlineWidth, halfBorderWidth ) - padding - marginOfError;
-    ly2 += marginY + Math.max( outlineWidth, halfBorderWidth ) + padding + marginOfError;
+    let leftPad  = marginX - Math.max( outlineWidth, halfBorderWidth ) - padding - marginOfError;
+    let rightPad = marginX + Math.max( outlineWidth, halfBorderWidth ) + padding + marginOfError;
+    let topPad   = marginY - Math.max( outlineWidth, halfBorderWidth ) - padding - marginOfError;
+    let botPad   = marginY + Math.max( outlineWidth, halfBorderWidth ) + padding + marginOfError;
+
+    lx1 += leftPad;
+    lx2 += rightPad;
+    ly1 += topPad;
+    ly2 += botPad;
 
     // always store the unrotated label bounds separately
     let bbPrefix = prefix || 'main';
@@ -356,6 +361,10 @@ let updateBoundsFromLabel = function( bounds, ele, prefix ){
     bb.y2 = ly2;
     bb.w = lx2 - lx1;
     bb.h = ly2 - ly1;
+    bb.leftPad = leftPad;
+    bb.rightPad = rightPad;
+    bb.topPad = topPad;
+    bb.botPad = botPad;
 
     let isAutorotate = ( isEdge && rotation.strValue === 'autorotate' );
     let isPfValue = ( rotation.pfValue != null && rotation.pfValue !== 0 );

--- a/src/extensions/renderer/canvas/index.js
+++ b/src/extensions/renderer/canvas/index.js
@@ -134,7 +134,7 @@ function CanvasRenderer( options ){
   let drawTargetLabel = (context, ele, bb, scaledLabelShown, useEleOpacity) => r.drawElementText( context, ele, bb, scaledLabelShown, 'target', useEleOpacity );
 
   let getElementBox = ele => { ele.boundingBox(); return ele[0]._private.bodyBounds; };
-  let getLabelBox = ele => { ele.boundingBox(); return ele[0]._private.labelBounds.main || emptyBb; };
+  let getLabelBox   = ele => { ele.boundingBox(); return ele[0]._private.labelBounds.main || emptyBb; };
   let getSourceLabelBox = ele => { ele.boundingBox(); return ele[0]._private.labelBounds.source || emptyBb; };
   let getTargetLabelBox = ele => { ele.boundingBox(); return ele[0]._private.labelBounds.target || emptyBb; };
 
@@ -172,19 +172,19 @@ function CanvasRenderer( options ){
     if( ele.isNode() ){
       switch( ele.pstyle('text-halign').value ){
         case 'left':
-          p.x = -bb.w;
+          p.x = -bb.w - (bb.leftPad || 0);
           break;
         case 'right':
-          p.x = 0;
+          p.x = -(bb.rightPad || 0);
           break;
       }
 
       switch( ele.pstyle('text-valign').value ){
         case 'top':
-          p.y = -bb.h;
+          p.y = -bb.h - (bb.topPad || 0);
           break;
         case 'bottom':
-          p.y = 0;
+          p.y = -(bb.botPad || 0);
           break;
       }
     }


### PR DESCRIPTION
Associated issues: 

- #3271

**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

- Now when the label rotation offset is calculated it includes the margin/outline/border/padding that is part of the label bounds.
- I don't know if this is the best way to fix the bug. I didn't want to change anything about how the bounding boxes are calculated or saved because I'm concerned I might break something. So instead it saves the "padding" along with the bounding box and uses it when calculating the rotation offset.

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
