### PR TITLE
Feat: add support for circular text background shape

### DIFF
--- a/debug/tests.js
+++ b/debug/tests.js
@@ -179,6 +179,16 @@
         'text-border-color': 'red',
         'text-border-style': 'double',
       });
+      cy.$('#h').css({
+        'text-background-color': '#e5e5e5',
+        'text-background-opacity': 1,
+        'font-size': '26px',
+        'text-background-shape': 'circle',
+        'text-background-padding': 5,
+        'text-border-width': 2,
+        'text-border-opacity': 1,
+        'text-border-color': 'red',
+      });
     },
     teardown: function(){
       cy.nodes().removeCss();

--- a/documentation/md/style.md
+++ b/documentation/md/style.md
@@ -730,7 +730,7 @@ Background:
 
  * **`text-background-color`** : A colour to apply on the text background.
  * **`text-background-opacity`** : The opacity of the label background; the background is disabled for `0` (default value).
- * **`text-background-shape`** : The shape to use for the label background, can be `rectangle` or `round-rectangle`.
+ * **`text-background-shape`** : The shape to use for the label background, can be `rectangle`, `round-rectangle`, or `circle`.
  * **`text-background-padding`** : A padding on the background of the label (e.g `5px`); zero padding is used by default.
 
 Border:

--- a/index.d.ts
+++ b/index.d.ts
@@ -5647,7 +5647,7 @@ declare namespace cytoscape {
             /**
              * The shape to use for the label background.
              */
-            "text-background-shape": PropertyValue<SingularType, "rectangle" | "roundrectangle">;
+            "text-background-shape": PropertyValue<SingularType, "rectangle" | "roundrectangle" | "circle">;
 
             /**
              * Border:

--- a/src/extensions/renderer/canvas/drawing-label-text.mjs
+++ b/src/extensions/renderer/canvas/drawing-label-text.mjs
@@ -129,23 +129,31 @@ CRp.setupTextStyle = function( context, ele, useEleOpacity = true ){
   this.colorStrokeStyle( context, outlineColor[ 0 ], outlineColor[ 1 ], outlineColor[ 2 ], outlineOpacity );
 };
 
-// TODO ensure re-used
-function roundRect( ctx, x, y, width, height, radius = 5, stroke){
+function circle(ctx, x, y, width, height) {
+  const diameter = Math.min(width, height);
+  const radius = diameter / 2;
+
+  const centerX = x + width / 2;
+  const centerY = y + height / 2;
+
   ctx.beginPath();
-  ctx.moveTo( x + radius, y );
-  ctx.lineTo( x + width - radius, y );
-  ctx.quadraticCurveTo( x + width, y, x + width, y + radius );
-  ctx.lineTo( x + width, y + height - radius );
-  ctx.quadraticCurveTo( x + width, y + height, x + width - radius, y + height );
-  ctx.lineTo( x + radius, y + height );
-  ctx.quadraticCurveTo( x, y + height, x, y + height - radius );
-  ctx.lineTo( x, y + radius );
-  ctx.quadraticCurveTo( x, y, x + radius, y );
+  ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
   ctx.closePath();
-  if(stroke)
-    ctx.stroke();
-  else
-    ctx.fill();
+}
+
+function roundRect(ctx, x, y, width, height, radius = 5) {
+  const r = Math.min(radius, width / 2, height / 2); // prevent overflow
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + width - r, y);
+  ctx.quadraticCurveTo(x + width, y, x + width, y + r);
+  ctx.lineTo(x + width, y + height - r);
+  ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+  ctx.lineTo(x + r, y + height);
+  ctx.quadraticCurveTo(x, y + height, x, y + height - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
 }
 
 CRp.getTextAngle = function( ele, prefix ){
@@ -241,89 +249,85 @@ CRp.drawText = function( context, ele, prefix, applyRotation = true, useEleOpaci
     let textBorderWidth = ele.pstyle( 'text-border-width' ).pfValue;
     let backgroundPadding = ele.pstyle( 'text-background-padding' ).pfValue;
     let styleShape = ele.pstyle( 'text-background-shape' ).strValue;
-    let rounded = styleShape.indexOf('round') === 0;
+    let rounded = styleShape === 'round-rectangle' || styleShape === 'roundrectangle';
+    let circled = styleShape === 'circle';
     let roundRadius = 2;
 
     if( backgroundOpacity > 0 || ( textBorderWidth > 0 && borderOpacity > 0 ) ){
-      let bgX = textX - backgroundPadding;
+      let textFill = context.fillStyle;
+      let textStroke = context.strokeStyle;
+      let textLineWidth = context.lineWidth;
 
+      let textBackgroundColor = ele.pstyle( 'text-background-color' ).value;
+      let textBorderColor = ele.pstyle( 'text-border-color' ).value;
+      let textBorderStyle = ele.pstyle( 'text-border-style' ).value;
+
+      let doFill = backgroundOpacity > 0;
+      let doStroke = textBorderWidth > 0 && borderOpacity > 0;
+
+      let bgX = textX - backgroundPadding;
       switch( halign ){
-        case 'left':
-          bgX -= textW;
-          break;
-        case 'center':
-          bgX -= textW / 2;
-          break;
-        case 'right':
-          break;
+        case 'left':   bgX -= textW; break;
+        case 'center': bgX -= textW / 2; break;
       }
 
       let bgY = textY - textH - backgroundPadding;
       let bgW = textW + 2*backgroundPadding;
       let bgH = textH + 2*backgroundPadding;
 
-      if( backgroundOpacity > 0 ){
-        let textFill = context.fillStyle;
-        let textBackgroundColor = ele.pstyle( 'text-background-color' ).value;
-
-        context.fillStyle = 'rgba(' + textBackgroundColor[ 0 ] + ',' + textBackgroundColor[ 1 ] + ',' + textBackgroundColor[ 2 ] + ',' + backgroundOpacity * parentOpacity + ')';
-        if( rounded ){
-          roundRect( context, bgX, bgY, bgW, bgH, roundRadius );
-        } else {
-          context.fillRect( bgX, bgY, bgW, bgH );
-        }
-        context.fillStyle = textFill;
+      if( doFill ){
+        context.fillStyle = `rgba(${textBackgroundColor[0]},${textBackgroundColor[1]},${textBackgroundColor[2]},${backgroundOpacity * parentOpacity})`;
       }
 
-      if( textBorderWidth > 0 && borderOpacity > 0 ){
-        let textStroke = context.strokeStyle;
-        let textLineWidth = context.lineWidth;
-        let textBorderColor = ele.pstyle( 'text-border-color' ).value;
-        let textBorderStyle = ele.pstyle( 'text-border-style' ).value;
-
-        context.strokeStyle = 'rgba(' + textBorderColor[ 0 ] + ',' + textBorderColor[ 1 ] + ',' + textBorderColor[ 2 ] + ',' + borderOpacity * parentOpacity + ')';
+      if( doStroke ){
+        context.strokeStyle = `rgba(${textBorderColor[0]},${textBorderColor[1]},${textBorderColor[2]},${borderOpacity * parentOpacity})`;
         context.lineWidth = textBorderWidth;
 
-        if( context.setLineDash ){ // for very outofdate browsers
+        if( context.setLineDash ){
           switch( textBorderStyle ){
-            case 'dotted':
-              context.setLineDash( [ 1, 1 ] );
-              break;
-            case 'dashed':
-              context.setLineDash( [ 4, 2 ] );
-              break;
+            case 'dotted': context.setLineDash([1, 1]); break;
+            case 'dashed': context.setLineDash([4, 2]); break;
             case 'double':
-              context.lineWidth = textBorderWidth / 4; // 50% reserved for white between the two borders
-              context.setLineDash( [] );
+              context.lineWidth = textBorderWidth / 4;
+              context.setLineDash([]);
               break;
-            case 'solid':
-              context.setLineDash( [] );
-              break;
+            case 'solid': default: context.setLineDash([]); break;
           }
         }
-
-        if( rounded ){
-          roundRect( context, bgX, bgY, bgW, bgH, roundRadius, 'stroke' );
-        } else {
-          context.strokeRect( bgX, bgY, bgW, bgH );
-        }
-
-        if( textBorderStyle === 'double' ){
-          let whiteWidth = textBorderWidth / 2;
-          if( rounded ){
-            roundRect( context, bgX + whiteWidth, bgY + whiteWidth, bgW - whiteWidth * 2, bgH - whiteWidth * 2, roundRadius, 'stroke' );
-          } else {
-            context.strokeRect( bgX + whiteWidth, bgY + whiteWidth, bgW - whiteWidth * 2, bgH - whiteWidth * 2 );
-          }
-        }
-
-        if( context.setLineDash ){ // for very outofdate browsers
-          context.setLineDash( [] );
-        }
-        context.lineWidth = textLineWidth;
-        context.strokeStyle = textStroke;
       }
 
+      if( rounded ){
+        context.beginPath();
+        roundRect(context, bgX, bgY, bgW, bgH, roundRadius, false); 
+      } else if (circled){
+        context.beginPath();
+        circle(context, bgX, bgY, bgW, bgH); 
+      } else {
+        context.beginPath();
+        context.rect(bgX, bgY, bgW, bgH);
+      }
+
+      if( doFill ) context.fill();
+      if( doStroke ) context.stroke();
+
+      // Double border pass for 'double' style
+      if( doStroke && textBorderStyle === 'double' ){
+        let whiteWidth = textBorderWidth / 2;
+        context.beginPath();
+
+        if( rounded ){
+          roundRect(context, bgX + whiteWidth, bgY + whiteWidth, bgW - 2*whiteWidth, bgH - 2*whiteWidth, roundRadius, false);
+        } else {
+          context.rect(bgX + whiteWidth, bgY + whiteWidth, bgW - 2*whiteWidth, bgH - 2*whiteWidth);
+        }
+
+        context.stroke();
+      }
+
+      context.fillStyle = textFill;
+      context.strokeStyle = textStroke;
+      context.lineWidth = textLineWidth;
+      if( context.setLineDash ) context.setLineDash([]);
     }
 
     let lineWidth = 2 * ele.pstyle( 'text-outline-width' ).pfValue; // *2 b/c the stroke is drawn centred on the middle

--- a/src/style/properties.mjs
+++ b/src/style/properties.mjs
@@ -71,7 +71,7 @@ const styfn = {};
     textTransform: { enums: [ 'none', 'uppercase', 'lowercase' ] },
     textWrap: { enums: [ 'none', 'wrap', 'ellipsis' ] },
     textOverflowWrap: { enums: [ 'whitespace', 'anywhere' ] },
-    textBackgroundShape: { enums: [ 'rectangle', 'roundrectangle', 'round-rectangle' ]},
+    textBackgroundShape: { enums: [ 'rectangle', 'roundrectangle', 'round-rectangle', 'circle' ]},
     nodeShape: { enums: [
       'rectangle', 'roundrectangle', 'round-rectangle', 'cutrectangle', 'cut-rectangle', 'bottomroundrectangle', 'bottom-round-rectangle', 'barrel',
       'ellipse', 'triangle', 'round-triangle', 'square', 'pentagon', 'round-pentagon', 'hexagon', 'round-hexagon', 'concavehexagon', 'concave-hexagon', 'heptagon', 'round-heptagon', 'octagon', 'round-octagon',


### PR DESCRIPTION
**Cross-references to related issues.**  
⚠️ Currently, label backgrounds in Cytoscape.js are limited to rectangle and round-rectangle. 

**Associated issues:** 

- #3385 

**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

- This PR adding support for `text-background-shape: circle`
- Also fixes some redundant drawing issues with `rectangle` and `round-rectangle`.

**📸 Demo:**
<img width="238" alt="Screenshot 2025-06-11 at 6 24 31 PM" src="https://github.com/user-attachments/assets/693fd81f-c991-4d68-b04d-ba1472bb3ca3" />
<img width="321" alt="Screenshot 2025-06-11 at 6 24 35 PM" src="https://github.com/user-attachments/assets/4a55e4e4-03d0-447e-bd6c-fb8ab8dc4127" />



**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).
- [x] For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.

cc: @maxkfranz