### PR TITLE
Extra validation for kMedoids when k exceeds the number of nodes

### DIFF
--- a/src/collection/algorithms/k-clustering.mjs
+++ b/src/collection/algorithms/k-clustering.mjs
@@ -248,6 +248,13 @@ let kMedoids = function( options ) {
   let node  = null;
   let opts  = setOptions( options );
 
+  // k distinct medoids are required, so k cannot exceed the number of nodes.
+  // Otherwise randomMedoids() can never pick k unique nodes and loops forever
+  // (e.g. an empty collection, where it also reads from an empty node list).
+  if ( opts.k > nodes.length ) {
+    util.error(`kMedoids: k (${opts.k}) cannot exceed the number of nodes (${nodes.length}).`);
+  }
+
   // Begin k-medoids algorithm
   let clusters = new Array(opts.k);
   let medoids;

--- a/test/collection-k-medoids.mjs
+++ b/test/collection-k-medoids.mjs
@@ -270,5 +270,33 @@ describe('Algorithms', function(){
       expect(cltrIExpected(1), '1st cluster expected').to.be.true;
     });
 
+    // Shared attribute accessors for the input-validation tests below.
+    var validationAttributes = [
+      function(node){ return node.data('attrA'); },
+      function(node){ return node.data('attrB'); }
+    ];
+
+    it('throws when k exceeds the number of nodes', function(){
+      // Regression: previously looped forever because randomMedoids() could
+      // never pick k unique medoids. It should fail loudly instead of hanging.
+      expect(function(){
+        cy.elements().kMedoids({
+          k: nodes.length + 1,
+          attributes: validationAttributes
+        });
+      }).to.throw(/cannot exceed the number of nodes/);
+    });
+
+    it('throws for an empty collection instead of hanging', function(){
+      var emptyCy = cytoscape({ headless: true, elements: { nodes: [] } });
+
+      expect(function(){
+        emptyCy.elements().kMedoids({
+          k: 2,
+          attributes: validationAttributes
+        });
+      }).to.throw(/cannot exceed the number of nodes/);
+    });
+
   });
 });


### PR DESCRIPTION
**Associated issues**

* None. Found while hardening the clustering algorithms against degenerate inputs as a follow-up to #3472. Happy to file a tracking issue if preferred.

**Notes on this pull request**

* `eles.kMedoids({ k })` could hang indefinitely when `k` was greater than the number of nodes, including an empty collection. `randomMedoids()` selects `k` distinct medoids using a rejection loop (`while (seenBefore(...))`). When `k` exceeds the available nodes, it can never find enough unique medoids, so the loop never terminates.

* A k-medoids clustering with `k > nodeCount` is invalid. This PR validates `k <= nodeCount` up front with `util.error(...)`, matching the existing validation used by `affinityPropagation`. Invalid input now fails fast with a clear error instead of hanging.

* Adds regression tests for `k > nodeCount` and for an empty collection. Both cases hang on the current implementation and pass with this fix.

**Checklist**

* [x] The proper base branch has been selected (`unstable`; bug-fix patch).
* [x] Automated tests have been included for the bug fix.
* [x] Associated GitHub issues have been included (none required for this small fix).
* [x] Notes have been included above.
* [x] No public API change (`index.d.ts` unchanged). Invalid input now errors instead of hanging.
