### PR TITLE
Use GCD of initial wheel deltas as inaccurate scroll factor

### DIFF
--- a/src/extensions/renderer/base/load-listeners.mjs
+++ b/src/extensions/renderer/base/load-listeners.mjs
@@ -1043,16 +1043,6 @@ BRp.load = function(){
   var inaccurateScrollDevice;
   var inaccurateScrollFactor = 100000; // base of inaccurate wheel deltas (e.g. base 5 could yield wheels of 10, 25, 50, etc.)
 
-  var allAreDivisibleBy = function( list, factor ){
-    for( var i = 0; i < list.length; i++ ){
-      if( list[i] % factor !== 0 ){
-        return false;
-      }
-    }
-
-    return true;
-  }
-
   var allAreSameMagnitude = function(list) {
     var firstMag = Math.abs(list[0]);
     for (var i = 1; i < list.length; i++) {
@@ -1081,38 +1071,25 @@ BRp.load = function(){
 
     if (inaccurateScrollDevice == null) {
       if (wheelDeltas.length >= wheelDeltaN) { // use log to determine if inaccurate
+        inaccurateScrollDevice = false;
         var wds = wheelDeltas;
-        inaccurateScrollDevice = allAreDivisibleBy(wds, 5);
-        var isfUnset = true;
 
-        if (!inaccurateScrollDevice) { // check for all large values of same or common-divisor magnitude
-          if (wds[0] > 5) {
-            var factor;
-            // an array of equal integers "x" will have a GCD of x, so in that
-            // case there is no need to have a separate "allAreSameMagnitude"
-            // check. but the GCD function only supports integers, so keeping
-            // both checks allows arrays of equal floating-point numbers
-            if (allAreSameMagnitude(wds)) {
-              factor = wds[0];
-            } else {
-              factor = math.gcdMultipleZeroIfNonInt(wds);
-            }
-            if (factor > 1) {
-              inaccurateScrollDevice = true;
-              inaccurateScrollFactor = factor;
-              // use this flag to indicate that we already have a scroll factor
-              // set -- no need to go through the list again
-              isfUnset = false;
-            }
+        if (wds[0] >= 5) {
+          var factor;
+          // an array of equal integers "x" will have a GCD of x, so in that
+          // case there is no need to have a separate "allAreSameMagnitude"
+          // check. but the GCD function only supports integers, so keeping
+          // both checks allows arrays of equal floating-point numbers
+          if (allAreSameMagnitude(wds)) {
+            factor = wds[0];
+          } else {
+            factor = math.gcdMultipleZeroIfNonInt(wds);
+          }
+          if (factor > 1) {
+            inaccurateScrollDevice = true;
+            inaccurateScrollFactor = factor;
           }
         }
-        
-        if (isfUnset && inaccurateScrollDevice) {
-          for (var i = 0; i < wds.length; i++) {
-            inaccurateScrollFactor = Math.min(wds[i], inaccurateScrollFactor);
-          }
-        }
-
         // console.log('Sampled wheel deltas:', wds);
         // console.log('inaccurateScrollDevice:', inaccurateScrollDevice);
         // console.log('inaccurateScrollFactor:', inaccurateScrollFactor);

--- a/src/extensions/renderer/base/load-listeners.mjs
+++ b/src/extensions/renderer/base/load-listeners.mjs
@@ -1053,23 +1053,6 @@ BRp.load = function(){
     return true;
   }
 
-  // https://en.wikipedia.org/wiki/Greatest_common_divisor#Euclidean_algorithm
-  var gcd = function( a, b ) {
-    if( b === 0 ) {
-      return a;
-    }
-    return gcd(b, a % b);
-  }
-
-  // Finds the GCD of a list of numbers: https://stackoverflow.com/a/4885641
-  var gcdMultiple = function( list ) {
-    var out = list[0];
-    for ( var i = 1; i < list.length; i++ ) {
-        out = gcd(out, list[i]);
-    }
-    return out;
-  }
-
   var wheelHandler = function( e ){
     var clamp = false;
     var delta = e.deltaY;
@@ -1094,7 +1077,7 @@ BRp.load = function(){
 
         if (!inaccurateScrollDevice) { // check for all large values with common divisor magnitude
           if (wds[0] > 5) {
-            var factor = gcdMultiple(wds);
+            var factor = math.gcdMultiple(wds);
             if (factor > 1) {
               inaccurateScrollDevice = true;
               inaccurateScrollFactor = factor;
@@ -1105,7 +1088,7 @@ BRp.load = function(){
           }
         }
         
-        if ( isfUnset && inaccurateScrollDevice ) {
+        if (isfUnset && inaccurateScrollDevice) {
           for (var i = 0; i < wds.length; i++) {
             inaccurateScrollFactor = Math.min(wds[i], inaccurateScrollFactor);
           }

--- a/src/extensions/renderer/base/load-listeners.mjs
+++ b/src/extensions/renderer/base/load-listeners.mjs
@@ -1053,6 +1053,16 @@ BRp.load = function(){
     return true;
   }
 
+  var allAreSameMagnitude = function(list) {
+    var firstMag = Math.abs(list[0]);
+    for (var i = 1; i < list.length; i++) {
+      if (Math.abs(list[i]) !== firstMag) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   var wheelHandler = function( e ){
     var clamp = false;
     var delta = e.deltaY;
@@ -1077,7 +1087,16 @@ BRp.load = function(){
 
         if (!inaccurateScrollDevice) { // check for all large values with common divisor magnitude
           if (wds[0] > 5) {
-            var factor = math.gcdMultiple(wds);
+            var factor;
+            // an array of equal integers "x" will have a GCD of x, so in that
+            // case there is no need to have a separate "allAreSameMagnitude"
+            // check. but the GCD function only supports integers, so keeping
+            // both checks allows arrays of equal floating-point numbers
+            if (allAreSameMagnitude(wds)) {
+              factor = wds[0];
+            } else {
+              factor = math.gcdMultipleZeroIfNonInt(wds);
+            }
             if (factor > 1) {
               inaccurateScrollDevice = true;
               inaccurateScrollFactor = factor;

--- a/src/extensions/renderer/base/load-listeners.mjs
+++ b/src/extensions/renderer/base/load-listeners.mjs
@@ -1085,7 +1085,7 @@ BRp.load = function(){
         inaccurateScrollDevice = allAreDivisibleBy(wds, 5);
         var isfUnset = true;
 
-        if (!inaccurateScrollDevice) { // check for all large values with common divisor magnitude
+        if (!inaccurateScrollDevice) { // check for all large values of same or common-divisor magnitude
           if (wds[0] > 5) {
             var factor;
             // an array of equal integers "x" will have a GCD of x, so in that

--- a/src/extensions/renderer/base/load-listeners.mjs
+++ b/src/extensions/renderer/base/load-listeners.mjs
@@ -1038,7 +1038,7 @@ BRp.load = function(){
 
   }, false );
 
-  var wheelDeltas = []; // log of first N wheel deltas
+  var wheelDeltas = []; // log of first N wheel deltas' magnitudes
   var wheelDeltaN = 4; // how many events to log
   var inaccurateScrollDevice;
   var inaccurateScrollFactor = 100000; // base of inaccurate wheel deltas (e.g. base 5 could yield wheels of 10, 25, 50, etc.)
@@ -1053,16 +1053,23 @@ BRp.load = function(){
     return true;
   }
 
-  var allAreSameMagnitude = function(list) {
-    var firstMag = Math.abs(list[0]);
-    for (var i = 1; i < list.length; i++) {
-      if (Math.abs(list[i]) !== firstMag) {
-        return false;
-      }
+  // https://en.wikipedia.org/wiki/Greatest_common_divisor#Euclidean_algorithm
+  var gcd = function( a, b ) {
+    if( b === 0 ) {
+      return a;
     }
-    return true;
+    return gcd(b, a % b);
   }
-      
+
+  // Finds the GCD of a list of numbers: https://stackoverflow.com/a/4885641
+  var gcdMultiple = function( list ) {
+    var out = list[0];
+    for ( var i = 1; i < list.length; i++ ) {
+        out = gcd(out, list[i]);
+    }
+    return out;
+  }
+
   var wheelHandler = function( e ){
     var clamp = false;
     var delta = e.deltaY;
@@ -1083,16 +1090,24 @@ BRp.load = function(){
       if (wheelDeltas.length >= wheelDeltaN) { // use log to determine if inaccurate
         var wds = wheelDeltas;
         inaccurateScrollDevice = allAreDivisibleBy(wds, 5);
+        var isfUnset = true;
 
-        if (!inaccurateScrollDevice) { // check for all large values of exact same magnitude
-          var firstMag = Math.abs(wds[0]);
-
-          inaccurateScrollDevice = allAreSameMagnitude(wds) && firstMag > 5;
+        if (!inaccurateScrollDevice) { // check for all large values with common divisor magnitude
+          if (wds[0] > 5) {
+            var factor = gcdMultiple(wds);
+            if (factor > 1) {
+              inaccurateScrollDevice = true;
+              inaccurateScrollFactor = factor;
+              // use this flag to indicate that we already have a scroll factor
+              // set -- no need to go through the list again
+              isfUnset = false;
+            }
+          }
         }
         
-        if (inaccurateScrollDevice) {
+        if ( isfUnset && inaccurateScrollDevice ) {
           for (var i = 0; i < wds.length; i++) {
-            inaccurateScrollFactor = Math.min(Math.abs(wds[i]), inaccurateScrollFactor);
+            inaccurateScrollFactor = Math.min(wds[i], inaccurateScrollFactor);
           }
         }
 
@@ -1100,7 +1115,7 @@ BRp.load = function(){
         // console.log('inaccurateScrollDevice:', inaccurateScrollDevice);
         // console.log('inaccurateScrollFactor:', inaccurateScrollFactor);
       } else { // clamp and log until we reach N
-        wheelDeltas.push(delta);
+        wheelDeltas.push(Math.abs(delta));
         clamp = true;
         // console.log('Clamping initial wheel events until we get a good sample');
       }

--- a/src/math.mjs
+++ b/src/math.mjs
@@ -1,3 +1,5 @@
+import * as is from './is.mjs';
+
 export const arePositionsSame = ( p1, p2 ) =>
   p1.x === p2.x && p1.y === p2.y;
 
@@ -114,15 +116,18 @@ export const gcd = ( a, b ) => {
 };
 
 // finds the GCD of an array of numbers: https://stackoverflow.com/a/4885641
-export const gcdMultiple = ( arr ) => {
+//
+// if any of the numbers are not integers, this returns zero (since even if
+// you try to take the GCD of two floating-point numbers you will end up with
+// either zero or some extremely small number that is almost zero)
+export const gcdMultipleZeroIfNonInt = ( arr ) => {
   var out = arr[0];
-  for ( var i = 1; i < arr.length; i++ ) {
-      // finding a 1 means we can bail early
-      // https://www.geeksforgeeks.org/dsa/gcd-two-array-numbers/
-      if ( out === 1 ) {
-        return out;
+  for ( var i = 0; i < arr.length; i++ ) {
+      if ( !is.integer( arr[i] ) ) {
+        return 0;
+      } else if (i > 0) {
+        out = gcd( out, arr[i] );
       }
-      out = gcd( out, arr[i] );
   }
   return out;
 };

--- a/src/math.mjs
+++ b/src/math.mjs
@@ -105,6 +105,28 @@ export const median = ( arr, begin = 0, end = arr.length, copy = true, sort = tr
   }
 };
 
+// https://en.wikipedia.org/wiki/Greatest_common_divisor#Euclidean_algorithm
+export const gcd = ( a, b ) => {
+  if( b === 0 ) {
+    return a;
+  }
+  return gcd( b, a % b );
+};
+
+// finds the GCD of an array of numbers: https://stackoverflow.com/a/4885641
+export const gcdMultiple = ( arr ) => {
+  var out = arr[0];
+  for ( var i = 1; i < arr.length; i++ ) {
+      // finding a 1 means we can bail early
+      // https://www.geeksforgeeks.org/dsa/gcd-two-array-numbers/
+      if ( out === 1 ) {
+        return out;
+      }
+      out = gcd( out, arr[i] );
+  }
+  return out;
+};
+
 export const deg2rad = deg =>
   Math.PI * deg / 180;
 

--- a/test/modules/math.mjs
+++ b/test/modules/math.mjs
@@ -54,6 +54,8 @@ describe('Math', function(){
             expect( gcd( 552, 138 ) ).equals( 138 );
             // https://en.wikipedia.org/wiki/Greatest_common_divisor#Euclidean_algorithm
             expect( gcd( 48, 18 ) ).equals( 6 );
+            expect( gcd( 45, 15 ) ).equals( 15 );
+            expect( gcd( 40, 15 ) ).equals( 5 );
             expect( gcd( 6, 5 ) ).equals( 1 );
             expect( gcd( 6, 1 ) ).equals( 1 );
             expect( gcd( 6, 0 ) ).equals( 6 );
@@ -61,6 +63,8 @@ describe('Math', function(){
         it('gcd(a, b) for integers a < b', function(){
             expect( gcd( 138, 552 ) ).equals( 138 );
             expect( gcd( 18, 48 ) ).equals( 6 );
+            expect( gcd( 15, 45 ) ).equals( 15 );
+            expect( gcd( 15, 40 ) ).equals( 5 );
             expect( gcd( 5, 6 ) ).equals( 1 );
             expect( gcd( 1, 6 ) ).equals( 1 );
             expect( gcd( 0, 6 ) ).equals( 6 );
@@ -79,6 +83,7 @@ describe('Math', function(){
             expect ( gcdMultipleZeroIfNonInt( [ 276, 276, 1242, 966 ] ) ).equals( 138 );
             expect ( gcdMultipleZeroIfNonInt( [ 276, 276, 0, 1242, 966 ] ) ).equals( 138 );
             expect ( gcdMultipleZeroIfNonInt( [ 276, 276, 1, 1242, 966 ] ) ).equals( 1 );
+            expect ( gcdMultipleZeroIfNonInt( [ 45, 15, 50, 25, 100 ] ) ).equals( 5 );
             expect ( gcdMultipleZeroIfNonInt( [ 138, 138 ] ) ).equals( 138 );
             expect ( gcdMultipleZeroIfNonInt( [ 5, 5 ] ) ).equals( 5 );
             expect ( gcdMultipleZeroIfNonInt( [ 5, 6 ] ) ).equals( 1 );

--- a/test/modules/math.mjs
+++ b/test/modules/math.mjs
@@ -1,4 +1,4 @@
-import { expandBoundingBoxSides, makeBoundingBox } from '../../src/math.mjs'
+import { expandBoundingBoxSides, makeBoundingBox, gcd, gcdMultiple } from '../../src/math.mjs'
 import { describe } from 'mocha'
 import { expect } from 'chai'
 
@@ -46,6 +46,48 @@ describe('Math', function(){
             expect( bb.y2 ).equals( 18 );
             expect( bb.w ).equals( 16 );
             expect( bb.h ).equals( 24 );
+        });
+    });
+
+    describe('GCD', function(){
+        it('gcd(a, b) for integers a > b', function(){
+            expect(gcd(552, 138)).equals(138);
+            // https://en.wikipedia.org/wiki/Greatest_common_divisor#Euclidean_algorithm
+            expect(gcd(48, 18)).equals(6);
+            expect(gcd(6, 5)).equals(1);
+            expect(gcd(6, 1)).equals(1);
+            expect(gcd(6, 0)).equals(6);
+        });
+        it('gcd(a, b) for integers a < b', function(){
+            expect(gcd(138, 552)).equals(138);
+            expect(gcd(18, 48)).equals(6);
+            expect(gcd(5, 6)).equals(1);
+            expect(gcd(1, 6)).equals(1);
+            expect(gcd(0, 6)).equals(6);
+        });
+        it('gcd(a, b) for integers a = b', function(){
+            expect(gcd(138, 138)).equals(138);
+            expect(gcd(18, 18)).equals(18);
+            expect(gcd(5, 5)).equals(5);
+            expect(gcd(1, 1)).equals(1);
+            // just define this as zero, per
+            // https://en.wikipedia.org/wiki/Greatest_common_divisor#Definition
+            expect(gcd(0, 0)).equals(0);
+        });
+        it('gcd of > 2 integers', function(){
+            expect(gcdMultiple([138, 552, 276, 138])).equals(138);
+            expect(gcdMultiple([276, 276, 1242, 966])).equals(138);
+            expect(gcdMultiple([276, 276, 0, 1242, 966])).equals(138);
+            expect(gcdMultiple([276, 276, 1, 1242, 966])).equals(1);
+            expect(gcdMultiple([138, 138])).equals(138);
+            expect(gcdMultiple([5, 5])).equals(5);
+            expect(gcdMultiple([5, 6])).equals(1);
+            expect(gcdMultiple([5, 6, 0])).equals(1);
+            expect(gcdMultiple([1, 1, 1, 1, 1, 1])).equals(1);
+            expect(gcdMultiple([0, 0, 0])).equals(0);
+            expect(gcdMultiple([1, 0, 0, 0])).equals(1);
+            expect(gcdMultiple([0, 0, 0, 1])).equals(1);
+            expect(gcdMultiple([0, 1, 0, 0])).equals(1);
         });
     });
 });

--- a/test/modules/math.mjs
+++ b/test/modules/math.mjs
@@ -51,48 +51,48 @@ describe('Math', function(){
 
     describe('GCD', function(){
         it('gcd(a, b) for integers a > b', function(){
-            expect(gcd(552, 138)).equals(138);
+            expect( gcd( 552, 138 ) ).equals( 138 );
             // https://en.wikipedia.org/wiki/Greatest_common_divisor#Euclidean_algorithm
-            expect(gcd(48, 18)).equals(6);
-            expect(gcd(6, 5)).equals(1);
-            expect(gcd(6, 1)).equals(1);
-            expect(gcd(6, 0)).equals(6);
+            expect( gcd( 48, 18 ) ).equals( 6 );
+            expect( gcd( 6, 5 ) ).equals( 1 );
+            expect( gcd( 6, 1 ) ).equals( 1 );
+            expect( gcd( 6, 0 ) ).equals( 6 );
         });
         it('gcd(a, b) for integers a < b', function(){
-            expect(gcd(138, 552)).equals(138);
-            expect(gcd(18, 48)).equals(6);
-            expect(gcd(5, 6)).equals(1);
-            expect(gcd(1, 6)).equals(1);
-            expect(gcd(0, 6)).equals(6);
+            expect( gcd( 138, 552 ) ).equals( 138 );
+            expect( gcd( 18, 48 ) ).equals( 6 );
+            expect( gcd( 5, 6 ) ).equals( 1 );
+            expect( gcd( 1, 6 ) ).equals( 1 );
+            expect( gcd( 0, 6 ) ).equals( 6 );
         });
         it('gcd(a, b) for integers a = b', function(){
-            expect(gcd(138, 138)).equals(138);
-            expect(gcd(18, 18)).equals(18);
-            expect(gcd(5, 5)).equals(5);
-            expect(gcd(1, 1)).equals(1);
+            expect( gcd( 138, 138 ) ).equals( 138 );
+            expect( gcd( 18, 18 ) ).equals( 18 );
+            expect( gcd( 5, 5 ) ).equals( 5 );
+            expect( gcd( 1, 1 ) ).equals( 1 );
             // just define this as zero, per
             // https://en.wikipedia.org/wiki/Greatest_common_divisor#Definition
-            expect(gcd(0, 0)).equals(0);
+            expect( gcd( 0, 0 ) ).equals( 0 );
         });
         it('gcd of an array of numbers (all integers)', function(){
-            expect(gcdMultipleZeroIfNonInt([138, 552, 276, 138])).equals(138);
-            expect(gcdMultipleZeroIfNonInt([276, 276, 1242, 966])).equals(138);
-            expect(gcdMultipleZeroIfNonInt([276, 276, 0, 1242, 966])).equals(138);
-            expect(gcdMultipleZeroIfNonInt([276, 276, 1, 1242, 966])).equals(1);
-            expect(gcdMultipleZeroIfNonInt([138, 138])).equals(138);
-            expect(gcdMultipleZeroIfNonInt([5, 5])).equals(5);
-            expect(gcdMultipleZeroIfNonInt([5, 6])).equals(1);
-            expect(gcdMultipleZeroIfNonInt([5, 6, 0])).equals(1);
-            expect(gcdMultipleZeroIfNonInt([1, 1, 1, 1, 1, 1])).equals(1);
-            expect(gcdMultipleZeroIfNonInt([0, 0, 0])).equals(0);
-            expect(gcdMultipleZeroIfNonInt([1, 0, 0, 0])).equals(1);
-            expect(gcdMultipleZeroIfNonInt([0, 0, 0, 1])).equals(1);
-            expect(gcdMultipleZeroIfNonInt([0, 1, 0, 0])).equals(1);
+            expect ( gcdMultipleZeroIfNonInt( [ 138, 552, 276, 138 ] ) ).equals( 138 );
+            expect ( gcdMultipleZeroIfNonInt( [ 276, 276, 1242, 966 ] ) ).equals( 138 );
+            expect ( gcdMultipleZeroIfNonInt( [ 276, 276, 0, 1242, 966 ] ) ).equals( 138 );
+            expect ( gcdMultipleZeroIfNonInt( [ 276, 276, 1, 1242, 966 ] ) ).equals( 1 );
+            expect ( gcdMultipleZeroIfNonInt( [ 138, 138 ] ) ).equals( 138 );
+            expect ( gcdMultipleZeroIfNonInt( [ 5, 5 ] ) ).equals( 5 );
+            expect ( gcdMultipleZeroIfNonInt( [ 5, 6 ] ) ).equals( 1 );
+            expect ( gcdMultipleZeroIfNonInt( [ 5, 6, 0 ] ) ).equals( 1 );
+            expect ( gcdMultipleZeroIfNonInt( [ 1, 1, 1, 1, 1, 1 ] ) ).equals( 1 );
+            expect ( gcdMultipleZeroIfNonInt( [ 0, 0, 0 ] ) ).equals( 0 );
+            expect ( gcdMultipleZeroIfNonInt( [ 1, 0, 0, 0 ] ) ).equals( 1 );
+            expect ( gcdMultipleZeroIfNonInt( [ 0, 0, 0, 1 ] ) ).equals( 1 );
+            expect ( gcdMultipleZeroIfNonInt( [ 0, 1, 0, 0 ] ) ).equals( 1 );
         });
         it('gcd of an array of numbers, including float(s)', function(){
-            expect(gcdMultipleZeroIfNonInt([138, 552, 276.3, 138])).equals(0);
-            expect(gcdMultipleZeroIfNonInt([276, 276.001, 1242, 966])).equals(0);
-            expect(gcdMultipleZeroIfNonInt([0, 1.5, 0, 0.3])).equals(0);
+            expect ( gcdMultipleZeroIfNonInt( [ 138, 552, 276.3, 138 ] ) ).equals( 0 );
+            expect ( gcdMultipleZeroIfNonInt( [ 276, 276.001, 1242, 966 ] ) ).equals( 0 );
+            expect ( gcdMultipleZeroIfNonInt( [ 0, 1.5, 0, 0.3 ] ) ).equals( 0 );
             // in theory, you could speed up this kind of function by exiting
             // as soon as it sees a 1 -- since (if the numbers in the list are
             // integers) then this indicates that these numbers' GCD is 1.
@@ -100,7 +100,7 @@ describe('Math', function(){
             // contains any non-integer values, we should *not* do this.
             // (shouldn't make a difference in terms of finding scroll factors,
             // but at least the function will behave as expected.)
-            expect(gcdMultipleZeroIfNonInt([1, 1.1])).equals(0);
+            expect ( gcdMultipleZeroIfNonInt( [ 1, 1.1 ] ) ).equals( 0 );
         });
     });
 });

--- a/test/modules/math.mjs
+++ b/test/modules/math.mjs
@@ -1,4 +1,4 @@
-import { expandBoundingBoxSides, makeBoundingBox, gcd, gcdMultiple } from '../../src/math.mjs'
+import { expandBoundingBoxSides, makeBoundingBox, gcd, gcdMultipleZeroIfNonInt } from '../../src/math.mjs'
 import { describe } from 'mocha'
 import { expect } from 'chai'
 
@@ -74,20 +74,33 @@ describe('Math', function(){
             // https://en.wikipedia.org/wiki/Greatest_common_divisor#Definition
             expect(gcd(0, 0)).equals(0);
         });
-        it('gcd of > 2 integers', function(){
-            expect(gcdMultiple([138, 552, 276, 138])).equals(138);
-            expect(gcdMultiple([276, 276, 1242, 966])).equals(138);
-            expect(gcdMultiple([276, 276, 0, 1242, 966])).equals(138);
-            expect(gcdMultiple([276, 276, 1, 1242, 966])).equals(1);
-            expect(gcdMultiple([138, 138])).equals(138);
-            expect(gcdMultiple([5, 5])).equals(5);
-            expect(gcdMultiple([5, 6])).equals(1);
-            expect(gcdMultiple([5, 6, 0])).equals(1);
-            expect(gcdMultiple([1, 1, 1, 1, 1, 1])).equals(1);
-            expect(gcdMultiple([0, 0, 0])).equals(0);
-            expect(gcdMultiple([1, 0, 0, 0])).equals(1);
-            expect(gcdMultiple([0, 0, 0, 1])).equals(1);
-            expect(gcdMultiple([0, 1, 0, 0])).equals(1);
+        it('gcd of an array of numbers (all integers)', function(){
+            expect(gcdMultipleZeroIfNonInt([138, 552, 276, 138])).equals(138);
+            expect(gcdMultipleZeroIfNonInt([276, 276, 1242, 966])).equals(138);
+            expect(gcdMultipleZeroIfNonInt([276, 276, 0, 1242, 966])).equals(138);
+            expect(gcdMultipleZeroIfNonInt([276, 276, 1, 1242, 966])).equals(1);
+            expect(gcdMultipleZeroIfNonInt([138, 138])).equals(138);
+            expect(gcdMultipleZeroIfNonInt([5, 5])).equals(5);
+            expect(gcdMultipleZeroIfNonInt([5, 6])).equals(1);
+            expect(gcdMultipleZeroIfNonInt([5, 6, 0])).equals(1);
+            expect(gcdMultipleZeroIfNonInt([1, 1, 1, 1, 1, 1])).equals(1);
+            expect(gcdMultipleZeroIfNonInt([0, 0, 0])).equals(0);
+            expect(gcdMultipleZeroIfNonInt([1, 0, 0, 0])).equals(1);
+            expect(gcdMultipleZeroIfNonInt([0, 0, 0, 1])).equals(1);
+            expect(gcdMultipleZeroIfNonInt([0, 1, 0, 0])).equals(1);
+        });
+        it('gcd of an array of numbers, including float(s)', function(){
+            expect(gcdMultipleZeroIfNonInt([138, 552, 276.3, 138])).equals(0);
+            expect(gcdMultipleZeroIfNonInt([276, 276.001, 1242, 966])).equals(0);
+            expect(gcdMultipleZeroIfNonInt([0, 1.5, 0, 0.3])).equals(0);
+            // in theory, you could speed up this kind of function by exiting
+            // as soon as it sees a 1 -- since (if the numbers in the list are
+            // integers) then this indicates that these numbers' GCD is 1.
+            // however, since we have stated that this function returns 0 if it
+            // contains any non-integer values, we should *not* do this.
+            // (shouldn't make a difference in terms of finding scroll factors,
+            // but at least the function will behave as expected.)
+            expect(gcdMultipleZeroIfNonInt([1, 1.1])).equals(0);
         });
     });
 });


### PR DESCRIPTION
Hi, and thanks as always for the amazing library! I found a very minor bug (which, arguably, is more of a problem with mouse events on my system than anything else). This PR addresses this bug on my system, and should keep behavior the same for people with other systems.

## Environment info

- Cytoscape.js version: 3.34.0
- OS: Linux (Ubuntu 22.04.5, using Xfce)
- Browser: Firefox 152.0.4 (but, from testing, this issue also impacts Chromium)
- USB Mouse: Logitech MX Ergo S (but, from testing, this issue also impacts another USB mouse -- and even the touchpad on my laptop)

## Current (buggy) behaviour

### Background

I have been using Cytoscape.js 3.31.4 on Linux for a while, and I've noticed that -- when using a USB mouse to scroll in a Cytoscape.js drawing -- the scrolling is very "jerky." This is presumably the same issue as #3336.

So, I updated to Cytoscape.js 3.34.0, which works very nicely! It makes scrolling with the mouse smoother, aside from one strange corner case:

### The bug

I noticed that, if the first couple scrolls that I do in a Cytoscape.js instance are very big / fast, then the scrolling from then on in the interface becomes very jerky -- like before. However, if the first couple scrolls are slower, then the scrolling from then on in the interface is smooth and nice.

### Screen recordings

(These use the [Dagre demo](https://cytoscape.org/cytoscape.js-dagre/), like #3336.)

#### Fast initial scrolling (results in future scrolling being jerky)

(This GIF involves a lot of fast-moving images by its nature, so [I am just going to link it here](https://github.com/user-attachments/assets/a47c513a-efab-40c2-bd4a-0d8e35f8804a) instead of pasting it directly here to avoid triggering people with photosensitivity.)

#### Slow initial scrolling (results in future scrolling being smooth)

<img width="1917" height="963" alt="Image" src="https://github.com/user-attachments/assets/53c486cf-0d83-488c-8a95-c0365526e4ea" />

## Desired behaviour

Ideally, even fast initial scrolling would still result in smooth scrolling.

## Why is this happening?

### Diagnosing the bug

I tried adding the following log statement to [right after this line in the Cytoscape source code](https://github.com/cytoscape/cytoscape.js/blob/9ebf7f0999e5763e89531a8a1b0ee1dca22a69ec/src/extensions/renderer/base/load-listeners.mjs#L1084):

```js
        if (wheelDeltas.length >= wheelDeltaN) {
          // use log to determine if inaccurate
          var wds = wheelDeltas;
          console.log("wds are", wds); // <-- new thing; log the wheel deltas
```

When there is slow initial scrolling that causes smooth future scrolling (i.e. the bug does not occur), I see the following:

```js
wds are Array(4) [ -138, -138, -138, -138 ]
```

But when when there is fast scrolling that causes jerky future scrolling (i.e. the bug occurs!), I see the following or something like it:

```js
wds are Array(4) [ -138, -276, -138, -138 ]
```

Note that 276 = 138 * 2. It looks like the values here are always multiples of `-138` -- another example is `[ -138, -552, -276, -138 ]`, and I was even able to get my laptop's touchpad to give me `[ -138, -138, -1242, -966 ]`.

My guess as to what is happening here is that, sometimes, **"fast" scroll events in a short interval are combined**. This would explain why everything is divisible by `-138`.

## Proposed solution

Under the assumption that the "base" magnitude (i.e. `138`, for my system) will always be present in the initial sampling of wheel deltas, we could replace `allAreSameMagnitude()` by just finding the minimum-magnitude value, and checking to see if all other magnitudes in the array are divisible by it.

However, this assumption may not hold (i.e. maybe `wds` is something dreadful like `[-276, -276, -1242, -966]`). To account for this pathological case, this PR instead finds the greatest common divisor (GCD) of the wheel deltas and sets this as the `inaccurateScrollFactor`.

The GCD is generally only defined for integers, and I wasn't sure if we needed to worry about non-integer wheel deltas; [MDN indicates that we might](https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent/deltaY). So, this PR includes some logic to gracefully handle non-integer wheel deltas -- if any of the input wheel deltas are not integers, then the GCD function will bail out and not change anything. (I've left `allAreSameMagnitude()` in, so that if the input wheel deltas are all identical large floating-point numbers then they should still be set as the `inaccuratescrollFactor`.)

Anyway, thanks so much for your time, and hope this is helpful!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wheel-zoom behavior on devices that report inconsistent scroll amounts by using a more robust initial wheel input sampling approach.
  * Wheel zoom now computes the zoom factor more reliably, reducing unexpected zoom speeds and improving consistency across different wheel hardware.

* **Tests**
  * Added new test coverage for the underlying GCD-based math helpers used to interpret sampled scroll input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->