### PR TITLE
Single element cose layout has no display #3379 : patch & test

### DIFF
--- a/playwright-tests/renderer.spec.js
+++ b/playwright-tests/renderer.spec.js
@@ -568,4 +568,43 @@ test.describe('Renderer', () => {
 
   }); // Rounded edges
 
+  test.describe('with layout', () => {
+
+    test('single node cose layout with bounding box', async ({ page }) => {
+      const pos = await page.evaluate(async () => {
+        const cy = window.cy;
+
+        // remove all eles
+        cy.elements().remove();
+
+        // add one node
+        let node = cy.add({ data: { id: 'a' } }); 
+
+        // run layout
+        let layout = cy.layout({
+          name: 'cose',
+          boundingBox: {
+            x1: 0,
+            y1: 0,
+            x2: 100,
+            y2: 100
+          },
+        });
+
+        let layoutstop = layout.promiseOn('layoutstop');
+
+        layout.run();
+
+        await layoutstop;
+
+        return node.position();
+      });
+      
+      expect(pos.x).not.toBeNaN();
+      expect(pos.y).not.toBeNaN();
+
+    }); // single node cose layout
+
+  }); // with layout
+
 }); // renderer

--- a/src/extensions/layout/cose.mjs
+++ b/src/extensions/layout/cose.mjs
@@ -644,8 +644,9 @@ var getScaleInBoundsFn = function( layoutInfo, options, nodes ){
     var lnode = layoutInfo.layoutNodes[ layoutInfo.idToIndex[ ele.data( 'id' ) ] ];
 
     if( options.boundingBox ){ // then add extra bounding box constraint
-      var pctX = (lnode.positionX - coseBB.x1) / coseBB.w;
-      var pctY = (lnode.positionY - coseBB.y1) / coseBB.h;
+      // Handle single node case where coseBB.w or coseBB.h is 0
+      var pctX = coseBB.w === 0 ? 0.5 : (lnode.positionX - coseBB.x1) / coseBB.w;
+      var pctY = coseBB.h === 0 ? 0.5 : (lnode.positionY - coseBB.y1) / coseBB.h;
 
       return {
         x: bb.x1 + pctX * bb.w,


### PR DESCRIPTION
**Cross-references to related issues.**  If there is no existing issue that describes your bug or feature request, then [create an issue](https://github.com/cytoscape/cytoscape.js/issues/new/choose) before making your pull request.

Associated issues: 

- #3379

**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

- Adds a Playwright test case.
- Patches the issue when the un-transformed bounding box has zero area.

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).
- [ ] For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
