### PR TITLE
fix webgl mode showing hidden nodes/edges

### DIFF
--- a/src/extensions/renderer/canvas/webgl/atlas.js
+++ b/src/extensions/renderer/canvas/webgl/atlas.js
@@ -528,7 +528,7 @@ export class AtlasManager {
     }
   }
 
-  isRenderable(ele, type) {
+  isVisible(ele, type) {
     const opts = this.getRenderTypeOpts(type);
     return opts && opts.isVisible(ele);
   }

--- a/src/extensions/renderer/canvas/webgl/defaults.js
+++ b/src/extensions/renderer/canvas/webgl/defaults.js
@@ -12,6 +12,6 @@ export const renderDefaults = defaults({
   getRotation: null,
   getRotationPoint: null,
   getRotationOffset: null,
-  isVisible: null,
+  isVisible: () => true,  // this is an extra check for visibility in addition to ele.visible()
   getPadding: null,
 });

--- a/src/extensions/renderer/canvas/webgl/drawing-redraw-webgl.js
+++ b/src/extensions/renderer/canvas/webgl/drawing-redraw-webgl.js
@@ -1,6 +1,3 @@
-// import { EdgeDrawing } from './drawing-edges-webgl';
-// import { EdgeBezierDrawing } from './drawing-edges-curved-webgl';
-// import { NodeDrawing } from './drawing-nodes-webgl';
 import { ElementDrawingWebGL } from './drawing-elements-webgl';
 import { RENDER_TARGET, renderDefaults } from './defaults';
 import { OverlayUnderlayRenderer } from './drawing-overlay';
@@ -50,16 +47,6 @@ CRp.initWebgl = function(opts, fns) {
     return label && label.value;
   };
 
-  // r.edgeDrawing = new EdgeBezierDrawing(r, gl, opts, renderDefaults({
-  //   getKey: fns.getLabelKey,
-  //   getBoundingBox: fns.getLabelBox,
-  //   drawElement: fns.drawLabel,
-  //   getRotation: getLabelRotation,
-  //   getRotationPoint: fns.getLabelRotationPoint,
-  //   getRotationOffset: fns.getLabelRotationOffset,
-  //   isVisible: isLabelVisible,
-  // }));
-
   r.eleDrawing = new ElementDrawingWebGL(r, gl, opts);
   const our = new OverlayUnderlayRenderer(r);
   
@@ -67,7 +54,6 @@ CRp.initWebgl = function(opts, fns) {
     getKey: fns.getStyleKey,
     getBoundingBox: fns.getElementBox,
     drawElement: fns.drawElement,
-    isVisible: ele => ele.visible(),
   }));
 
   r.eleDrawing.addTextureRenderType('node-label', renderDefaults({


### PR DESCRIPTION
Associated issues: 

- #3320

**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

- Fixes issue where the webgl mode was still displaying nodes/edges that had the `visibility:hidden` property.
- Selection seems to work fine. I think it wasn't working for the nodes that were supposed to be hidden.

**Checklist**

Author:

- [ ] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [ ] The associated GitHub issues are included (above).
- [ ] Notes have been included (above).
- [ ] For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
