### PR TITLE
docs: fix build target list in README (umd listed twice, missing cjs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Run `npm run <target>` in the console.  The main targets are:
 
 **Building:**
 
- * `build`: do all builds of the library (umd, min, umd, esm)
+ * `build`: do all builds of the library (umd, min, cjs, esm)
  * `build:min` : do the unminified build with bundled dependencies (for simple html pages, good for novices)
  * `build:umd` : do the umd (cjs/amd/globals) build
  * `build:esm` : do the esm (ES 2015 modules) build


### PR DESCRIPTION
The README lists the build targets as `(umd, min, umd, esm)` — `umd` appears twice and `cjs` is missing.

The actual build outputs from `rollup.config.mjs` are:
- `build/cytoscape.umd.js` (umd)
- `build/cytoscape.min.js` (min)
- `build/cytoscape.cjs.js` (cjs)
- `build/cytoscape.esm.min.mjs` (esm)

This fixes the list to `(umd, min, cjs, esm)`.