### PR TITLE
Feat: Box selection of partially selected lines

### DIFF
--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -391,6 +391,7 @@ These properties affect the styling of an edge's line:
  * **`line-fill`** : The filling style of the edge's line; may be `solid` (default), `linear-gradient` (source to target), or `radial-gradient` (midpoint outwards).
  * **`line-dash-pattern`** : The `dashed` line pattern which specifies alternating lengths of lines and gaps. (e.g. `[6, 3]`).
  * **`line-dash-offset`** : The `dashed` line offset (e.g. `24`). It is useful for creating edge animations.
+ * **`box-select-lines`** : This allows selecting a line when at least one of its endpoints (start or end) is inside the user's selection box (box selection), which then selects the line as well as any associated connected lines attached to that point.
 
 ## Gradient
 

--- a/src/style/properties.mjs
+++ b/src/style/properties.mjs
@@ -407,7 +407,8 @@ const styfn = {};
     { name: 'loop-direction', type: t.angle, triggersBounds: diff.any },
     { name: 'loop-sweep', type: t.angle, triggersBounds: diff.any },
     { name: 'source-distance-from-node', type: t.size, triggersBounds: diff.any },
-    { name: 'target-distance-from-node', type: t.size, triggersBounds: diff.any }
+    { name: 'target-distance-from-node', type: t.size, triggersBounds: diff.any },
+    { name: 'box-select-lines', type: t.bool, triggersBounds: diff.any }
   ];
 
   let ghost = [
@@ -806,6 +807,7 @@ styfn.getDefaultProperties = function(){
     'target-endpoint': 'outside-to-node',
     'line-dash-pattern': [6, 3],
     'line-dash-offset': 0,
+    'box-select-lines': 'no',
   }, [
     { name: 'arrow-shape', value: 'none' },
     { name: 'arrow-color', value: '#999' },


### PR DESCRIPTION
**Cross-references to related issues.**  

⚠️ Cytoscape only checks if both (start and end points) or all endpoints (in the case of haystacks) are inside the user selection box to consider it selected.

**Example of the issue:**
![46bd8c505ae762](https://github.com/user-attachments/assets/d3006bc7-1a7a-4ab9-81f6-f6911c7c9869)


Associated issues: 

- #3359

**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

- This PR introduces a new style parameter, `box-select-lines: yes`. When this attribute is included, line can be selected even if at least one (start or end point) is inside the user selection box.

📸 **Demo**:
![430671812-a8f83487-6273-4aaf-8694-41e488103810](https://github.com/user-attachments/assets/9a9854ae-9839-4af0-b037-a1c34c4092b5)




**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).
- [ ] For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
