### PR TITLE
:bug: Fix #3318 label not shown in specific case with round-segments

### DIFF
--- a/debug/init.js
+++ b/debug/init.js
@@ -57,7 +57,8 @@ var cy, defaultSty, options;
           'source-arrow-shape': 'triangle-backcurve',
           'target-arrow-shape': 'triangle',
           'mid-target-arrow-shape': 'triangle',
-          'mid-source-arrow-shape': 'triangle-backcurve'
+          'mid-source-arrow-shape': 'triangle-backcurve',
+          'label': e => e.data('id'),
         })
       .selector('#ab')
         .style({
@@ -123,9 +124,9 @@ var cy, defaultSty, options;
       .selector('#eh')
         .style({
           'curve-style': 'round-segments',
-          'segment-distances': [ 20, -80 ],
-          'segment-weights': [ 0.25, 0.5 ],
-          'segment-radii': [ 8, 8 ],
+          "segment-distances": [-50, -50, -50],
+          "segment-weights": [0.25,0.5,0.75],
+          'segment-radii': [ 50, 50 , 50]
         })
       .selector('#ed')
         .style({

--- a/src/extensions/renderer/base/coord-ele-math/edge-control-points.mjs
+++ b/src/extensions/renderer/base/coord-ele-math/edge-control-points.mjs
@@ -666,19 +666,25 @@ BRp.storeAllpts = function( edge ){
       } else {
         let point = {x: rs.segpts[i1], y: rs.segpts[i1 + 1]};
         const corner = rs.roundCorners[i1 / 2];
+        if( corner.radius === 0 ){ // On collinear points
+          const nextPoint = {x: rs.segpts[i1 + 2], y: rs.segpts[i1 + 3]};
+          rs.midX = point.x;
+          rs.midY = point.y;
+          rs.midVector = [point.y - nextPoint.y, nextPoint.x - point.x];
+        } else { // On rounded points
+          let v = [
+            point.x - corner.cx,
+            point.y - corner.cy
+          ];
 
-        let v  = [
-           point.x - corner.cx,
-           point.y - corner.cy
-        ];
+          const factor = corner.radius / Math.sqrt(Math.pow(v[0], 2) + Math.pow(v[1], 2));
 
-        const factor = corner.radius / Math.sqrt(Math.pow(v[0], 2) +  Math.pow(v[1], 2));
+          v = v.map(c => c * factor);
 
-        v = v.map(c => c * factor);
-
-        rs.midX = corner.cx + v[0];
-        rs.midY = corner.cy + v[1];
-        rs.midVector = v;
+          rs.midX = corner.cx + v[0];
+          rs.midY = corner.cy + v[1];
+          rs.midVector = v;
+        }
       }
     }
 


### PR DESCRIPTION
**Cross-references to related issues.**  

Associated issues: 

- #3318 

**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

- This PR fixes the issue by covering cases when points are collinear and therefore corner radius = 0 ( essentially avoiding division by 0 leading to label being placed at [NaN, NaN])
<img width="738" alt="Screenshot 2025-02-12 at 18 41 37" src="https://github.com/user-attachments/assets/0ce276d4-76ba-4631-a67c-cca1995064d9" />

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).
- [x] For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
