### PR TITLE
FIx: Bezier control points seems incorrect in version 3.31.2 #3364

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "cytoscape",
       "version": "3.32.0-unstable",
+      "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.26.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "unpkg": "dist/cytoscape.min.js",
   "jsdelivr": "dist/cytoscape.min.js",
   "scripts": {
+    "postinstall": "npx playwright install",
     "lint": "eslint src/**/*.mjs",
     "build": "rollup -c",
     "build:esm": "cross-env FILE=esm rollup -c",

--- a/playwright-tests/renderer.spec.js
+++ b/playwright-tests/renderer.spec.js
@@ -330,6 +330,47 @@ test.describe('Renderer', () => {
       
     }); // move when setting one edge to curve-style:straight
 
+    test('diagonal bottom left to top right', async ({page}) => {
+      let controlPoints = await page.evaluate(() => {
+        const cy = window.cy;
+        cy.style().fromJson([{
+          selector: 'edge',
+          style: {
+            'curve-style': 'bezier',
+            'control-point-step-size': Math.sqrt(200)
+          }
+        }]).update();
+        cy.add([{
+          data: {id: 'a'}
+        }, {
+          data: {id: 'b'}
+        }, {
+          data: {id: 'ab1', source: 'a', target: 'b'}
+        }, {
+          data: {id: 'ab2', source: 'a', target: 'b'}
+        }]);
+        var presetOptions = {
+          name: 'preset',
+          positions: {
+            a: {x: 0, y: 100},
+            b: {x: 100, y: 0}
+          }
+        };
+        cy.layout(presetOptions).run();
+        let pt_ab1_1 = cy.$('#ab1').controlPoints()[0];
+        let pt_ab2_1 = cy.$('#ab2').controlPoints()[0];
+        return [pt_ab1_1, pt_ab2_1]
+      });
+      // Step size 14.14, sqrt(10*10+10*10).
+      // Gives a 5 pixel translation away from the mid-point,
+      // if the vector between the nodes are at a 45 deg angle.
+      // Mid-point is at (50,50)
+      expect(controlPoints[0].x).toBeCloseTo(45, 5);
+      expect(controlPoints[0].y).toBeCloseTo(45, 5);
+      expect(controlPoints[1].x).toBeCloseTo(55, 5);
+      expect(controlPoints[1].y).toBeCloseTo(55, 5);
+    });
+
     // test('do not move when straight edge added', async ({ page }) => {
     //   await page.evaluate(() => {
     //     window.cy.add([

--- a/src/extensions/renderer/base/coord-ele-math/edge-control-points.mjs
+++ b/src/extensions/renderer/base/coord-ele-math/edge-control-points.mjs
@@ -876,8 +876,8 @@ BRp.findEdgeControlPoints = function( edges ){
           y2: tgtPos.y
         };
 
-        let dy = Math.abs( tgtOutside[1] - srcOutside[1] );
-        let dx = Math.abs( tgtOutside[0] - srcOutside[0] );
+        let dy = ( tgtOutside[1] - srcOutside[1] );
+        let dx = ( tgtOutside[0] - srcOutside[0] );
         let l = Math.sqrt( 
           (dx * dx) + 
           (dy * dy)


### PR DESCRIPTION
**Cross-references to related issues.**  If there is no existing issue that describes your bug or feature request, then [create an issue](https://github.com/cytoscape/cytoscape.js/issues/new/choose) before making your pull request.

Associated issues: 

- #3364

**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

FIx: Bezier control points seems incorrect in version 3.31.2 #3364

Ref: 85ad43f
Ref: Reapply @d2fong's change re. : Unbundled bezier edge disappear or flip when nodes are close #3251

@mikael.konradsson @dwchMikael

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).
- [x] For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
