### PR TITLE
Fix bug on custom polygon shape with border

### DIFF
--- a/src/collection/dimensions/bounds.mjs
+++ b/src/collection/dimensions/bounds.mjs
@@ -455,6 +455,9 @@ let updateBoundsFromMiter = function( bounds, ele, opacity, expansionSize, expan
   
   let cy = ele.cy();
   let shape = ele.pstyle('shape').value
+  if (shape === 'polygon') {
+    return;
+  }
   let rshape = cy.renderer().nodeShapes[shape];
   let { x, y } = ele.position();
   let w = ele.width();


### PR DESCRIPTION
Resolve #3413 by skipping miter calculations for custom polygon shapes

**Cross-references to related issues.**

Associated issues: 

- #3413 

**Notes re. the content of the pull request.**

- This PR skips the miter calculations for custom polygon shapes. It's not a full solution to the original issue (#3382) but it's much better than the current situation where the render completely fails.

**Checklist**

Author:

- [X] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [X] The associated GitHub issues are included (above).
- [X] Notes have been included (above).
- [ ] For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
