### PR TITLE
Remove OMIC tools link (currently showing casinos and other random te…

### DIFF
--- a/documentation/md/intro.md
+++ b/documentation/md/intro.md
@@ -43,7 +43,7 @@
    * Weekly patch release cadence
    * Monthly feature release cadence
 * Listed by [Zenodo](https://doi.org/10.5281/zenodo.831800) for per-version DOIs
-* Listed by [OMIC Tools](https://omictools.com/cytoscape-js-tool)
+* Listed by OMIC Tools
 
 ## Who uses Cytoscape.js
 


### PR DESCRIPTION
…xt?)

Not sure who to contact from omic tools about fixing that. Looks like it's not every page, but the main page and other project pages are all displaying these links to bet/casino/etc., in some language (Finnish maybe?).

I was going to suggest adding a WayBack machine link, but the Internet Archive is currently offline due to a DDOS attack… so I guess for now the simplest would be to remove the link? Let me know it'd be better to remove the text altogether.

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [ ] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
