### PR TITLE
Add webgl edge guard in texture getter

### DIFF
--- a/src/extensions/renderer/canvas/webgl/drawing-elements-webgl.mjs
+++ b/src/extensions/renderer/canvas/webgl/drawing-elements-webgl.mjs
@@ -556,11 +556,10 @@ export class ElementDrawingWebGL {
       return;
     }
 
-    // Edges are not drawn as textures
-    // Edges with invalid points could be passed here, causing errors
+    // Edges with invalid points could be passed here (labels), causing errors
     // Ref: Random "Script Error" thrown when generating nodes and edges in newest webgl version #3365
     // https://github.com/cytoscape/cytoscape.js/issues/3365
-    if(ele.isEdge()) {
+    if(ele.isEdge() && !this._isValidEdge(ele)) {
       return;
     }
 
@@ -997,11 +996,21 @@ export class ElementDrawingWebGL {
     }
   }
 
+  _isValidEdge(edge) {
+    const rs = edge._private.rscratch;
+    
+    if( rs.badLine || rs.allpts == null || isNaN(rs.allpts[0]) ){ // isNaN in case edge is impossible and browser bugs (e.g. safari)
+      return false;
+    }
+
+    return true;
+  }
+
   _getEdgePoints(edge) {
     const rs = edge._private.rscratch;
 
     // if bezier ctrl pts can not be calculated, then die
-    if( rs.badLine || rs.allpts == null || isNaN(rs.allpts[0]) ){ // isNaN in case edge is impossible and browser bugs (e.g. safari)
+    if(!this._isValidEdge(edge)){ // isNaN in case edge is impossible and browser bugs (e.g. safari)
       return;
     }
     const controlPoints = rs.allpts;

--- a/src/extensions/renderer/canvas/webgl/drawing-elements-webgl.mjs
+++ b/src/extensions/renderer/canvas/webgl/drawing-elements-webgl.mjs
@@ -556,6 +556,14 @@ export class ElementDrawingWebGL {
       return;
     }
 
+    // Edges are not drawn as textures
+    // Edges with invalid points could be passed here, causing errors
+    // Ref: Random "Script Error" thrown when generating nodes and edges in newest webgl version #3365
+    // https://github.com/cytoscape/cytoscape.js/issues/3365
+    if(ele.isEdge()) {
+      return;
+    }
+
     if(this.renderTarget.picking && opts.getTexPickingMode) {
       const mode = opts.getTexPickingMode(ele);
       if(mode === TEX_PICKING_MODE.IGNORE) {


### PR DESCRIPTION
**Cross-references to related issues.**  If there is no existing issue that describes your bug or feature request, then [create an issue](https://github.com/cytoscape/cytoscape.js/issues/new/choose) before making your pull request.

Associated issues: 

- #3365

**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

- Adds a guard in `ElementDrawingWebGL.drawTexture()` for invalid edges.

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).
- [ ] For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
