### PR TITLE
Fix the enum values of breadthfirst's direction option to *ward

### DIFF
--- a/documentation/md/layouts/breadthfirst.md
+++ b/documentation/md/layouts/breadthfirst.md
@@ -1,1 +1,1 @@
-The `breadthfirst` layout puts nodes in a hierarchy, based on a breadthfirst traversal of the graph.  It is best suited to trees and forests in its default top-down mode, and it is best suited to DAGs in its circle mode.
+The `breadthfirst` layout puts nodes in a hierarchy, based on a breadthfirst traversal of the graph.  It is best suited to trees and forests in its default downward direction, and it is best suited to DAGs in its circle mode.

--- a/index.d.ts
+++ b/index.d.ts
@@ -6294,8 +6294,8 @@ declare namespace cytoscape {
 
         // whether the tree is directed downwards (or edges can point in any direction if false)
         directed?: boolean;
-        // determines the orientation in which the tree structure is drawn
-        direction?: 'top-bottom' | 'bottom-top' | 'left-right' | 'right-left';
+        // determines the direction in which the tree structure is drawn
+        direction?: 'downward' | 'upward' | 'rightward' | 'leftward';
         // put depths in concentric circles if true, put depths top down if false
         circle?: boolean;
         // the roots of the trees

--- a/src/extensions/layout/breadthfirst.mjs
+++ b/src/extensions/layout/breadthfirst.mjs
@@ -6,7 +6,7 @@ import * as is from '../../is.mjs';
 const defaults = {
   fit: true, // whether to fit the viewport to the graph
   directed: false, // whether the tree is directed downwards (or edges can point in any direction if false)
-  direction: 'top-bottom', // determines the orientation in which the tree structure is drawn.  The possible values are 'top-bottom', 'bottom-top', 'left-right', or 'right-left'
+  direction: 'downward', // determines the direction in which the tree structure is drawn.  The possible values are 'downward', 'upward', 'rightward', or 'leftward'.
   padding: 30, // padding on fit
   circle: false, // put depths in concentric circles if true, put depths top down if false
   grid: false, // whether to create an even grid into which the DAG is placed (circle:false only)
@@ -388,10 +388,10 @@ BreadthFirstLayout.prototype.run = function(){
   };
 
   const rotateDegrees = {
-    'bottom-top': 180,
-    'left-right': -90,
-    'right-left': 90,
-    'top-bottom': 0,
+    'downward': 0,
+    'leftward': 90,
+    'upward': 180,
+    'rightward': -90,
   }
 
   if (Object.keys(rotateDegrees).indexOf(options.direction) === -1) {


### PR DESCRIPTION
Fix the enum values of breadthfirst's direction option so they're more consistent with other properties. Change to the following:
- downward
- upward
- rightward
- leftward

**Cross-references to related issues.** 

Associated issues: 

- https://github.com/cytoscape/cytoscape.js/issues/3369
- https://github.com/cytoscape/cytoscape.js/pull/3373

**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

- Renaming of the enum values based on @maxkfranz comment
- https://github.com/cytoscape/cytoscape.js/pull/3373#issuecomment-2955979295

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).
- [x] For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
