### PR TITLE
WebGL: fix label picking

### DIFF
--- a/debug/webgl/network-styles.json
+++ b/debug/webgl/network-styles.json
@@ -64,7 +64,8 @@
         "background-gradient-stop-colors": "cyan magenta yellow",
         "text-valign": "top",
         "text-rotation": 0.7853981633974483,
-        "label": "n3 - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod"
+        "label": "n3 - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod",
+        "text-events": "yes"
       }
     },
     {

--- a/src/extensions/renderer/canvas/webgl/defaults.mjs
+++ b/src/extensions/renderer/canvas/webgl/defaults.mjs
@@ -5,6 +5,11 @@ export const RENDER_TARGET = {
   PICKING: { name: 'picking', picking: true },
 };
 
+export const TEX_PICKING_MODE = {
+  NORMAL: 0, // render the texture just like in RENDER_TARGET.SCREEN mode
+  IGNORE: 1, // don't render the texture at all
+  USE_BB: 2  // render the bounding box as an opaque rectangle
+}
 
 export const atlasCollectionDefaults = defaults({
   texRows: 24,
@@ -21,4 +26,5 @@ export const renderDefaults = defaults({
   getRotationOffset: null,
   isVisible: () => true,  // this is an extra check for visibility in addition to ele.visible()
   getPadding: 0,
+  getTexPickingMode: null,
 });

--- a/src/extensions/renderer/canvas/webgl/drawing-redraw-webgl.mjs
+++ b/src/extensions/renderer/canvas/webgl/drawing-redraw-webgl.mjs
@@ -1,5 +1,6 @@
 import { ElementDrawingWebGL } from './drawing-elements-webgl.mjs';
-import { RENDER_TARGET, renderDefaults, atlasCollectionDefaults } from './defaults.mjs';
+import { RENDER_TARGET, TEX_PICKING_MODE } from './defaults.mjs';
+import { renderDefaults, atlasCollectionDefaults } from './defaults.mjs';
 import { OverlayUnderlayRenderer } from './drawing-overlay.mjs';
 import * as util from './webgl-util.mjs';
 import * as eleTextureCache from '../ele-texture-cache.mjs';
@@ -34,6 +35,10 @@ CRp.initWebgl = function(opts, fns) {
     const label = ele.pstyle(prop);
     return label && label.value;
   };
+  const getTexPickingMode = (ele) => {
+    const enabled = ele.pstyle('text-events').strValue === 'yes';
+    return enabled ? TEX_PICKING_MODE.USE_BB : TEX_PICKING_MODE.IGNORE;
+  };
 
   r.drawing = new ElementDrawingWebGL(r, gl, opts);
   const our = new OverlayUnderlayRenderer(r);
@@ -55,6 +60,7 @@ CRp.initWebgl = function(opts, fns) {
 
   r.drawing.addAtlasRenderType('label', renderDefaults({ // node label or edge mid label
     collection: 'label',
+    getTexPickingMode,
     getKey: fns.getLabelKey,
     getBoundingBox: fns.getLabelBox,
     drawElement: fns.drawLabel,
@@ -84,6 +90,7 @@ CRp.initWebgl = function(opts, fns) {
 
   r.drawing.addAtlasRenderType('edge-source-label', renderDefaults({
     collection: 'label',
+    getTexPickingMode,
     getKey: fns.getSourceLabelKey,
     getBoundingBox: fns.getSourceLabelBox,
     drawElement: fns.drawSourceLabel,
@@ -95,6 +102,7 @@ CRp.initWebgl = function(opts, fns) {
 
   r.drawing.addAtlasRenderType('edge-target-label', renderDefaults({
     collection: 'label',
+    getTexPickingMode,
     getKey: fns.getTargetLabelKey,
     getBoundingBox: fns.getTargetLabelBox,
     drawElement: fns.drawTargetLabel,


### PR DESCRIPTION
- This PR fixes bug #3337 
- Unfortunately the idea to set the background opacity of labels to 0.0001 did not work. I don't know why, but it would not detect the clicks when I tried this. Maybe something in WebGL ignores small alpha values. I'm not sure.
- Instead I took an approach of reusing the "simple shapes" mode that draws rectangles. If `text-events: no` then it will ignore the label, if `text-events: yes` then it will render the bounding box of the label as an opaque rectangle that can be clicked on. Of course you can't see this because its happening in an offscreen framebuffer.
  - I didn't try measuring but this may actually be more performant. It doesn't have to render label textures anymore for picking. Labels are either ignored or rendered as rectangles.

**Checklist**

Author:

- [ ] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [ ] The associated GitHub issues are included (above).
- [ ] Notes have been included (above).
- [ ] For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
