### PR TITLE
Add support for loading .json files in cytoscape.js

### DIFF
--- a/documentation/demos/edge-arrows/code.js
+++ b/documentation/demos/edge-arrows/code.js
@@ -3,20 +3,25 @@
 (function(){
   var toJson = function(res){ return res.json(); };
 
-  var cy = window.cy = cytoscape({
-    container: document.getElementById('cy'),
+  Promise.all([
+    fetch('cy-style.json').then(toJson),
+    fetch('data.json').then(toJson)
+  ]).then(function(dataArray) {
+    var cy = window.cy = cytoscape({
+      container: document.getElementById('cy'),
 
-    layout: {
-      name: 'grid',
-      columns: 4
-    },
+      layout: {
+        name: 'grid',
+        columns: 4
+      },
 
-    style: fetch('cy-style.json').then(toJson),
+      style: dataArray[0],
 
-    elements: fetch('data.json').then(toJson)
-  });
+      elements: dataArray[1]
+    });
 
-  document.getElementById('hollow').addEventListener('click', function(){
-    cy.edges().toggleClass('hollow');
+    document.getElementById('hollow').addEventListener('click', function(){
+      cy.edges().toggleClass('hollow');
+    });
   });
 })();

--- a/documentation/demos/edge-types/code.js
+++ b/documentation/demos/edge-types/code.js
@@ -3,48 +3,53 @@
 (function(){
   var toJson = function(res){ return res.json(); };
 
-  var cy = window.cy = cytoscape({
-    container: document.getElementById('cy'),
+  Promise.all([
+    fetch('cy-style.json').then(toJson),
+    fetch('data.json').then(toJson)
+  ]).then(function(dataArray) {
+    var cy = window.cy = cytoscape({
+      container: document.getElementById('cy'),
 
-    layout: {
-      name: 'grid',
-      columns: 6
-    },
+      layout: {
+        name: 'grid',
+        columns: 6
+      },
 
-    style: fetch('cy-style.json').then(toJson),
+      style: dataArray[0],
 
-    elements: fetch('data.json').then(toJson)
-  });
-
-  cy.ready(function(){ // make taxi nodes better organised
-    var n19 = cy.$('#n19');
-    var n17 = cy.$('#n17');
-    var n18 = cy.$('#n18');
-    var p17 = n17.position();
-    var p18 = n18.position();
-    var d = (p18.x - p17.x)/4;
-
-    n19.position({
-      x: (p17.x + p18.x)/2,
-      y: p17.y - d
+      elements: dataArray[1]
     });
 
-    n17.add(n18).position({ y: p17.y + d });
+    cy.ready(function(){ // make taxi nodes better organised
+      var n19 = cy.$('#n19');
+      var n17 = cy.$('#n17');
+      var n18 = cy.$('#n18');
+      var p17 = n17.position();
+      var p18 = n18.position();
+      var d = (p18.x - p17.x)/4;
 
-    // make round-taxi nodes better organised
-    var n22 = cy.$('#n22');
-    var n20 = cy.$('#n20');
-    var n21 = cy.$('#n21');
-    var p20 = n20.position();
-    var p21 = n21.position();
-    var dr = (p21.x - p20.x)/4;
+      n19.position({
+        x: (p17.x + p18.x)/2,
+        y: p17.y - d
+      });
 
-    n22.position({
-      x: (p20.x + p21.x)/2,
-      y: p20.y -d
+      n17.add(n18).position({ y: p17.y + d });
+
+      // make round-taxi nodes better organised
+      var n22 = cy.$('#n22');
+      var n20 = cy.$('#n20');
+      var n21 = cy.$('#n21');
+      var p20 = n20.position();
+      var p21 = n21.position();
+      var dr = (p21.x - p20.x)/4;
+
+      n22.position({
+        x: (p20.x + p21.x)/2,
+        y: p20.y -d
+      });
+
+      n20.add(n21).position({ y: p20.y + dr });
+
     });
-
-    n20.add(n21).position({ y: p20.y + dr });
-
   });
 })();

--- a/documentation/demos/initialisation/code.js
+++ b/documentation/demos/initialisation/code.js
@@ -1,76 +1,64 @@
-var cy = cytoscape({
-  container: document.querySelector('#cy'),
+fetch('data.json')
+  .then(function(res) {
+    return res.json();
+  })
+  .then(function(data) {
+    var cy = cytoscape({
+      container: document.querySelector('#cy'),
 
-  boxSelectionEnabled: false,
-  autounselectify: true,
+      boxSelectionEnabled: false,
+      autounselectify: true,
 
-  style: cytoscape.stylesheet()
-    .selector('node')
-      .css({
-        'content': 'data(name)',
-        'text-valign': 'center',
-        'color': 'white',
-        'text-outline-width': 2,
-        'background-color': '#999',
-        'text-outline-color': '#999'
-      })
-    .selector('edge')
-      .css({
-        'curve-style': 'bezier',
-        'target-arrow-shape': 'triangle',
-        'target-arrow-color': '#ccc',
-        'line-color': '#ccc',
-        'width': 1
-      })
-    .selector(':selected')
-      .css({
-        'background-color': 'black',
-        'line-color': 'black',
-        'target-arrow-color': 'black',
-        'source-arrow-color': 'black'
-      })
-    .selector('.faded')
-      .css({
-        'opacity': 0.25,
-        'text-opacity': 0
-      }),
+      style: cytoscape.stylesheet()
+        .selector('node')
+          .css({
+            'content': 'data(name)',
+            'text-valign': 'center',
+            'color': 'white',
+            'text-outline-width': 2,
+            'background-color': '#999',
+            'text-outline-color': '#999'
+          })
+        .selector('edge')
+          .css({
+            'curve-style': 'bezier',
+            'target-arrow-shape': 'triangle',
+            'target-arrow-color': '#ccc',
+            'line-color': '#ccc',
+            'width': 1
+          })
+        .selector(':selected')
+          .css({
+            'background-color': 'black',
+            'line-color': 'black',
+            'target-arrow-color': 'black',
+            'source-arrow-color': 'black'
+          })
+        .selector('.faded')
+          .css({
+            'opacity': 0.25,
+            'text-opacity': 0
+          }),
 
-  elements: {
-    nodes: [
-      { data: { id: 'j', name: 'Jerry' } },
-      { data: { id: 'e', name: 'Elaine' } },
-      { data: { id: 'k', name: 'Kramer' } },
-      { data: { id: 'g', name: 'George' } }
-    ],
-    edges: [
-      { data: { source: 'j', target: 'e' } },
-      { data: { source: 'j', target: 'k' } },
-      { data: { source: 'j', target: 'g' } },
-      { data: { source: 'e', target: 'j' } },
-      { data: { source: 'e', target: 'k' } },
-      { data: { source: 'k', target: 'j' } },
-      { data: { source: 'k', target: 'e' } },
-      { data: { source: 'k', target: 'g' } },
-      { data: { source: 'g', target: 'j' } }
-    ]
-  },
+      elements: data,
 
-  layout: {
-    name: 'grid',
-    padding: 10
-  }
-});
+      layout: {
+        name: 'grid',
+        padding: 10
+      }
+    });
 
-cy.on('tap', 'node', function(e){
-  var node = e.cyTarget;
-  var neighborhood = node.neighborhood().add(node);
+    cy.on('tap', 'node', function(e){
+      var node = e.cyTarget;
+      var neighborhood = node.neighborhood().add(node);
 
-  cy.elements().addClass('faded');
-  neighborhood.removeClass('faded');
-});
+      cy.elements().addClass('faded');
+      neighborhood.removeClass('faded');
+    });
 
-cy.on('tap', function(e){
-  if( e.cyTarget === cy ){
-    cy.elements().removeClass('faded');
-  }
-});
+    cy.on('tap', function(e){
+      if( e.cyTarget === cy ){
+        cy.elements().removeClass('faded');
+      }
+    });
+  });

--- a/documentation/demos/visual-style/code.js
+++ b/documentation/demos/visual-style/code.js
@@ -1,74 +1,27 @@
-cytoscape({
-  container: document.getElementById('cy'),
+/* global document, window, fetch, cytoscape */
 
-  layout: {
-    name: 'cose',
-    padding: 10
-  },
+(function(){
+  var toJson = function(res){ return res.json(); };
 
-  style: cytoscape.stylesheet()
-    .selector('node')
-      .css({
-        'shape': 'data(faveShape)',
-        'width': 'mapData(weight, 40, 80, 20, 60)',
-        'content': 'data(name)',
-        'text-valign': 'center',
-        'text-outline-width': 2,
-        'text-outline-color': 'data(faveColor)',
-        'background-color': 'data(faveColor)',
-        'color': '#fff'
-      })
-    .selector(':selected')
-      .css({
-        'border-width': 3,
-        'border-color': '#333'
-      })
-    .selector('edge')
-      .css({
-        'curve-style': 'bezier',
-        'opacity': 0.666,
-        'width': 'mapData(strength, 70, 100, 2, 6)',
-        'target-arrow-shape': 'triangle',
-        'source-arrow-shape': 'circle',
-        'line-color': 'data(faveColor)',
-        'source-arrow-color': 'data(faveColor)',
-        'target-arrow-color': 'data(faveColor)'
-      })
-    .selector('edge.questionable')
-      .css({
-        'line-style': 'dotted',
-        'target-arrow-shape': 'diamond'
-      })
-    .selector('.faded')
-      .css({
-        'opacity': 0.25,
-        'text-opacity': 0
-      }),
+  Promise.all([
+    fetch('cy-style.json').then(toJson),
+    fetch('data.json').then(toJson)
+  ]).then(function(dataArray) {
+    var cy = window.cy = cytoscape({
+      container: document.getElementById('cy'),
 
-  elements: {
-    nodes: [
-      { data: { id: 'j', name: 'Jerry', weight: 65, faveColor: '#6FB1FC', faveShape: 'triangle' } },
-      { data: { id: 'e', name: 'Elaine', weight: 45, faveColor: '#EDA1ED', faveShape: 'ellipse' } },
-      { data: { id: 'k', name: 'Kramer', weight: 75, faveColor: '#86B342', faveShape: 'octagon' } },
-      { data: { id: 'g', name: 'George', weight: 70, faveColor: '#F5A45D', faveShape: 'rectangle' } }
-    ],
-    edges: [
-      { data: { source: 'j', target: 'e', faveColor: '#6FB1FC', strength: 90 } },
-      { data: { source: 'j', target: 'k', faveColor: '#6FB1FC', strength: 70 } },
-      { data: { source: 'j', target: 'g', faveColor: '#6FB1FC', strength: 80 } },
+      layout: {
+        name: 'cose',
+        padding: 10
+      },
 
-      { data: { source: 'e', target: 'j', faveColor: '#EDA1ED', strength: 95 } },
-      { data: { source: 'e', target: 'k', faveColor: '#EDA1ED', strength: 60 }, classes: 'questionable' },
+      style: dataArray[0],
 
-      { data: { source: 'k', target: 'j', faveColor: '#86B342', strength: 100 } },
-      { data: { source: 'k', target: 'e', faveColor: '#86B342', strength: 100 } },
-      { data: { source: 'k', target: 'g', faveColor: '#86B342', strength: 100 } },
+      elements: dataArray[1],
 
-      { data: { source: 'g', target: 'j', faveColor: '#F5A45D', strength: 90 } }
-    ]
-  },
-
-  ready: function(){
-    window.cy = this;
-  }
-});
+      ready: function(){
+        window.cy = this;
+      }
+    });
+  });
+})();


### PR DESCRIPTION
Add fetch calls to load style and elements from .json files in various demo files.

* **documentation/demos/edge-arrows/code.js**
  - Add fetch calls to load the style from `cy-style.json`.
  - Add fetch calls to load the elements from `data.json`.
  - Update the cytoscape initialization to use the fetched style and elements.

* **documentation/demos/edge-types/code.js**
  - Add fetch calls to load the style from `cy-style.json`.
  - Add fetch calls to load the elements from `data.json`.
  - Update the cytoscape initialization to use the fetched style and elements.

* **documentation/demos/initialisation/code.js**
  - Add fetch call to load the elements from `data.json`.
  - Update the cytoscape initialization to use the fetched elements.

* **documentation/demos/visual-style/code.js**
  - Add fetch calls to load the style from `cy-style.json`.
  - Add fetch calls to load the elements from `data.json`.
  - Update the cytoscape initialization to use the fetched style and elements.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/cytoscape/cytoscape.js/pull/3371?shareId=ff1cac65-5505-4729-a129-7e9ec5aa9ab6).