### PR TITLE
docs: update gpu demo polyfill link

### DIFF
--- a/documentation/demos/gpu/index.html
+++ b/documentation/demos/gpu/index.html
@@ -7,7 +7,7 @@
     <link href="style.css" rel="stylesheet" />
 
     <!-- For loading external data files -->
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Promise,fetch"></script>
+    <script src="https://cdnjs.cloudflare.com/polyfill/v2/polyfill.min.js?features=Promise,fetch"></script>
 
     <script src="../../js/cytoscape.umd.js"></script>
 


### PR DESCRIPTION
fixes #3461

cdn[.]polyfill[.]io has been compromised.

Ref: https://zero.checkmarx.com/alert-cdn-service-polyfill-io-f9999bb1eb8f


**Cross-references to related issues.**  If there is no existing issue that describes your bug or feature request, then [create an issue](https://github.com/cytoscape/cytoscape.js/issues/new/choose) before making your pull request.

Associated issues: 

- #3461

**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

- update gpu demo cdn link to match other demos

  Here is [project search showing other references to polyfill.min.js](https://github.com/search?q=repo%3Acytoscape%2Fcytoscape.js%20polyfill.min.js&type=code)

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [n/a] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).
- [n/a] For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.
- [x] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
