### PR TITLE
Extra validation for hierarchicalClustering dendrogram on empty collection

### DIFF
--- a/src/collection/algorithms/hierarchical-clustering.mjs
+++ b/src/collection/algorithms/hierarchical-clustering.mjs
@@ -237,6 +237,13 @@ let hierarchicalClustering = function( options ){
   let cy    = this.cy();
   let nodes = this.nodes();
 
+  // Nothing to cluster: return no clusters and add no dendrogram. Handles the
+  // empty case locally so dendrogram mode never indexes into empty `clusters`
+  // (which previously threw a TypeError), and keeps both modes consistent.
+  if ( nodes.length === 0 ){
+    return [];
+  }
+
   // Set parameters of algorithm: linkage type, distance metric, etc.
   let opts = setOptions( options );
 

--- a/test/collection-hierarchical.mjs
+++ b/test/collection-hierarchical.mjs
@@ -320,6 +320,44 @@ describe('Algorithms', function(){
         });
         expect(dendroCy.edges().length).to.equal(originalEdgeCount + 2);
       });
+
+      // Shared base for the empty-collection cases; tests override addDendrogram.
+      function emptyDendrogramOpts( overrides ){
+        return Object.assign({
+          distance: 'euclidean',
+          linkage: 'min',
+          attributes: [
+            function(node){ return node.data('X1'); },
+            function(node){ return node.data('X2'); }
+          ],
+          mode: 'dendrogram',
+          dendrogramDepth: 0,
+          addDendrogram: false
+        }, overrides);
+      }
+
+      it('returns an empty array for an empty collection (dendrogram mode)', function(){
+        var emptyCy = cytoscape({ elements: { nodes: [] } });
+
+        // Regression: previously threw `TypeError: Cannot read properties of
+        // undefined (reading 'key')` on an empty collection, while threshold
+        // mode returned []. Dendrogram mode should be consistent.
+        var clusters = emptyCy.elements().hierarchicalClustering( emptyDendrogramOpts() );
+
+        expect(clusters).to.exist;
+        expect(Array.isArray(clusters)).to.be.true;
+        expect(clusters.length).to.equal(0);
+      });
+
+      it('does not add dendrogram nodes/edges for an empty collection', function(){
+        var emptyCy = cytoscape({ elements: { nodes: [] } });
+
+        var clusters = emptyCy.elements().hierarchicalClustering( emptyDendrogramOpts({ addDendrogram: true }) );
+
+        expect(clusters.length).to.equal(0);
+        expect(emptyCy.nodes().length).to.equal(0);
+        expect(emptyCy.edges().length).to.equal(0);
+      });
     }
 
   });


### PR DESCRIPTION
**Associated issues**

- None — small, reproducible bug found while extending the dendrogram tests (#3470). Happy to file a tracking issue if preferred.

**Notes re. the content of the pull request**

- `eles.hierarchicalClustering({ mode: 'dendrogram' })` threw `TypeError: Cannot read properties of undefined (reading 'key')` when called on an **empty collection**. `mergeClosest()` only treated `clusters.length === 1` as the dendrogram stop condition, so with `0` clusters it fell through to `index[minKey]` (which is `undefined`) and crashed.

- Threshold mode already returned `[]` for empty input, so dendrogram mode was inconsistent. This PR broadens the stop condition to `clusters.length <= 1`, so dendrogram mode also returns `[]` for empty input. Single-node behavior is unchanged.

- Adds regression tests for empty input with `addDendrogram` off and on — both throw before the fix and pass after.

**Checklist**


- [x] The proper base branch has been selected. (`unstable`; bug-fix patch.)
- [x] Automated tests have been included for the bug fix.
- [x] The associated GitHub issues are included (none required for this small fix).
- [x] Notes have been included (above).
- [x] No API change — internal behavior fix only, so `index.d.ts` is unchanged.
