### PR TITLE
docs: fix incorrect ES5/ESM description and remove deprecated babel-polyfill

### DIFF
--- a/documentation/md/getting-started.md
+++ b/documentation/md/getting-started.md
@@ -91,7 +91,7 @@ To install Cytoscape.js via Meteor/Atmosphere:
 npm install cytoscape
 ```
 
-Cytoscape.js supports environments with ES5 (a version of [ESM]) or newer, as it is transpiled by Babel and it uses only basic features of the standard library.  Feature detection is used for optional features that improve performance.  However, a future version of Cytoscape.js may require a more up-to-date version of the standard library.  You may want to use [`babel-polyfill`](https://babeljs.io/docs/usage/polyfill/) or [`core-js`](https://github.com/zloirock/core-js) if you want to support old browsers in future.
+Cytoscape.js supports environments with ES5 or newer, as it is transpiled by Babel and it uses only basic features of the standard library.  Feature detection is used for optional features that improve performance.  However, a future version of Cytoscape.js may require a more up-to-date version of the standard library.  You may want to use [`core-js`](https://github.com/zloirock/core-js) if you want to support old browsers in future.
 
 
 


### PR DESCRIPTION
The getting-started docs incorrectly describe ES5 as "a version of ESM." ES5 (ECMAScript 5) is a language specification version, while ESM (ES Modules) is the module system introduced in ES2015 — they are unrelated concepts.

Also removes the reference to `babel-polyfill`, which was deprecated in Babel 7. The existing `core-js` reference is the current recommendation.