### PR TITLE
Inflate convex polygon node shape bounds based on miter

### DIFF
--- a/playwright-tests/renderer.spec.js
+++ b/playwright-tests/renderer.spec.js
@@ -49,6 +49,42 @@ test.describe('Renderer', () => {
     expect(numNodes).toBe(1);
   });
 
+  test.describe('node style', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.evaluate(() => {
+        const cy = window.cy;
+
+        cy.add({ data: { id: 'a' } });
+
+      });
+    }); // beforeEach
+
+    test('node bounding box extends beyond width and height for bordered triangle', async ({ page }) => {
+      const bb = await page.evaluate(() => {
+        const cy = window.cy;
+
+        cy.style().fromJson([
+          {
+            selector: 'node',
+            style: {
+              'shape': 'triangle',
+              'width': 100,
+              'height': 100,
+              'border-width': 10,
+              'border-color': 'black',
+            }
+          }
+        ]).update();
+
+        return cy.$('#a').boundingBox();
+      });
+
+      expect(bb.w).toBeGreaterThan(105);
+      expect(bb.h).toBeGreaterThan(105);
+    } ); // node bounding box extends beyond width and height for triangle
+
+  });
+
   test.describe('straight edges', () => {
     test.beforeEach(async ({ page }) => {
       await page.evaluate(() => {

--- a/src/extensions/renderer/base/node-shapes.mjs
+++ b/src/extensions/renderer/base/node-shapes.mjs
@@ -30,6 +30,12 @@ BRp.generatePolygon = function( name, points ){
       return math.pointInsidePolygon( x, y, this.points,
         centerX, centerY, width, height, [0, -1], padding )
       ;
+    },
+
+    hasMiterBounds: name !== 'rectangle',
+
+    miterBounds: function( centerX, centerY, width, height, strokeWidth, strokePosition ){
+      return math.miterBox( this.points, centerX, centerY, width, height, strokeWidth, strokePosition );
     }
   } );
 };


### PR DESCRIPTION
**Cross-references to related issues.**  If there is no existing issue that describes your bug or feature request, then [create an issue](https://github.com/cytoscape/cytoscape.js/issues/new/choose) before making your pull request.

Associated issues: 

- #3382

**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

- Add a function to calculate inflated polygon bounds in `math.inflatePolygon(polygonPoints: Array<Number>, d: Number)`
- Use `inflatePolygon` for both the miter-border bounds and the bounds of outlines (more accurate than the previous approximation approach in #3156 #3158)
- In the node shape spec objects, shapes affected by miter are marked with `hasMiterBounds` so that only affected shapes get the extra expense
- `hasMiterBounds: false` shapes (e.g. rectangle) use the simple approach of just expanding the bounding box appropriately by the outside size of the border
- The border width, position, and opacity are taken into account so the extra expanse is only incurred for appropriate node shapes that have a visible border applied
- Add automated tests

You can see that a cyan bounding box (via button in the sidebar) in the debug page encloses a convex node shape's miter:

<img width="100" alt="Screenshot 2025-06-16 at 12 06 22" src="https://github.com/user-attachments/assets/f7f764f5-e34c-433f-8737-69fcdb28069a" /> <img width="100" alt="Screenshot 2025-06-13 at 16 39 05" src="https://github.com/user-attachments/assets/3bd30ad2-bac1-4dff-bb27-4c938d84ea14" />


**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).
- [ ] For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
