### PR TITLE
Add `cy.renderedExtent()` to types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -82,6 +82,15 @@ declare namespace cytoscape {
         y: number;
     }
 
+    interface BoundingBox {
+        x1: number;
+        y1: number;
+        x2: number;
+        y2: number;
+        w: number;
+        h: number;
+    }
+
     type CssStyleDeclaration = any;
 
     interface ElementDefinition {
@@ -1021,14 +1030,7 @@ declare namespace cytoscape {
          * positions are visible in the viewport.
          * http://js.cytoscape.org/#cy.extent
          */
-        extent(): {
-            x1: number;
-            y1: number;
-            x2: number;
-            y2: number;
-            w: number;
-            h: number;
-        };
+        extent(): BoundingBox;
 
         /**
          * Get the rendered extent of the viewport, a bounding box in rendered
@@ -1036,14 +1038,7 @@ declare namespace cytoscape {
          * positions are visible in the viewport.
          * http://js.cytoscape.org/#cy.renderedExtent
          */
-        renderedExtent(): {
-            x1: number;
-            y1: number;
-            x2: number;
-            y2: number;
-            w: number;
-            h: number;
-        };
+        renderedExtent(): BoundingBox;
 
         /**
          * Get whether nodes are automatically locked

--- a/index.d.ts
+++ b/index.d.ts
@@ -1031,6 +1031,21 @@ declare namespace cytoscape {
         };
 
         /**
+         * Get the rendered extent of the viewport, a bounding box in rendered
+         * coordinates that lets you know what rendered
+         * positions are visible in the viewport.
+         * http://js.cytoscape.org/#cy.renderedExtent
+         */
+        renderedExtent(): {
+            x1: number;
+            y1: number;
+            x2: number;
+            y2: number;
+            w: number;
+            h: number;
+        };
+
+        /**
          * Get whether nodes are automatically locked
          * (i.e. if true, nodes are locked despite their individual state).
          * http://js.cytoscape.org/#cy.autolock


### PR DESCRIPTION
**Cross-references to related issues.**  If there is no existing issue that describes your bug or feature request, then [create an issue](https://github.com/cytoscape/cytoscape.js/issues/new/choose) before making your pull request.

Associated issues: 

- #3339

**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

- Adds the type definition for `cy.renderedExtent()`

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x]  N/A: Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).
- [x] For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
