### PR TITLE
`eles.withinBox()` and `eles.hit()` for hit test use cases

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2193,21 +2193,19 @@ declare namespace cytoscape {
         renderedBoundingBox(options?: BoundingBoxOptions): BoundingBox12 & BoundingBoxWH;
         renderedBoundingbox(options?: BoundingBoxOptions): BoundingBox12 & BoundingBoxWH;
         /**
-         * Get the bounding polygon of the elements in model coordinates.
-         * Returns an array of points [{x, y}, ...] representing the polygon.
-         * 
-         * @returns Polygon in model coordinate space.
+         * Get the bounding polygon of a label in model coordinates.
+         * For edges, use `label: 'source'` or `label: 'target'` to select a specific label slot.
+         * Defaults to the main label.
          */
-        actualLabelBoundingBox(): PolygonBoundingBox;
-        actualLabelBoundingbox(): PolygonBoundingBox;
+        actualLabelBoundingBox(options?: { label?: 'main' | 'source' | 'target' }): PolygonBoundingBox;
+        actualLabelBoundingbox(options?: { label?: 'main' | 'source' | 'target' }): PolygonBoundingBox;
         /**
-         * Get the bounding polygon of the elements in rendered coordinates.
-         * Returns an array of points [{x, y}, ...] representing the polygon.
-         * 
-         * @returns Polygon in rendered coordinate space.
+         * Get the bounding polygon of a label in rendered coordinates.
+         * For edges, use `label: 'source'` or `label: 'target'` to select a specific label slot.
+         * Defaults to the main label.
          */
-        renderedActualLabelBoundingBox(): PolygonBoundingBox;
-        renderedActualLabelBoundingbox(): PolygonBoundingBox;
+        renderedActualLabelBoundingBox(options?: { label?: 'main' | 'source' | 'target' }): PolygonBoundingBox;
+        renderedActualLabelBoundingbox(options?: { label?: 'main' | 'source' | 'target' }): PolygonBoundingBox;
     }
 
     /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -2192,6 +2192,22 @@ declare namespace cytoscape {
          */
         renderedBoundingBox(options?: BoundingBoxOptions): BoundingBox12 & BoundingBoxWH;
         renderedBoundingbox(options?: BoundingBoxOptions): BoundingBox12 & BoundingBoxWH;
+        /**
+         * Get the bounding polygon of the elements in model coordinates.
+         * Returns an array of points [{x, y}, ...] representing the polygon.
+         * 
+         * @returns Polygon in model coordinate space.
+         */
+        actualLabelBoundingBox(): PolygonBoundingBox;
+        actualLabelBoundingbox(): PolygonBoundingBox;
+        /**
+         * Get the bounding polygon of the elements in rendered coordinates.
+         * Returns an array of points [{x, y}, ...] representing the polygon.
+         * 
+         * @returns Polygon in rendered coordinate space.
+         */
+        renderedActualLabelBoundingBox(): PolygonBoundingBox;
+        renderedActualLabelBoundingbox(): PolygonBoundingBox;
     }
 
     /**
@@ -2996,6 +3012,30 @@ declare namespace cytoscape {
              */
             ele: SingularElementReturnValue;
         };
+        /**
+         * Returns a new collection containing nodes whose position lies inside
+         * the specified rectangular box in model coordinates.
+         * This is a spatial filter based on element positions.
+         *
+         * @param box BoundingBox12 & BoundingBoxWH
+         */
+        withinBox(box: BoundingBox12 & BoundingBoxWH): Collection<TIn>;
+        /**
+         * Returns a new collection containing nodes whose polygonal bounds
+         * intersect the specified polygon in model coordinates.
+         * This is a spatial filter based on polygon-polygon intersection using SAT.
+         *
+         * @param polygon Array of points {x, y} defining a polygon
+         */
+        polygonIntersection(polygon: PolygonBoundingBox): Collection<TIn>;
+        /**
+         * Returns a new collection containing nodes whose label polygon bounds
+         * contain the specified point (in model coordinates).
+         * This is useful for hit-testing clicks inside rendered labels.
+         *
+         * @param point The point in model coordinates {x, y}
+         */
+        labelsContainPoint(point: Position): Collection<TIn>;
     }
 
     /**
@@ -6225,6 +6265,7 @@ declare namespace cytoscape {
         w: number;
         h: number;
     }
+    type PolygonBoundingBox = Position[];
     interface AnimatedLayoutOptions {
         // whether to transition the node positions
         animate?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2199,13 +2199,6 @@ declare namespace cytoscape {
          */
         actualLabelBoundingBox(options?: { label?: 'main' | 'source' | 'target' }): PolygonBoundingBox;
         actualLabelBoundingbox(options?: { label?: 'main' | 'source' | 'target' }): PolygonBoundingBox;
-        /**
-         * Get the bounding polygon of a label in rendered coordinates.
-         * For edges, use `label: 'source'` or `label: 'target'` to select a specific label slot.
-         * Defaults to the main label.
-         */
-        renderedActualLabelBoundingBox(options?: { label?: 'main' | 'source' | 'target' }): PolygonBoundingBox;
-        renderedActualLabelBoundingbox(options?: { label?: 'main' | 'source' | 'target' }): PolygonBoundingBox;
     }
 
     /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -6265,7 +6265,9 @@ declare namespace cytoscape {
     type PolygonBoundingBox = Position[];
     interface HitTestOptions {
         includeBody?: boolean;
-        includeLabels?: boolean;
+        includeMainLabels?: boolean;
+        includeSourceLabels?: boolean;
+        includeTargetLabels?: boolean;
         isTouch?: boolean;
     }
     interface AnimatedLayoutOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -3011,9 +3011,8 @@ declare namespace cytoscape {
             ele: SingularElementReturnValue;
         };
         /**
-         * Returns a new collection containing nodes whose position lies inside
-         * the specified rectangular box in model coordinates.
-         * This is a spatial filter based on element positions.
+         * Returns subset of collection within the given box, using the
+         * renderer's box-selection rules
          *
          * @param box BoundingBox12 & BoundingBoxWH
          */
@@ -3027,13 +3026,13 @@ declare namespace cytoscape {
          */
         polygonIntersection(polygon: PolygonBoundingBox): Collection<TIn>;
         /**
-         * Returns a new collection containing nodes whose label polygon bounds
-         * contain the specified point (in model coordinates).
-         * This is useful for hit-testing clicks inside rendered labels.
+         * Returns elements from collection that are hit by the given position,
+         * sorted topmost first (by z-order); also works with rotated labels.
          *
-         * @param point The point in model coordinates {x, y}
+         * @param pos        The point in model coordinates {x, y}
+         * @param options    What to include in the hit test
          */
-        labelsContainPoint(point: Position): Collection<TIn>;
+        hit(pos: Position, options?: HitTestOptions): Collection<TIn>;
     }
 
     /**
@@ -6264,6 +6263,11 @@ declare namespace cytoscape {
         h: number;
     }
     type PolygonBoundingBox = Position[];
+    interface HitTestOptions {
+        includeBody?: boolean;
+        includeLabels?: boolean;
+        isTouch?: boolean;
+    }
     interface AnimatedLayoutOptions {
         // whether to transition the node positions
         animate?: boolean;

--- a/src/collection/dimensions/bounds.mjs
+++ b/src/collection/dimensions/bounds.mjs
@@ -27,8 +27,8 @@ elesfn.renderedBoundingBox = function( options ){
   };
 };
 
-elesfn.renderedActualLabelBoundingBox = function(){
-  let polygon = this.actualLabelBoundingBox();
+elesfn.renderedActualLabelBoundingBox = function( options ){
+  let polygon = this.actualLabelBoundingBox( options );
   let cy = this.cy();
   let zoom = cy.zoom();
   let pan = cy.pan();
@@ -39,36 +39,45 @@ elesfn.renderedActualLabelBoundingBox = function(){
   }));
 };
 
-elesfn.actualLabelBoundingBox = function() {
-  let bounds;
+elesfn.actualLabelBoundingBox = function( options ) {
+  let label = (options && options.label) || 'main';
+  let prefix = label === 'main' ? undefined : label; // 'source' | 'target' | undefined
 
   let isDirty = memoize(ele => {
     let _p = ele._private;
+    let cache = _p.labelPolygonCache;
 
-    return _p.labelPolygonCache == null || _p.styleDirty || _p.labelPolygonPosKey !== getLabelPolygonPosKey(ele);
+    return cache == null || cache[label] == null || _p.styleDirty || _p.labelPolygonPosKey !== getLabelPolygonPosKey(ele);
   }, ele => ele.id());
 
   if (this.length === 1 && !isDirty(this[0])) {
-    bounds = this[0]._private.labelPolygonCache;
-  } else {
-    let eles = this;
-    let cy = eles.cy();
-    let styleEnabled = cy.styleEnabled();
-    this.edges().forEach(isDirty);
-    this.nodes().forEach(isDirty);
+    return this[0]._private.labelPolygonCache[label];
+  }
 
-    if(styleEnabled) {
-      this.recalculateRenderedStyle();
-    }
+  let eles = this;
+  let cy = eles.cy();
+  let styleEnabled = cy.styleEnabled();
+  this.edges().forEach(isDirty);
+  this.nodes().forEach(isDirty);
 
-    for (let i = 0; i < eles.length; i++) {
-      let ele = eles[i];
-      let _p = ele._private;
-      let polygon = getRotatedLabelBox(ele);
-      _p.labelPolygonCache = polygon;
+  if(styleEnabled) {
+    this.recalculateRenderedStyle();
+  }
+
+  let bounds;
+
+  for (let i = 0; i < eles.length; i++) {
+    let ele = eles[i];
+    let _p = ele._private;
+
+    if( _p.labelPolygonCache == null || _p.labelPolygonPosKey !== getLabelPolygonPosKey(ele) ){
+      _p.labelPolygonCache = {};
       _p.labelPolygonPosKey = getLabelPolygonPosKey(ele);
-      bounds = polygon;
     }
+
+    let polygon = getRotatedLabelBox(ele, prefix);
+    _p.labelPolygonCache[label] = polygon;
+    bounds = polygon;
   }
 
   return bounds;
@@ -990,14 +999,18 @@ let cachedBoundingBoxImpl = function( ele, opts ){
 };
 
 let getLabelPolygonPosKey = function(ele) {
-  let pos = ele.position();
   let angle = ele.pstyle('text-rotation').pfValue || 0;
 
-  return hashIntsArray([
-    Math.round(pos.x),
-    Math.round(pos.y),
-    Math.round(angle * 1000) 
-  ]);
+  if( ele.isEdge() ){
+    let p1 = ele.source().position();
+    let p2 = ele.target().position();
+
+    return hashIntsArray([ Math.round(p1.x), Math.round(p1.y), Math.round(p2.x), Math.round(p2.y), Math.round(angle * 1000) ]);
+  } else {
+    let pos = ele.position();
+
+    return hashIntsArray([ Math.round(pos.x), Math.round(pos.y), Math.round(angle * 1000) ]);
+  }
 };
 
 let defBbOpts = {
@@ -1100,7 +1113,7 @@ elesfn.dirtyBoundingBoxCache = function(){
     _p.arrowBounds.target = null;
     _p.arrowBounds['mid-source'] = null;
     _p.arrowBounds['mid-target'] = null;
-    _p.labelPolygonCache = null;
+    _p.labelPolygonCache = {};
     _p.labelPolygonPosKey = null;
   }
 

--- a/src/collection/dimensions/bounds.mjs
+++ b/src/collection/dimensions/bounds.mjs
@@ -27,6 +27,53 @@ elesfn.renderedBoundingBox = function( options ){
   };
 };
 
+elesfn.renderedActualLabelBoundingBox = function(){
+  let polygon = this.actualLabelBoundingBox();
+  let cy = this.cy();
+  let zoom = cy.zoom();
+  let pan = cy.pan();
+
+  return polygon.map(p => ({
+    x: p.x * zoom + pan.x,
+    y: p.y * zoom + pan.y
+  }));
+};
+
+elesfn.actualLabelBoundingBox = function() {
+  let bounds;
+
+  let isDirty = memoize(ele => {
+    let _p = ele._private;
+
+    return _p.labelPolygonCache == null || _p.styleDirty || _p.labelPolygonPosKey !== getLabelPolygonPosKey(ele);
+  }, ele => ele.id());
+
+  if (this.length === 1 && !isDirty(this[0])) {
+    bounds = this[0]._private.labelPolygonCache;
+  } else {
+    let eles = this;
+    let cy = eles.cy();
+    let styleEnabled = cy.styleEnabled();
+    this.edges().forEach(isDirty);
+    this.nodes().forEach(isDirty);
+
+    if(styleEnabled) {
+      this.recalculateRenderedStyle();
+    }
+
+    for (let i = 0; i < eles.length; i++) {
+      let ele = eles[i];
+      let _p = ele._private;
+      let polygon = getRotatedLabelBox(ele);
+      _p.labelPolygonCache = polygon;
+      _p.labelPolygonPosKey = getLabelPolygonPosKey(ele);
+      bounds = polygon;
+    }
+  }
+
+  return bounds;
+};
+
 elesfn.dirtyCompoundBoundsCache = function(silent = false){
   let cy = this.cy();
 
@@ -223,6 +270,69 @@ let updateBoundsFromBox = function( b, b2 ){
 let prefixedProperty = function( obj, field, prefix ){
   return getPrefixedProperty( obj, field, prefix );
 };
+
+let getRotatedLabelBox = function (ele, prefix) {
+
+  if( ele.cy().headless() ){ return; }
+
+  var _p = ele._private;
+  let cy = ele.cy();
+  var zoom = cy.zoom();
+  var th = 2 / zoom;
+  ele.boundingBox({ includeLabels: true });
+
+  var prefixDash = prefix ? prefix + '-' : '';
+  let label = ele.pstyle( prefixDash + 'label' ).strValue;
+  if (!label) {
+    return null;
+  }
+  let bbPrefix = prefix || 'main';
+  let bbs = _p.labelBounds;
+  let bb = bbs[bbPrefix] = bbs[bbPrefix] || {};
+
+  // If the bounding box is not available, return null.
+  // This indicates that the label box cannot be calculated, which is consistent
+  // with the expected behavior of this function. Returning null allows the caller
+  // to handle the absence of a bounding box explicitly.
+  if (!bb) {
+    return null;
+  }
+
+  var lx = prefixedProperty(_p.rscratch, 'labelX', prefix);
+  var ly = prefixedProperty(_p.rscratch, 'labelY', prefix);
+  var theta = prefixedProperty(_p.rscratch, 'labelAngle', prefix);
+
+  var ox = ele.pstyle(prefixDash + 'text-margin-x').pfValue;
+  var oy = ele.pstyle(prefixDash + 'text-margin-y').pfValue;
+
+  var lx1 = bb.x1 - th - ox;
+  var lx2 = bb.x2 + th - ox;
+  var ly1 = bb.y1 - th - oy;
+  var ly2 = bb.y2 + th - oy;
+
+  if (theta) {
+    var cos = Math.cos(theta);
+    var sin = Math.sin(theta);
+
+    var rotate = function (x, y) {
+      x = x - lx;
+      y = y - ly;
+      return {
+        x: x * cos - y * sin + lx,
+        y: x * sin + y * cos + ly,
+      };
+    };
+
+    return [rotate(lx1, ly1), rotate(lx2, ly1), rotate(lx2, ly2), rotate(lx1, ly2)];
+  } else {
+    return [
+      { x: lx1, y: ly1 },
+      { x: lx2, y: ly1 },
+      { x: lx2, y: ly2 },
+      { x: lx1, y: ly2 },
+    ];
+  }
+}
 
 let updateBoundsFromArrow = function( bounds, ele, prefix ){
   if( ele.cy().headless() ){ return; }
@@ -879,6 +989,17 @@ let cachedBoundingBoxImpl = function( ele, opts ){
   return bb;
 };
 
+let getLabelPolygonPosKey = function(ele) {
+  let pos = ele.position();
+  let angle = ele.pstyle('text-rotation').pfValue || 0;
+
+  return hashIntsArray([
+    Math.round(pos.x),
+    Math.round(pos.y),
+    Math.round(angle * 1000) 
+  ]);
+};
+
 let defBbOpts = {
   includeNodes: true,
   includeEdges: true,
@@ -979,6 +1100,8 @@ elesfn.dirtyBoundingBoxCache = function(){
     _p.arrowBounds.target = null;
     _p.arrowBounds['mid-source'] = null;
     _p.arrowBounds['mid-target'] = null;
+    _p.labelPolygonCache = null;
+    _p.labelPolygonPosKey = null;
   }
 
   this.emitAndNotify('bounds');
@@ -1041,5 +1164,7 @@ elesfn.boundingBoxAt = function( fn ){
 
 fn.boundingbox = fn.bb = fn.boundingBox;
 fn.renderedBoundingbox = fn.renderedBoundingBox;
+fn.actualLabelBoundingbox = fn.actualLabelBoundingBox;
+fn.renderedActualLabelBoundingbox = fn.renderedActualLabelBoundingBox;
 
 export default elesfn;

--- a/src/collection/dimensions/bounds.mjs
+++ b/src/collection/dimensions/bounds.mjs
@@ -27,17 +27,6 @@ elesfn.renderedBoundingBox = function( options ){
   };
 };
 
-elesfn.renderedActualLabelBoundingBox = function( options ){
-  let polygon = this.actualLabelBoundingBox( options );
-  let cy = this.cy();
-  let zoom = cy.zoom();
-  let pan = cy.pan();
-
-  return polygon.map(p => ({
-    x: p.x * zoom + pan.x,
-    y: p.y * zoom + pan.y
-  }));
-};
 
 elesfn.actualLabelBoundingBox = function( options ) {
   let label = (options && options.label) || 'main';
@@ -1178,6 +1167,5 @@ elesfn.boundingBoxAt = function( fn ){
 fn.boundingbox = fn.bb = fn.boundingBox;
 fn.renderedBoundingbox = fn.renderedBoundingBox;
 fn.actualLabelBoundingbox = fn.actualLabelBoundingBox;
-fn.renderedActualLabelBoundingbox = fn.renderedActualLabelBoundingBox;
 
 export default elesfn;

--- a/src/collection/filter.mjs
+++ b/src/collection/filter.mjs
@@ -1,5 +1,6 @@
 import * as is from '../is.mjs';
 import Selector from '../selector/index.mjs';
+import { satPolygonIntersection, pointInsidePolygon, pointInsidePolygonPoints } from '../math.mjs';
 
 let elesfn = ({
   nodes: function( selector ){
@@ -378,7 +379,65 @@ let elesfn = ({
       value: min,
       ele: minEle
     };
-  }
+  },
+
+  withinBox: function(box) {
+    let eles = this;
+    const { x1, y1, x2, y2 } = box;
+    let filtered = [];
+
+    for (let i = 0, len = eles.length; i < len; i++) {
+      const ele = eles[i];
+      const pos = ele._private.position || ele.position(); 
+      if (pos.x >= x1 && pos.x <= x2 && pos.y >= y1 && pos.y <= y2) {
+        filtered.push(ele);
+      }
+    }
+
+    return this.spawn(filtered);
+  },
+
+  labelsContainPoint: function(point) {
+    const nodes = this.nodes();
+    if (nodes.empty()) return this.spawn();
+
+    const inside = [];
+
+    for (let i = 0; i < nodes.length; i++) {
+      const ele = nodes[i];
+      const labelPoly = ele.actualLabelBoundingBox();
+
+      if (!labelPoly || labelPoly.length === 0) continue;
+
+      const flatPoints = [];
+      for (let j = 0; j < labelPoly.length; j++) {
+        flatPoints.push(labelPoly[j].x, labelPoly[j].y);
+      }
+
+      if (pointInsidePolygonPoints(point.x, point.y, flatPoints)) {
+        inside.push(ele);
+      }
+    }
+
+    return this.spawn(inside);
+  },
+
+  polygonIntersection: function(polygon) {
+    const matches = [];
+
+    for (let i = 0; i < this.length; i++) {
+      const ele = this[i];
+
+      const elePoly = ele.actualLabelBoundingBox();
+      if (!elePoly || !elePoly.length) continue;
+
+      if (satPolygonIntersection(elePoly, polygon)) {
+        matches.push(ele);
+      }
+    }
+
+    return this.spawn(matches);
+  },
 });
 
 // aliases

--- a/src/collection/filter.mjs
+++ b/src/collection/filter.mjs
@@ -1,6 +1,6 @@
 import * as is from '../is.mjs';
 import Selector from '../selector/index.mjs';
-import { satPolygonIntersection, pointInsidePolygon, pointInsidePolygonPoints } from '../math.mjs';
+import { satPolygonIntersection, pointInsidePolygon, pointInsidePolygonPoints, makeBoundingBox } from '../math.mjs';
 
 let elesfn = ({
   nodes: function( selector ){
@@ -383,12 +383,12 @@ let elesfn = ({
 
   withinBox: function(box) {
     let eles = this;
-    const { x1, y1, x2, y2 } = box;
+    let { x1, y1, x2, y2 } = makeBoundingBox(box);
     let filtered = [];
 
     for (let i = 0, len = eles.length; i < len; i++) {
       const ele = eles[i];
-      const pos = ele._private.position || ele.position(); 
+      const pos = ele._private.position || ele.position();
       if (pos.x >= x1 && pos.x <= x2 && pos.y >= y1 && pos.y <= y2) {
         filtered.push(ele);
       }
@@ -423,15 +423,35 @@ let elesfn = ({
   },
 
   polygonIntersection: function(polygon) {
+    const eles = this;
+    const cy = eles.cy();
+
+    if( cy.styleEnabled() ){
+      this.recalculateRenderedStyle();
+    }
+
     const matches = [];
 
-    for (let i = 0; i < this.length; i++) {
-      const ele = this[i];
+    for (let i = 0; i < eles.length; i++) {
+      const ele = eles[i];
+      const bb = ele._private.bodyBounds;
 
-      const elePoly = ele.actualLabelBoundingBox();
-      if (!elePoly || !elePoly.length) continue;
+      if (bb) {
+        const bodyPoly = [
+          { x: bb.x1, y: bb.y1 },
+          { x: bb.x2, y: bb.y1 },
+          { x: bb.x2, y: bb.y2 },
+          { x: bb.x1, y: bb.y2 }
+        ];
 
-      if (satPolygonIntersection(elePoly, polygon)) {
+        if (satPolygonIntersection(bodyPoly, polygon)) {
+          matches.push(ele);
+          continue;
+        }
+      }
+
+      const labelPoly = ele.actualLabelBoundingBox();
+      if (labelPoly && labelPoly.length && satPolygonIntersection(labelPoly, polygon)) {
         matches.push(ele);
       }
     }

--- a/src/collection/filter.mjs
+++ b/src/collection/filter.mjs
@@ -1,6 +1,6 @@
 import * as is from '../is.mjs';
 import Selector from '../selector/index.mjs';
-import { satPolygonIntersection, pointInsidePolygon, pointInsidePolygonPoints, makeBoundingBox } from '../math.mjs';
+import { satPolygonIntersection } from '../math.mjs';
 
 let elesfn = ({
   nodes: function( selector ){
@@ -382,44 +382,23 @@ let elesfn = ({
   },
 
   withinBox: function(box) {
-    let eles = this;
-    let { x1, y1, x2, y2 } = makeBoundingBox(box);
-    let filtered = [];
-
-    for (let i = 0, len = eles.length; i < len; i++) {
-      const ele = eles[i];
-      const pos = ele._private.position || ele.position();
-      if (pos.x >= x1 && pos.x <= x2 && pos.y >= y1 && pos.y <= y2) {
-        filtered.push(ele);
-      }
-    }
-
-    return this.spawn(filtered);
+    const cy = this.cy();
+    const r = cy.renderer();
+    if( cy.styleEnabled() ){ this.recalculateRenderedStyle(); }
+    const x1 = box.x1 != null ? box.x1 : box.x;
+    const y1 = box.y1 != null ? box.y1 : box.y;
+    const x2 = box.x2 != null ? box.x2 : x1 + box.w;
+    const y2 = box.y2 != null ? box.y2 : y1 + box.h;
+    const allInBox = r.getAllInBox(x1, y1, x2, y2);
+    const col = this;
+    return this.spawn( allInBox.filter(ele => col.has(ele)) );
   },
 
-  labelsContainPoint: function(point) {
-    const nodes = this.nodes();
-    if (nodes.empty()) return this.spawn();
-
-    const inside = [];
-
-    for (let i = 0; i < nodes.length; i++) {
-      const ele = nodes[i];
-      const labelPoly = ele.actualLabelBoundingBox();
-
-      if (!labelPoly || labelPoly.length === 0) continue;
-
-      const flatPoints = [];
-      for (let j = 0; j < labelPoly.length; j++) {
-        flatPoints.push(labelPoly[j].x, labelPoly[j].y);
-      }
-
-      if (pointInsidePolygonPoints(point.x, point.y, flatPoints)) {
-        inside.push(ele);
-      }
-    }
-
-    return this.spawn(inside);
+  hit: function(pos, options) {
+    const cy = this.cy();
+    const r = cy.renderer();
+    if( cy.styleEnabled() ){ this.recalculateRenderedStyle(); }
+    return this.spawn( r.hitTestAt(pos.x, pos.y, this, options) );
   },
 
   polygonIntersection: function(polygon) {

--- a/src/extensions/renderer/base/coord-ele-math/coords.mjs
+++ b/src/extensions/renderer/base/coord-ele-math/coords.mjs
@@ -335,79 +335,11 @@ BRp.findNearestElements = function( x, y, interactiveElementsOnly, isTouch ){
     }
   }
 
-  function preprop( obj, name, pre ){
-    return util.getPrefixedProperty( obj, name, pre );
-  }
-
   function checkLabel( ele, prefix ){
-    var _p = ele._private;
-    var th = labelThreshold;
-
-    var prefixDash;
-    if( prefix ){
-      prefixDash = prefix + '-';
-    } else {
-      prefixDash = '';
+    if( self.checkLabelHitAt( ele, x, y, prefix, labelThreshold ) ){
+      addEle( ele );
+      return true;
     }
-
-    ele.boundingBox();
-    var bb = _p.labelBounds[prefix || 'main'];
-
-    var text = ele.pstyle( prefixDash + 'label' ).value;
-    var eventsEnabled = ele.pstyle( 'text-events' ).strValue === 'yes';
-
-    if( !eventsEnabled || !text ){ return; }
-
-    var lx = preprop( _p.rscratch, 'labelX', prefix );
-    var ly = preprop( _p.rscratch, 'labelY', prefix );
-
-    var theta = preprop( _p.rscratch, 'labelAngle', prefix );
-
-    var ox = ele.pstyle(prefixDash + 'text-margin-x').pfValue;
-    let oy = ele.pstyle(prefixDash + 'text-margin-y').pfValue;
-
-    var lx1 = bb.x1 - th - ox; // (-ox, -oy) as bb already includes margin
-    var lx2 = bb.x2 + th - ox; // and rotation is about (lx, ly)
-    var ly1 = bb.y1 - th - oy;
-    var ly2 = bb.y2 + th - oy;
-
-    if( theta ){
-      var cos = Math.cos( theta );
-      var sin = Math.sin( theta );
-
-      var rotate = function( x, y ){
-        x = x - lx;
-        y = y - ly;
-
-        return {
-          x: x * cos - y * sin + lx,
-          y: x * sin + y * cos + ly
-        };
-      };
-
-      var px1y1 = rotate( lx1, ly1 );
-      var px1y2 = rotate( lx1, ly2 );
-      var px2y1 = rotate( lx2, ly1 );
-      var px2y2 = rotate( lx2, ly2 );
-
-      var points = [ // with the margin added after the rotation is applied
-        px1y1.x + ox, px1y1.y + oy,
-        px2y1.x + ox, px2y1.y + oy,
-        px2y2.x + ox, px2y2.y + oy,
-        px1y2.x + ox, px1y2.y + oy
-      ];
-
-      if( math.pointInsidePolygonPoints( x, y, points ) ){
-        addEle( ele );
-        return true;
-      }
-    } else { // do a cheaper bb check
-      if( math.inBoundingBox( bb, x, y ) ){
-        addEle( ele );
-        return true;
-      }
-    }
-
   }
 
   for( var i = eles.length - 1; i >= 0; i-- ){ // reverse order for precedence

--- a/src/extensions/renderer/base/coord-ele-math/coords.mjs
+++ b/src/extensions/renderer/base/coord-ele-math/coords.mjs
@@ -72,6 +72,105 @@ BRp.invalidateContainerClientCoordsCache = function(){
   this.containerBB = null;
 };
 
+// Returns true if (x, y) is inside the label of ele.
+BRp.checkLabelHitAt = function( ele, x, y, prefix, th ){
+  var _p = ele._private;
+  var prefixDash = prefix ? prefix + '-' : '';
+
+  ele.boundingBox();
+  var bb = _p.labelBounds[ prefix || 'main' ];
+  var text = ele.pstyle( prefixDash + 'label' ).value;
+  var eventsEnabled = ele.pstyle( 'text-events' ).strValue === 'yes';
+
+  if( !eventsEnabled || !text || !bb ){ return false; }
+
+  var lx = util.getPrefixedProperty( _p.rscratch, 'labelX', prefix );
+  var ly = util.getPrefixedProperty( _p.rscratch, 'labelY', prefix );
+  var theta = util.getPrefixedProperty( _p.rscratch, 'labelAngle', prefix );
+  var ox = ele.pstyle( prefixDash + 'text-margin-x' ).pfValue;
+  var oy = ele.pstyle( prefixDash + 'text-margin-y' ).pfValue;
+
+  var lx1 = bb.x1 - th - ox;
+  var lx2 = bb.x2 + th - ox;
+  var ly1 = bb.y1 - th - oy;
+  var ly2 = bb.y2 + th - oy;
+
+  if( theta ){
+    var cos = Math.cos( theta );
+    var sin = Math.sin( theta );
+    var rotate = function( px, py ){
+      px = px - lx; py = py - ly;
+      return { x: px * cos - py * sin + lx, y: px * sin + py * cos + ly };
+    };
+    var px1y1 = rotate( lx1, ly1 );
+    var px1y2 = rotate( lx1, ly2 );
+    var px2y1 = rotate( lx2, ly1 );
+    var px2y2 = rotate( lx2, ly2 );
+    var points = [
+      px1y1.x + ox, px1y1.y + oy,
+      px2y1.x + ox, px2y1.y + oy,
+      px2y2.x + ox, px2y2.y + oy,
+      px1y2.x + ox, px1y2.y + oy
+    ];
+    return math.pointInsidePolygonPoints( x, y, points );
+  } else {
+    return math.inBoundingBox( bb, x, y );
+  }
+};
+
+// Returns all elements from eles that are hit by (x, y), sorted topmost first.
+// options: { includeBody: true, includeLabels: true, isTouch: false }
+BRp.hitTestAt = function( x, y, eles, options ){
+  var r = this;
+  var zoom = r.cy.zoom();
+  var opts = options || {};
+  var isTouch = opts.isTouch;
+  var includeBody   = opts.includeBody   !== false;
+  var includeLabels = opts.includeLabels !== false;
+  var nodeThreshold  = ( isTouch ? 8 : 2 ) / zoom;
+  var labelThreshold = ( isTouch ? 8 : 2 ) / zoom;
+
+  var eleIds = new Set();
+  for( var i = 0; i < eles.length; i++ ){ eleIds.add( eles[i]._private.data.id ); }
+
+  var zSorted = r.getCachedZSortedEles();
+  var matches = [];
+
+  for( var i = zSorted.length - 1; i >= 0; i-- ){ // reverse = topmost first
+    var ele = zSorted[ i ];
+    if( !eleIds.has( ele._private.data.id ) ){ continue; }
+
+    var hit = false;
+
+    if( ele.isNode() ){
+      if( includeBody ){
+        var width  = ele.outerWidth()  + 2 * nodeThreshold;
+        var height = ele.outerHeight() + 2 * nodeThreshold;
+        var pos    = ele.position();
+        if( pos.x - width/2 <= x && x <= pos.x + width/2 &&
+            pos.y - height/2 <= y && y <= pos.y + height/2 ){
+          var cornerRadius = ele.pstyle('corner-radius').value === 'auto' ? 'auto' : ele.pstyle('corner-radius').pfValue;
+          var shape = r.nodeShapes[ r.getNodeShape( ele ) ];
+          hit = shape.checkPoint( x, y, 0, width, height, pos.x, pos.y, cornerRadius, ele._private.rscratch );
+        }
+      }
+      if( !hit && includeLabels ){
+        hit = r.checkLabelHitAt( ele, x, y, null, labelThreshold );
+      }
+    } else { // edge
+      if( includeLabels ){
+        hit = r.checkLabelHitAt( ele, x, y, null,     labelThreshold )
+           || r.checkLabelHitAt( ele, x, y, 'source', labelThreshold )
+           || r.checkLabelHitAt( ele, x, y, 'target', labelThreshold );
+      }
+    }
+
+    if( hit ){ matches.push( ele ); }
+  }
+
+  return matches;
+};
+
 BRp.findNearestElement = function( x, y, interactiveElementsOnly, isTouch ){
   return this.findNearestElements( x, y, interactiveElementsOnly, isTouch )[0];
 };

--- a/src/extensions/renderer/base/coord-ele-math/coords.mjs
+++ b/src/extensions/renderer/base/coord-ele-math/coords.mjs
@@ -119,14 +119,16 @@ BRp.checkLabelHitAt = function( ele, x, y, prefix, th ){
 };
 
 // Returns all elements from eles that are hit by (x, y), sorted topmost first.
-// options: { includeBody: true, includeLabels: true, isTouch: false }
+// options: { includeBody, includeMainLabels, includeSourceLabels, includeTargetLabels, isTouch }
 BRp.hitTestAt = function( x, y, eles, options ){
   var r = this;
   var zoom = r.cy.zoom();
   var opts = options || {};
-  var isTouch = opts.isTouch;
-  var includeBody   = opts.includeBody   !== false;
-  var includeLabels = opts.includeLabels !== false;
+  var isTouch            = opts.isTouch;
+  var includeBody        = opts.includeBody        !== false;
+  var includeMainLabels  = opts.includeMainLabels  !== false;
+  var includeSourceLabels = opts.includeSourceLabels !== false;
+  var includeTargetLabels = opts.includeTargetLabels !== false;
   var nodeThreshold  = ( isTouch ? 8 : 2 ) / zoom;
   var labelThreshold = ( isTouch ? 8 : 2 ) / zoom;
 
@@ -154,14 +156,18 @@ BRp.hitTestAt = function( x, y, eles, options ){
           hit = shape.checkPoint( x, y, 0, width, height, pos.x, pos.y, cornerRadius, ele._private.rscratch );
         }
       }
-      if( !hit && includeLabels ){
+      if( !hit && includeMainLabels ){
         hit = r.checkLabelHitAt( ele, x, y, null, labelThreshold );
       }
     } else { // edge
-      if( includeLabels ){
-        hit = r.checkLabelHitAt( ele, x, y, null,     labelThreshold )
-           || r.checkLabelHitAt( ele, x, y, 'source', labelThreshold )
-           || r.checkLabelHitAt( ele, x, y, 'target', labelThreshold );
+      if( includeMainLabels ){
+        hit = hit || r.checkLabelHitAt( ele, x, y, null,     labelThreshold );
+      }
+      if( includeSourceLabels ){
+        hit = hit || r.checkLabelHitAt( ele, x, y, 'source', labelThreshold );
+      }
+      if( includeTargetLabels ){
+        hit = hit || r.checkLabelHitAt( ele, x, y, 'target', labelThreshold );
       }
     }
 

--- a/src/extensions/renderer/null/index.mjs
+++ b/src/extensions/renderer/null/index.mjs
@@ -14,6 +14,8 @@ NullRenderer.prototype = {
   notify: function(){ this.notifications++; },
   init: noop,
   isHeadless: function(){ return true; },
+  getAllInBox: function(){ return []; },
+  hitTestAt: function(){ return []; },
   png: throwImgErr,
   jpg: throwImgErr
 };


### PR DESCRIPTION
Cytoscape currently only exposes axis-aligned bounding boxes (AABB) for labels. This does not work well for rotated labels, which require polygon-based bounds for accurate hit-testing and intersection detection.
These features are already implemented as part of Cytoscape's box selection, but the functions were private and not accessible to users.
This PR exposes them as part of the public API.

- **withinBox(box)** - filter elements by position inside a rectangular box
- **labelsContainPoint(point)** - hit-test which nodes' label polygons contain a point
- **polygonIntersection(polygon)** - filter elements whose label bounds intersect a given polygon (using SAT)

Associated issues: 

- #3466

**Notes re. the content of the pull request.** Give context to reviewers or serve as a general record of the changes made.  Add a screenshot or video to demonstrate your new feature, if possible.

- This PR adds this.
- This PR does that.
- This PR allows us to do some other thing.

**Checklist**

Author:

- [ ] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [ ] The associated GitHub issues are included (above).
- [ ] Notes have been included (above).
- [ ] For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.
- [ ] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added APIs to retrieve precise polygon bounds for main, source, and target labels, including rotated labels.
  * Added collection filtering by rectangular regions and polygon intersections.
  * Added position-based hit testing for element bodies and main, source, or target labels.
  * Added touch-aware hit testing and configurable hit-test behavior.
  * Added TypeScript declarations for the new geometry, filtering, and hit-testing APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->