### PR TITLE
Recompute round-polygon corners when node size or corner radius changes

### DIFF
--- a/src/extensions/renderer/base/node-shapes.mjs
+++ b/src/extensions/renderer/base/node-shapes.mjs
@@ -76,13 +76,19 @@ BRp.generateRoundPolygon = function( name, points ){
     points: points,
 
     getOrCreateCorners: function (centerX, centerY, width, height, cornerRadius, rs, field) {
-      if( rs[field] !== undefined && rs[field + '-cx'] === centerX && rs [field + '-cy'] === centerY ){
+      if( rs[field] !== undefined
+          && rs[field + '-cx'] === centerX && rs[field + '-cy'] === centerY
+          && rs[field + '-w'] === width && rs[field + '-h'] === height
+          && rs[field + '-corner-radius'] === cornerRadius ){
         return rs[field];
       }
 
       rs[field] = new Array( points.length / 2 );
       rs[field + '-cx'] = centerX;
       rs[field + '-cy'] = centerY;
+      rs[field + '-w'] = width;
+      rs[field + '-h'] = height;
+      rs[field + '-corner-radius'] = cornerRadius;
       const halfW = width / 2;
       const halfH = height / 2;
       cornerRadius = cornerRadius === 'auto' ? math.getRoundPolygonRadius( width, height ) : cornerRadius;

--- a/test/modules/node-shapes.mjs
+++ b/test/modules/node-shapes.mjs
@@ -1,0 +1,70 @@
+import BRp from '../../src/extensions/renderer/base/node-shapes.mjs'
+import { describe } from 'mocha'
+import { expect } from 'chai'
+
+describe('Node shapes', function(){
+
+  describe('Round polygon corner caching', function(){
+
+    let nodeShapes;
+
+    beforeEach(function(){
+      let renderer = Object.create( BRp );
+
+      renderer.registerNodeShapes();
+
+      nodeShapes = renderer.nodeShapes;
+    });
+
+    let cornerExtent = function( corners ){
+      return Math.max( ...corners.map( c => Math.max( Math.abs(c.cx), Math.abs(c.cy) ) ) );
+    };
+
+    it('recomputes corners when width and height change (#3494)', function(){
+      let shape = nodeShapes['round-hexagon'];
+      let rs = {}; // stand-in for a node's rscratch
+
+      let small = shape.getOrCreateCorners( 0, 0, 25, 25, 'auto', rs, 'corners' );
+      let smallExtent = cornerExtent( small );
+
+      let large = shape.getOrCreateCorners( 0, 0, 80, 80, 'auto', rs, 'corners' );
+      let largeExtent = cornerExtent( large );
+
+      expect( large ).to.not.equal( small );
+      expect( largeExtent ).to.be.above( smallExtent );
+    });
+
+    it('recomputes corners when the corner radius changes', function(){
+      let shape = nodeShapes['round-hexagon'];
+      let rs = {};
+
+      let subtle = shape.getOrCreateCorners( 0, 0, 80, 80, 2, rs, 'corners' );
+      let round = shape.getOrCreateCorners( 0, 0, 80, 80, 20, rs, 'corners' );
+
+      expect( round ).to.not.equal( subtle );
+      expect( round[0].radius ).to.not.equal( subtle[0].radius );
+    });
+
+    it('reuses cached corners for identical geometry', function(){
+      let shape = nodeShapes['round-hexagon'];
+      let rs = {};
+
+      let a = shape.getOrCreateCorners( 0, 0, 25, 25, 'auto', rs, 'corners' );
+      let b = shape.getOrCreateCorners( 0, 0, 25, 25, 'auto', rs, 'corners' );
+
+      expect( b ).to.equal( a );
+    });
+
+    it('recomputes corners when the centre moves', function(){
+      let shape = nodeShapes['round-hexagon'];
+      let rs = {};
+
+      let a = shape.getOrCreateCorners( 0, 0, 25, 25, 'auto', rs, 'corners' );
+      let b = shape.getOrCreateCorners( 10, 0, 25, 25, 'auto', rs, 'corners' );
+
+      expect( b ).to.not.equal( a );
+    });
+
+  });
+
+});


### PR DESCRIPTION
**Cross-references to related issues.**

Associated issues:

- #3494

**Notes re. the content of the pull request.**

- `getOrCreateCorners()` in `src/extensions/renderer/base/node-shapes.mjs` memoises round-polygon corner geometry on the node's `rscratch`, but the cache key only compared the centre coordinates (`cx`/`cy`). Width, height, and corner radius feed into the corner computation but were not part of the key, so a node that changed size in place (without moving) kept painting its old geometry — affecting `round-triangle`, `round-diamond`, `round-pentagon`, `round-hexagon`, `round-heptagon`, `round-octagon`, and `round-tag`.
- This PR extends the cache key to also compare width, height, and the raw `cornerRadius` argument (compared before `'auto'` resolution). Cache hits for unchanged geometry behave as before.
- Adds a regression test module, `test/modules/node-shapes.mjs`, following the repro from the issue: same centre, changed width/height must yield recomputed corners. It also covers corner-radius changes, cache reuse for identical inputs, and invalidation when the centre moves. The two stale-cache tests fail without the fix and pass with it.

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).
- [x] For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.  (No API change — internal cache fix only.)

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.
- [x] For bug fixes:  Just after this pull request is merged, it should be applied to both the `master` branch and the `unstable` branch.  Normally, this just requires cherry-picking the corresponding merge commit from `master` to `unstable` -- or vice versa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed rounded polygon rendering so cached corner geometry is refreshed when node dimensions, corner radius, or position changes.
  - Prevented outdated corner data from being reused across different shapes or sizes.

- **Tests**
  - Added coverage for cache reuse and recalculation across geometry and positioning changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->