### PR TITLE
Improve performance by avoiding repeated recalculateRenderedStyle #3309

### DIFF
--- a/src/collection/dimensions/bounds.js
+++ b/src/collection/dimensions/bounds.js
@@ -1,6 +1,6 @@
 import * as is from '../../is';
 import { assignBoundingBox, expandBoundingBoxSides,  clearBoundingBox, expandBoundingBox, makeBoundingBox, copyBoundingBox, shiftBoundingBox, updateBoundingBox } from '../../math';
-import { defaults, getPrefixedProperty, hashIntsArray } from '../../util';
+import { defaults, getPrefixedProperty, getBoundingBoxPosKey } from '../../util';
 
 let fn, elesfn;
 
@@ -800,18 +800,6 @@ let getKey = function( opts ){
   return key;
 };
 
-let getBoundingBoxPosKey = ele => {
-  if( ele.isEdge() ){
-    let p1 = ele.source().position();
-    let p2 = ele.target().position();
-    let r = x => Math.round(x);
-
-    return hashIntsArray([ r(p1.x), r(p1.y), r(p2.x), r(p2.y) ]);
-  } else {
-    return 0;
-  }
-};
-
 let cachedBoundingBoxImpl = function( ele, opts ){
   let _p = ele._private;
   let bb;
@@ -926,6 +914,7 @@ elesfn.boundingBox = function( options ){
         let isPosKeySame = _p.bbCachePosKey === currPosKey;
         let useCache = opts.useCache && isPosKeySame && !_p.styleDirty;
 
+        _p.bbCachePosKey = currPosKey;
         ele.recalculateRenderedStyle( useCache );
       }
     }

--- a/src/extensions/renderer/base/coord-ele-math/edge-control-points.js
+++ b/src/extensions/renderer/base/coord-ele-math/edge-control-points.js
@@ -706,28 +706,7 @@ BRp.findEdgeControlPoints = function( edges ){
   let cy = r.cy;
   let hasCompounds = cy.hasCompoundNodes();
 
-  let hashTable = {
-    map: new Map(),
-    get: function(pairId){
-      let map2 = this.map.get(pairId[0]);
-
-      if( map2 != null ){
-        return map2.get(pairId[1]);
-      } else {
-        return null;
-      }
-    },
-    set: function(pairId, val){
-      let map2 = this.map.get(pairId[0]);
-
-      if( map2 == null ){
-        map2 = new Map();
-        this.map.set(pairId[0], map2);
-      }
-
-      map2.set(pairId[1], val);
-    }
-  };
+  let hashTable = new Map();
 
   let pairIds = [];
   let haystackEdges = [];
@@ -756,7 +735,7 @@ BRp.findEdgeControlPoints = function( edges ){
     let srcIndex = src.poolIndex();
     let tgtIndex = tgt.poolIndex();
 
-    let pairId = [ srcIndex, tgtIndex ].sort();
+    let pairId = `${srcIndex}_${tgtIndex}_${edgeIsUnbundled}`;
 
     let tableEntry = hashTable.get( pairId );
 

--- a/src/extensions/renderer/base/coord-ele-math/edge-control-points.js
+++ b/src/extensions/renderer/base/coord-ele-math/edge-control-points.js
@@ -735,7 +735,8 @@ BRp.findEdgeControlPoints = function( edges ){
     let srcIndex = src.poolIndex();
     let tgtIndex = tgt.poolIndex();
 
-    let pairId = `${srcIndex}_${tgtIndex}_${edgeIsUnbundled}`;
+    let sortIndex = [ srcIndex, tgtIndex ].sort();
+    let pairId = `${sortIndex[0]}_${sortIndex[1]}_${edgeIsUnbundled}`;
 
     let tableEntry = hashTable.get( pairId );
 

--- a/src/extensions/renderer/base/coord-ele-math/rendered-style.js
+++ b/src/extensions/renderer/base/coord-ele-math/rendered-style.js
@@ -1,3 +1,5 @@
+import { getBoundingBoxPosKey } from '../../../../util';
+
 let BRp = {};
 
 BRp.registerCalculationListeners = function(){
@@ -50,6 +52,8 @@ BRp.registerCalculationListeners = function(){
           enqueue( ele.connectedEdges() );
 
           rstyle.cleanConnected = true;
+        } else if (ele.isEdge()) {
+          ele._private.bbCachePosKey = getBoundingBoxPosKey( ele );
         }
       }
 

--- a/src/util/bounds.js
+++ b/src/util/bounds.js
@@ -1,0 +1,13 @@
+import { hashIntsArray } from '.';
+
+export const getBoundingBoxPosKey = (ele) => {
+  if (ele.isEdge()) {
+    let p1 = ele.source().position();
+    let p2 = ele.target().position();
+    let r = (x) => Math.round(x);
+
+    return hashIntsArray([r(p1.x), r(p1.y), r(p2.x), r(p2.y)]);
+  } else {
+    return 0;
+  }
+};

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -12,6 +12,7 @@ export * from './maps';
 export * from './strings';
 export * from './timing';
 export * from './hash';
+export * from './bounds';
 
 export { strings, extend, extend as assign, memoize, regex, sort };
 


### PR DESCRIPTION
**Cross-references to related issues.**  If there is no existing issue that describes your bug or feature request, then [create an issue](https://github.com/cytoscape/cytoscape.js/issues/new/choose) before making your pull request.

Associated issues: 

- #3309

**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

- Avoid repeated render to improve performance.
In my local environment, redraw time descrease from 130-140ms to 5-9ms when parellel bezier edges count is 100.
redraw time descrease from 3200-3400ms to 25-35ms when parellel bezier edges count is 500.


**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
