### PR TITLE
Fix debug add/remove when nodes=0

### DIFF
--- a/debug/add-remove.js
+++ b/debug/add-remove.js
@@ -42,18 +42,31 @@
     }
 
     function randNodeId(){
-      return nodes[ Math.round(Math.random() * (nodes.length - 1)) ].data.id;
+      var pool = nodes.length ? nodes : cy.nodes().toArray();
+
+      if( pool.length === 0 ){
+        return null;
+      }
+
+      return pool[ Math.floor(Math.random() * pool.length) ].data.id;
     }
 
     var edges = [];
     for(var i = 0; i < e; i++){
+      var source = randNodeId();
+      var target = randNodeId();
+
+      if( source == null || target == null ){
+        continue;
+      }
+
       edges.push({
         group: 'edges',
         data: {
           id: makeId(),
           weight: Math.round( Math.random() * 100 ),
-          source: randNodeId(),
-          target: randNodeId()
+          source: source,
+          target: target
         }
       });
     }

--- a/debug/add-remove.js
+++ b/debug/add-remove.js
@@ -41,34 +41,32 @@
       });
     }
 
+    var pool = nodes.length ? nodes : cy.nodes().jsons();
+
+    if( pool.length === 0 && e > 0 ){
+      console.warn('Add/Remove: No nodes available for edge creation; skipping edges.');
+    }
+
     function randNodeId(){
-      var pool = nodes.length ? nodes : cy.nodes().toArray();
-
-      if( pool.length === 0 ){
-        return null;
-      }
-
       return pool[ Math.floor(Math.random() * pool.length) ].data.id;
     }
 
     var edges = [];
-    for(var i = 0; i < e; i++){
-      var source = randNodeId();
-      var target = randNodeId();
+    if( pool.length > 0 ){
+      for(var i = 0; i < e; i++){
+        var source = randNodeId();
+        var target = randNodeId();
 
-      if( source == null || target == null ){
-        continue;
+        edges.push({
+          group: 'edges',
+          data: {
+            id: makeId(),
+            weight: Math.round( Math.random() * 100 ),
+            source: source,
+            target: target
+          }
+        });
       }
-
-      edges.push({
-        group: 'edges',
-        data: {
-          id: makeId(),
-          weight: Math.round( Math.random() * 100 ),
-          source: source,
-          target: target
-        }
-      });
     }
 
     var eles = {

--- a/debug/tests.js
+++ b/debug/tests.js
@@ -1026,4 +1026,53 @@
     }
   });
 
+  test({
+    name: "addEdgesNoNodes",
+    displayName: "Add edges with zero nodes",
+    description: "Sets Nodes=0 and Edges=1 then clicks Add. Expect no crash and no edges when the graph is empty.",
+
+    setup: function(){
+      var nodesInput = $('#nodes-number');
+      var edgesInput = $('#edges-number');
+      var addButton = $('#add-elements-button');
+
+      cy.scratch('prevEles', cy.elements().jsons());
+      cy.elements().remove();
+
+      cy.scratch('prevAddRemoveInputs', {
+        nodes: nodesInput.value,
+        edges: edgesInput.value
+      });
+
+      nodesInput.value = 0;
+      edgesInput.value = 1;
+
+      addButton.click();
+
+      if( cy.edges().length === 0 ){
+        notify('Add/Remove', 'No edges added when nodes=0 (expected).');
+      } else {
+        notify('Add/Remove', 'Edges were added with nodes=0 (unexpected).');
+      }
+    },
+
+    teardown: function(){
+      var nodesInput = $('#nodes-number');
+      var edgesInput = $('#edges-number');
+      var prevInputs = cy.scratch('prevAddRemoveInputs');
+
+      if( prevInputs ){
+        nodesInput.value = prevInputs.nodes;
+        edgesInput.value = prevInputs.edges;
+        cy.removeScratch('prevAddRemoveInputs');
+      }
+
+      var prevEles = cy.scratch('prevEles');
+      if( prevEles ){
+        cy.add(prevEles);
+        cy.removeScratch('prevEles');
+      }
+    }
+  });
+
 })();


### PR DESCRIPTION
## Summary
- reuse a single node pool for the debug add/remove panel, using jsons for existing nodes
- warn when edges are requested but no nodes exist
- add a debug test entry documenting Nodes=0 / Edges>0 behavior

## Testing
- npm test (lint reports existing warnings in src/define/data.mjs, src/define/events.mjs, src/selector/expressions.mjs, src/style/apply.mjs)
- manual: debug page, Nodes=0 and Edges=1, Add (no crash, no edges)

Fixes #3467
