### PR TITLE
Reapply @d2fong's change re. : Unbundled bezier edge disappear or flip when nodes are close #3251

### DIFF
--- a/src/extensions/renderer/base/coord-ele-math/edge-control-points.mjs
+++ b/src/extensions/renderer/base/coord-ele-math/edge-control-points.mjs
@@ -5,6 +5,7 @@ import Map from '../../../../map.mjs';
 import {getRoundCorner} from "../../../../round.mjs";
 
 const AVOID_IMPOSSIBLE_BEZIER_CONSTANT = 0.01;
+const AVOID_IMPOSSIBLE_BEZIER_CONSTANT_L = Math.sqrt(2 * AVOID_IMPOSSIBLE_BEZIER_CONSTANT);
 
 let BRp = {};
 
@@ -878,9 +879,18 @@ BRp.findEdgeControlPoints = function( edges ){
         let dy = Math.abs( tgtOutside[1] - srcOutside[1] );
         let dx = Math.abs( tgtOutside[0] - srcOutside[0] );
         let l = Math.sqrt( 
-          Math.max(dx * dx, AVOID_IMPOSSIBLE_BEZIER_CONSTANT) + 
-          Math.max(dy * dy, AVOID_IMPOSSIBLE_BEZIER_CONSTANT)
+          (dx * dx) + 
+          (dy * dy)
         );
+
+        if (is.number(l) && l >= AVOID_IMPOSSIBLE_BEZIER_CONSTANT_L) {
+          // keep l
+        } else {
+          l = Math.sqrt( 
+            Math.max(dx * dx, AVOID_IMPOSSIBLE_BEZIER_CONSTANT) + 
+            Math.max(dy * dy, AVOID_IMPOSSIBLE_BEZIER_CONSTANT)
+          );
+        }
 
         let vector = pairInfo.vector = {
           x: dx,

--- a/src/extensions/renderer/base/coord-ele-math/edge-control-points.mjs
+++ b/src/extensions/renderer/base/coord-ele-math/edge-control-points.mjs
@@ -4,6 +4,8 @@ import * as util from '../../../../util/index.mjs';
 import Map from '../../../../map.mjs';
 import {getRoundCorner} from "../../../../round.mjs";
 
+const AVOID_IMPOSSIBLE_BEZIER_CONSTANT = 0.01;
+
 let BRp = {};
 
 BRp.findMidptPtsEtc = function(edge, pairInfo) {
@@ -231,8 +233,8 @@ BRp.findCompoundLoopPoints = function( edge, pairInfo, i, edgeIsUnbundled ){
 
   // avoids cases with impossible beziers
   let minCompoundStretch = 0.5;
-  let compoundStretchA = Math.max( minCompoundStretch, Math.log( srcW * 0.01 ) );
-  let compoundStretchB = Math.max( minCompoundStretch, Math.log( tgtW * 0.01 ) );
+  let compoundStretchA = Math.max( minCompoundStretch, Math.log( srcW * AVOID_IMPOSSIBLE_BEZIER_CONSTANT ) );
+  let compoundStretchB = Math.max( minCompoundStretch, Math.log( tgtW * AVOID_IMPOSSIBLE_BEZIER_CONSTANT ) );
 
   rs.ctrlpts = [
     loopPos.x,
@@ -873,9 +875,12 @@ BRp.findEdgeControlPoints = function( edges ){
           y2: tgtPos.y
         };
 
-        let dy = ( tgtOutside[1] - srcOutside[1] );
-        let dx = ( tgtOutside[0] - srcOutside[0] );
-        let l = Math.sqrt( dx * dx + dy * dy );
+        let dy = Math.abs( tgtOutside[1] - srcOutside[1] );
+        let dx = Math.abs( tgtOutside[0] - srcOutside[0] );
+        let l = Math.sqrt( 
+          Math.max(dx * dx, AVOID_IMPOSSIBLE_BEZIER_CONSTANT) + 
+          Math.max(dy * dy, AVOID_IMPOSSIBLE_BEZIER_CONSTANT)
+        );
 
         let vector = pairInfo.vector = {
           x: dx,


### PR DESCRIPTION

**Cross-references to related issues.**  If there is no existing issue that describes your bug or feature request, then [create an issue](https://github.com/cytoscape/cytoscape.js/issues/new/choose) before making your pull request.

Associated issues: 

- #3280 
- #3251

**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

Just reapplies Dylan's changes cleanly on the unstable branch.

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] N/A -- Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).
- [x] For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
