### PR TITLE
Higher-level caching for label dimensions

### DIFF
--- a/src/extensions/renderer/base/coord-ele-math/labels.mjs
+++ b/src/extensions/renderer/base/coord-ele-math/labels.mjs
@@ -471,16 +471,6 @@ BRp.calculateLabelDimensions = function( ele, text ){
 
   var document = containerWindow.document;
 
-  let cacheKey = util.hashString( text, ele._private.labelDimsKey );
-
-  let cache = r.labelDimCache || (r.labelDimCache = []);
-
-  let existingVal = cache[ cacheKey ];
-
-  if( existingVal != null ){
-    return existingVal;
-  }
-
   let padding = 0; // add padding around text dims, as the measurement isn't that accurate
   let fStyle = ele.pstyle('font-style').strValue;
   let size = ele.pstyle('font-size').pfValue;
@@ -522,12 +512,11 @@ BRp.calculateLabelDimensions = function( ele, text ){
   width += padding;
   height += padding;
 
-  return ( cache[ cacheKey ] = {
+  return {
     width,
     height
-  } );
+  };
 };
-
 
 BRp.calculateLabelAngle = function( ele, prefix ){
   let _p = ele._private;

--- a/src/extensions/renderer/base/coord-ele-math/labels.mjs
+++ b/src/extensions/renderer/base/coord-ele-math/labels.mjs
@@ -299,6 +299,17 @@ BRp.applyPrefixedLabelDimensions = function( ele, prefix ){
   let _p = ele._private;
 
   let text = this.getLabelText( ele, prefix );
+
+  let cacheKey = util.hashString( text, ele._private.labelDimsKey );
+
+  // save recalc if the label is the same as before
+  if( util.getPrefixedProperty( _p.rscratch, 'prefixedLabelDimsKey', prefix ) === cacheKey ){
+    return; // then the label dimensions + text are the same
+  }
+
+  // save the key
+  util.setPrefixedProperty( _p.rscratch, 'prefixedLabelDimsKey', prefix, cacheKey );
+
   let labelDims = this.calculateLabelDimensions( ele, text );
   let lineHeight = ele.pstyle('line-height').pfValue;
   let textWrap = ele.pstyle('text-wrap').strValue;


### PR DESCRIPTION
**Cross-references to related issues.**  If there is no existing issue that describes your bug or feature request, then [create an issue](https://github.com/cytoscape/cytoscape.js/issues/new/choose) before making your pull request.

Associated issues: 

- #3270 (addresses this)
- #3298 (supersedes this)

**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

- Remove caching in BRp.calculateLabelDimensions: This removes caching on the text level, which is used for things like multiline calculations).  This can use a fair bit of memory.
- Cache label dims in BRp.applyPrefixedLabelDimensions instead.  
  - The label dimensions are already stored for use later in the renderer, so we're not using additional memory or fields for the values.  
  - One value stored per label (main, source, target).
  - One cache key stored per label (32 bit int, hash of style props and text value).
- Not sure if we can automatically test this.

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).
- [x] For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
