### PR TITLE
Bug fix for box selection of nodes without labels

### DIFF
--- a/src/extensions/renderer/base/coord-ele-math/coords.mjs
+++ b/src/extensions/renderer/base/coord-ele-math/coords.mjs
@@ -353,6 +353,10 @@ BRp.getAllInBox = function( x1, y1, x2, y2 ){
     ele.boundingBox();
     var bb = _p.labelBounds[prefix || 'main'];
 
+    // If the bounding box is not available, return null.
+    // This indicates that the label box cannot be calculated, which is consistent
+    // with the expected behavior of this function. Returning null allows the caller
+    // to handle the absence of a bounding box explicitly.
     if (!bb) {
       return null;
     }

--- a/src/extensions/renderer/base/coord-ele-math/coords.mjs
+++ b/src/extensions/renderer/base/coord-ele-math/coords.mjs
@@ -353,6 +353,10 @@ BRp.getAllInBox = function( x1, y1, x2, y2 ){
     ele.boundingBox();
     var bb = _p.labelBounds[prefix || 'main'];
 
+    if (!bb) {
+      return null;
+    }
+
     var lx = preprop(_p.rscratch, 'labelX', prefix);
     var ly = preprop(_p.rscratch, 'labelY', prefix);
     var theta = preprop(_p.rscratch, 'labelAngle', prefix);
@@ -412,7 +416,7 @@ BRp.getAllInBox = function( x1, y1, x2, y2 ){
           { x: boxBb.x1, y: boxBb.y2 },
         ];
 
-        if (math.satPolygonIntersection(rotatedLabelBox, selectionBox)) {
+        if (!rotatedLabelBox || math.satPolygonIntersection(rotatedLabelBox, selectionBox)) {
           box.push(node);
         }
       }


### PR DESCRIPTION
Associated issues: 

- #3372

- This PR fixes a JS TypeError that prevents a node from being selected when:
  a.  no `label` style has been specified; or
  b. the node does not have a label

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).
- [ ] For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
