### PR TITLE
Fix breadthfirst layout to stay inside viewport on fit: false and no boundingBox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "cytoscape",
-      "version": "3.30.0-unstable",
+      "version": "3.31.0-unstable",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.3.4",

--- a/src/extensions/layout/breadthfirst.js
+++ b/src/extensions/layout/breadthfirst.js
@@ -48,8 +48,9 @@ BreadthFirstLayout.prototype.run = function(){
   const maximal = options.acyclic || options.maximal || options.maximalAdjustments > 0; // maximalAdjustments for compat. w/ old code; also, setting acyclic to true sets maximal to true
 
   const hasBoundingBox = !!options.boundingBox;
+  const cyExtent = cy.extent();
   const bb = math.makeBoundingBox( hasBoundingBox ? options.boundingBox : {
-    x1: 0, y1: 0, w: cy.width(), h: cy.height()
+    x1: cyExtent.x1, y1: cyExtent.y1, w: cyExtent.w, h: cyExtent.h
   } );
 
   let roots;


### PR DESCRIPTION
Associated issues: 

- #3293 

**Notes

- This PR fixes the issue above, from:

https://github.com/user-attachments/assets/a3f78a3f-efd2-48de-b390-6f07840fe2ee

- This PR fixes the issue above, to:

https://github.com/user-attachments/assets/0e18b170-ab39-4ffa-84be-1251adff0a18

**Checklist**

Author:

- [ ] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [ ] The associated GitHub issues are included (above).
- [ ] Notes have been included (above).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
