### PR TITLE
Attach the 'mousemove' handler to the window and the shadow DOM root.

### DIFF
--- a/src/extensions/renderer/base/load-listeners.js
+++ b/src/extensions/renderer/base/load-listeners.js
@@ -8,8 +8,20 @@ var BRp = {};
 
 BRp.registerBinding = function( target, event, handler, useCapture ){ // eslint-disable-line no-unused-vars
   var args = Array.prototype.slice.apply( arguments, [1] ); // copy
-  var b = this.binder( target );
 
+  if( Array.isArray(target) ){
+    let res = [];
+    for( var i = 0; i < target.length; i++ ){
+      let t = target[i];
+      if( t !== undefined ){
+        var b = this.binder( t );
+        res.push( b.on.apply( b, args ) );
+      }
+    }
+    return res;
+  }
+
+  var b = this.binder( target );
   return b.on.apply( b, args );
 };
 
@@ -89,6 +101,14 @@ BRp.load = function(){
   var r = this;
   var containerWindow = r.cy.window();
   var isSelected = ele => ele.selected();
+
+  var getShadowRoot = function( element ){
+    const rootNode = element.getRootNode();
+    // Check if the root node is a shadow root
+    if ( rootNode && rootNode.nodeType === 11 && rootNode.host !== undefined ) {
+      return rootNode;
+    }
+  }
 
   var triggerEvents = function( target, names, e, position ){
     if( target == null ){
@@ -560,7 +580,8 @@ BRp.load = function(){
 
   }, false );
 
-  r.registerBinding( containerWindow, 'mousemove', function mousemoveHandler( e ){ // eslint-disable-line no-undef
+  var shadowRoot = getShadowRoot( r.container );
+  r.registerBinding( [ containerWindow, shadowRoot ], 'mousemove', function mousemoveHandler( e ){ // eslint-disable-line no-undef
     var capture = r.hoverData.capture;
 
     if( !capture && !eventInContainer(e) ){ return; }

--- a/src/extensions/renderer/base/load-listeners.js
+++ b/src/extensions/renderer/base/load-listeners.js
@@ -108,7 +108,7 @@ BRp.load = function(){
     if ( rootNode && rootNode.nodeType === 11 && rootNode.host !== undefined ) {
       return rootNode;
     }
-  }
+  };
 
   var triggerEvents = function( target, names, e, position ){
     if( target == null ){


### PR DESCRIPTION
Associated issues: 

- #3273 

Notes re. the content of the pull request. Give context to reviewers or serve as a general record of the changes made. Add a screenshot or video to demonstrate your new feature, if possible.

- This PR attaches the 'mousemove' handler to both the window and the shadow DOM root of the cytoscape container if there is one.

The problem is described in detail in #3273, but I will recap here. The 'mousemove' handler is attached to the window, but it uses a function called `eventInContainer()` to test if the mouse is over the cytoscape container. The problem is that when the canvas is inside a shadow DOM the event.target field is retargeted to the shadow root, and the `eventInContainer()` function can't tell that the event was over the container. This prevents the 'mouseover' node event from ever firing.

I believe the reason the handler is attached to the window is so it can detect when a node is dragged beyond the bounds of the canvas. Like in this video...

https://github.com/user-attachments/assets/7e1f5391-72e9-4eb5-8bad-13198c8984e0

That means that making the event root for 'mousemove' configurable as suggested in the bug report will break this behaviour. (It would also add API just to handle this case which is undesirable.) Here is an example where I tried attacing the listener to the shadow root instead of the window.

https://github.com/user-attachments/assets/aeadf438-d05e-43bf-8671-3f129cd3396d

The solution I landed on is to test for a shadow root, and if there is one attach the listener to both the window and the shadow root. When the mouse moves over the canvas the listener attached to the shadow root is called, when it moves off the canvas the listener attached to the window is called. Since dragging is initiated by clicking on the canvas the dragging behaviour works correctly. This solution also doesn't require any API change.


**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
