### PR TITLE
Add support for the `pie-start-angle` property

### DIFF
--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -348,11 +348,12 @@ The following is an example of valid background image styling using JSON. The ex
 
 ## Pie chart background
 
-These properties allow you to create pie chart (or ring chart) backgrounds on nodes ([demo](demos/pie-style)).  Note that 16 slices maximum are supported per node, so in the properties `1 <= i <= 16`.  Of course, you must specify a numerical value for each property in place of `i`.  Each nonzero sized slice is placed in order of `i`, starting from the 12 o'clock position and working clockwise.
+These properties allow you to create pie chart (or ring chart) backgrounds on nodes ([demo](demos/pie-style)).  Note that 16 slices maximum are supported per node, so in the properties `1 <= i <= 16`.  Of course, you must specify a numerical value for each property in place of `i`.  Each nonzero sized slice is placed in order of `i`, starting from the 12 o'clock position and working clockwise.  The start angle may be shifted from the 12 o'clock position, if needed.
 
 You may find it useful to reserve a number to a particular colour for all nodes in your stylesheet.  Then you can specify values for `pie-i-background-size` accordingly for each node via a [mapper](#style/mappers).  This would allow you to create consistently coloured pie charts in each node of the graph based on element data.
 
  * **`pie-size`** : The diameter of the pie, measured as a percent of node size (e.g. `100%`) or an absolute length (e.g. `25px`).
+ * **`pie-start-angle`** : The start angle of the pie, measured as an angle starting at the 12 o'clock position and going clockwise (e.g. `90deg` is 3 o'clock).  The default is to start at 12 o'clock (`0deg`, `0rad`).
  * **`pie-hole`** : The diameter of the hole in the centre of the pie, measured as a percent of node size (e.g. `100%`) or an absolute length (e.g. `25px`).  This effectively converts the pie chart into a ring chart (default disabled, `0`).
  * **`pie-i-background-color`** : The colour of the node's ith pie chart slice.
  * **`pie-i-background-size`** : The size of the node's ith pie chart slice, measured in percent (e.g. `25%`).

--- a/index.d.ts
+++ b/index.d.ts
@@ -4550,6 +4550,13 @@ declare namespace cytoscape {
              */
             "pie-hole": PropertyValueNode<number|string>;
             /**
+             * 
+             * The start angle of the pie, measured as an angle starting at
+             * the 12 o'clock position and going clockwise (e.g. `90deg`
+             * is 3 o'clock).  The default is to start at 12 o'clock (`0deg`, `0rad`).
+             */
+            "pie-start-angle": PropertyValueNode<number|string>;
+            /**
              * @deprecated
              *
              * The colour of the node’s ith pie chart slice.

--- a/src/extensions/renderer/canvas/drawing-nodes.mjs
+++ b/src/extensions/renderer/canvas/drawing-nodes.mjs
@@ -644,6 +644,7 @@ CRp.drawPie = function( context, node, nodeOpacity, pos ){
   let cyStyle = node.cy().style();
   let pieSize = node.pstyle( 'pie-size' );
   let hole = node.pstyle('pie-hole');
+  let overallStartAngle = node.pstyle('pie-start-angle').pfValue;
   let x = pos.x;
   let y = pos.y;
   let nodeW = node.width();
@@ -685,7 +686,8 @@ CRp.drawPie = function( context, node, nodeOpacity, pos ){
       percent = 1 - lastPercent;
     }
 
-    let angleStart = 1.5 * Math.PI + 2 * Math.PI * lastPercent; // start at 12 o'clock and go clockwise
+    let angleStart = (1.5 * Math.PI) + (2 * Math.PI * lastPercent); // start at 12 o'clock and go clockwise
+    angleStart += overallStartAngle; // shift by the overall pie start angle
     let angleDelta = 2 * Math.PI * percent;
     let angleEnd = angleStart + angleDelta;
 

--- a/src/style/properties.mjs
+++ b/src/style/properties.mjs
@@ -434,6 +434,7 @@ const styfn = {};
   styfn.pieBackgroundN = 16; // because the pie properties are numbered, give access to a constant N (for renderer use)
   pie.push( { name: 'pie-size', type: t.sizeMaybePercent } );
   pie.push( { name: 'pie-hole', type: t.sizeMaybePercent } );
+  pie.push( { name: 'pie-start-angle', type: t.angle } );
   for( let i = 1; i <= styfn.pieBackgroundN; i++ ){
     pie.push( { name: 'pie-' + i + '-background-color', type: t.color } );
     pie.push( { name: 'pie-' + i + '-background-size', type: t.percent } );
@@ -741,6 +742,7 @@ styfn.getDefaultProperties = function(){
     // node pie bg
     'pie-size': '100%',
     'pie-hole': 0,
+    'pie-start-angle': '0deg',
   }, [
     { name: 'pie-{{i}}-background-color', value: 'black' },
     { name: 'pie-{{i}}-background-size', value: '0%' },


### PR DESCRIPTION
**Cross-references to related issues.**  If there is no existing issue that describes your bug or feature request, then [create an issue](https://github.com/cytoscape/cytoscape.js/issues/new/choose) before making your pull request.

Associated issues: 

-  #3355
- 
**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

Updated documentation for the pie charts:

These properties allow you to create pie chart (or ring chart) backgrounds on nodes ([demo](demos/pie-style)).  Note that 16 slices maximum are supported per node, so in the properties `1 <= i <= 16`.  Of course, you must specify a numerical value for each property in place of `i`.  Each nonzero sized slice is placed in order of `i`, starting from the 12 o'clock position and working clockwise.  The start angle may be shifted from the 12 o'clock position, if needed.

You may find it useful to reserve a number to a particular colour for all nodes in your stylesheet.  Then you can specify values for `pie-i-background-size` accordingly for each node via a [mapper](#style/mappers).  This would allow you to create consistently coloured pie charts in each node of the graph based on element data.

 * **`pie-size`** : The diameter of the pie, measured as a percent of node size (e.g. `100%`) or an absolute length (e.g. `25px`).
 * **`pie-start-angle`** : The start angle of the pie, measured as an angle starting at the 12 o'clock position and going clockwise (e.g. `90deg` is 3 o'clock).  The default is to start at 12 o'clock (`0deg`, `0rad`).
 * **`pie-hole`** : The diameter of the hole in the centre of the pie, measured as a percent of node size (e.g. `100%`) or an absolute length (e.g. `25px`).  This effectively converts the pie chart into a ring chart (default disabled, `0`).
 * **`pie-i-background-color`** : The colour of the node's ith pie chart slice.
 * **`pie-i-background-size`** : The size of the node's ith pie chart slice, measured in percent (e.g. `25%`).
 * **`pie-i-background-opacity`** : The opacity of the node's ith pie chart slice.

**Checklist**

Author:

- [ ] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).
- [x] For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
