### PR TITLE
Fix command injection vulnerability

### DIFF
--- a/.github/workflows/feature-release.yml
+++ b/.github/workflows/feature-release.yml
@@ -2,11 +2,6 @@ name: Feature Release
 
 on:
   workflow_dispatch:
-    inputs:
-      branch:
-        description: 'Branch to run the action on'
-        required: true
-        default: 'unstable'
 
 jobs:  
   feature-release:

--- a/.github/workflows/patch-release.yml
+++ b/.github/workflows/patch-release.yml
@@ -2,24 +2,17 @@ name: Patch Release
 
 on:
   workflow_dispatch:
-    inputs:
-      branch:
-        description: 'Branch to run the action on'
-        required: true
-        default: 'master'
 
-jobs:  
+jobs:
   patch-release:
     runs-on: ubuntu-latest
     environment: prod
-    env:
-      BRANCH: ${{ github.event.inputs.branch }}
     steps:
-      - name: Echo branch name
+      - name: Set branch name
         shell: bash
-        id: echo_branch
         run: |
-          echo "Branch: " $BRANCH
+          echo "BRANCH=master" >> $GITHUB_ENV
+          echo "Branch: master"
       - name: checkout patch branch
         uses: actions/checkout@v6
         with:
@@ -45,7 +38,7 @@ jobs:
         run: echo branch $BRANCH
         shell: bash
       - name: See new patch version
-        run: echo "# version:" $BRANCH
+        run: echo "# version:" ${{ env.VERSION }}
         shell: bash
       - name: checkout master branch
         uses: actions/checkout@v6

--- a/.github/workflows/patch-release.yml
+++ b/.github/workflows/patch-release.yml
@@ -12,12 +12,13 @@ jobs:
   patch-release:
     runs-on: ubuntu-latest
     environment: prod
+    env:
+      BRANCH: ${{ github.event.inputs.branch }}
     steps:
-      - name: Extract branch name
+      - name: Echo branch name
         shell: bash
-        id: extract_branch
+        id: echo_branch
         run: |
-          echo "BRANCH=${{ github.event.inputs.branch }}" >> $GITHUB_ENV
           echo "Branch: " $BRANCH
       - name: checkout patch branch
         uses: actions/checkout@v6
@@ -41,10 +42,10 @@ jobs:
           . ./.github/workflows/scripts/new-patch-version.sh
         shell: bash
       - name: See patch branch
-        run: echo branch ${{ env.BRANCH }}
+        run: echo branch $BRANCH
         shell: bash
       - name: See new patch version
-        run: echo "# version:" ${{ env.VERSION }}
+        run: echo "# version:" $BRANCH
         shell: bash
       - name: checkout master branch
         uses: actions/checkout@v6
@@ -87,7 +88,7 @@ jobs:
         id: release
         run: |
           chmod +rx .github/workflows/scripts/pre_release_test.sh
-          . .github/workflows/scripts/pre_release_test.sh ${{ env.BRANCH }}
+          . .github/workflows/scripts/pre_release_test.sh $BRANCH
       - name: Archive action failure results
         uses: actions/upload-artifact@v4
         if: ${{ failure() && steps.release.conclusion == 'failure' }}

--- a/.github/workflows/patch-release.yml
+++ b/.github/workflows/patch-release.yml
@@ -35,7 +35,7 @@ jobs:
           . ./.github/workflows/scripts/new-patch-version.sh
         shell: bash
       - name: See patch branch
-        run: echo branch $BRANCH
+        run: echo branch ${{ env.BRANCH }}
         shell: bash
       - name: See new patch version
         run: echo "# version:" ${{ env.VERSION }}
@@ -81,7 +81,7 @@ jobs:
         id: release
         run: |
           chmod +rx .github/workflows/scripts/pre_release_test.sh
-          . .github/workflows/scripts/pre_release_test.sh $BRANCH
+          . .github/workflows/scripts/pre_release_test.sh ${{ env.BRANCH }}
       - name: Archive action failure results
         uses: actions/upload-artifact@v4
         if: ${{ failure() && steps.release.conclusion == 'failure' }}


### PR DESCRIPTION
`patch-release.yml` workflow is vulnerable to command injection via ${{ github.event.inputs.branch }}.

See [GitHub's security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections).

Associated issues: 

- #3464


---

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [ ] N/A : Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).
- [ ] N/A : For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.
