### PR TITLE
Resort the A* open set when a queued node gets a lower score

### DIFF
--- a/src/collection/algorithms/a-star.mjs
+++ b/src/collection/algorithms/a-star.mjs
@@ -142,6 +142,10 @@ let elesfn = ({
         if( tempScore < gScore[ wid ] ){
           gScore[ wid ] = tempScore;
           fScore[ wid ] = tempScore + heuristic( w );
+
+          // the heap is ordered by fScore, so it must be resorted for the new value
+          openSet.updateItem( w );
+
           cameFrom[ wid ] = cMin;
           cameFromEdge[ wid ] = e;
         }

--- a/test/collection-astar.mjs
+++ b/test/collection-astar.mjs
@@ -265,4 +265,81 @@ describe('Algorithms', function(){
       expect(resD.pathTo(nodes[1][5]).stdFilter(isNode).map(ele2id)).to.deep.equal(path);
     });
   });
+
+  describe('eles.aStar() with edge weights', function(){
+
+    var cy;
+
+    beforeEach(function(done){
+      cytoscape({
+        elements: {
+          nodes: [
+            { data: { id: 'a' } },
+            { data: { id: 'b' } },
+            { data: { id: 'c' } },
+            { data: { id: 'd' } }
+          ],
+
+          edges: [
+            { data: { id: 'ab', source: 'a', target: 'b', weight: 4 } },
+            { data: { id: 'ac', source: 'a', target: 'c', weight: 6 } },
+            { data: { id: 'ad', source: 'a', target: 'd', weight: 1 } },
+            { data: { id: 'dc', source: 'd', target: 'c', weight: 1 } },
+            { data: { id: 'cb', source: 'c', target: 'b', weight: 1 } }
+          ]
+        },
+
+        ready: function(){
+          cy = this;
+
+          done();
+        }
+      });
+    });
+
+    function weight( edge ){
+      return edge.data('weight');
+    }
+
+    function ele2id( ele ){
+      return ele.id();
+    }
+
+    function isNode( ele ){
+      return ele.isNode();
+    }
+
+    // a-d-c-b costs 3 while the direct a-b edge costs 4.  The cheaper route is only
+    // taken if c is re-prioritised in the open set when d lowers its score to 2.
+    it('eles.aStar(): weighted: a node already in the open set can be reached more cheaply', function(){
+      var res = cy.elements().aStar({ root: cy.$('#a'), goal: cy.$('#b'), weight: weight });
+
+      expect(res.found).to.equal(true);
+      expect(res.distance).to.equal(3);
+      expect(res.path.stdFilter(isNode).map(ele2id)).to.deep.equal(["a", "d", "c", "b"]);
+    });
+
+    [true, false].forEach(function( directed ){
+      it('eles.aStar(): weighted, ' + (directed ? 'directed' : 'undirected') + ': same as dijkstra', function(){
+        var nodes = cy.nodes();
+
+        for( var i = 0; i < nodes.length; i++ ){
+          var root = nodes[i];
+          var resD = cy.elements().dijkstra({ root: root, weight: weight, directed: directed });
+
+          for( var j = 0; j < nodes.length; j++ ){
+            var goal = nodes[j];
+            var res = cy.elements().aStar({ root: root, goal: goal, weight: weight, directed: directed });
+            var msg = root.id() + ' to ' + goal.id();
+
+            expect(res.found, msg).to.equal(resD.distanceTo(goal) !== Infinity);
+
+            if( res.found ){
+              expect(res.distance, msg).to.equal(resD.distanceTo(goal));
+            }
+          }
+        }
+      });
+    });
+  });
 });

--- a/test/collection-astar.mjs
+++ b/test/collection-astar.mjs
@@ -316,7 +316,7 @@ describe('Algorithms', function(){
 
       expect(res.found).to.equal(true);
       expect(res.distance).to.equal(3);
-      expect(res.path.stdFilter(isNode).map(ele2id)).to.deep.equal(["a", "d", "c", "b"]);
+      expect(res.path.stdFilter(isNode).map(ele2id)).to.deep.equal(['a', 'd', 'c', 'b']);
     });
 
     [true, false].forEach(function( directed ){


### PR DESCRIPTION
**Cross-references to related issues.**

Associated issues:

- #3497
- #2880 (same symptom, closed as stale in 2021)

**Notes re. the content of the pull request.**

`aStar()` keeps its open set in a `Heap` ordered by `fScore`. When a queued node turns out to be reachable more cheaply, `gScore`/`fScore` were lowered in place and the heap was never resorted, so it kept ordering that node by its stale score. A node could then be popped ahead of a cheaper one — and when that node is the goal, `aStar()` returns immediately with whatever `gScore` the goal holds at that moment.

- This PR adds the missing `openSet.updateItem( w )`, which is what `dijkstra()`'s `setDist()` already does for exactly the same reason. The element passed is the same singleton that was pushed (`edge.source()` / `edge.target()` return the canonical element), so the heap finds it.
- This PR adds regression tests on a four-node weighted graph, plus an A*-vs-Dijkstra sweep over every node pair, in both directed and undirected mode.

Minimum reproduction, spelled out in #3497 — the direct `a → b` edge costs 4, `a → d → c → b` costs 3:

```js
cy.elements().aStar({ root, goal, weight }).distance;          // 4 before, 3 after
cy.elements().dijkstra({ root, weight }).distanceTo(goal);     // 3
cy.elements().bellmanFord({ root, weight }).distanceTo(goal);  // 3
cy.elements().floydWarshall({ weight }).distance(root, goal);  // 3
```

**Why this went unnoticed**

The A*/Dijkstra consistency tests added in 97c2770 for #2880 never pass a `weight` option — the grid fixture carries `weight: 1.0` in edge data, but nothing reads it, so they all run on the default `weight: edge => 1`. Lowering the score of a queued node requires a strictly cheaper route to it, which unit weights effectively rule out. Over 3,840 `aStar()` runs on random graphs, the affected branch was entered **0 times with unit weights and 2,429 times with varied weights**. The new tests supply a `weight` function for that reason.

**Verification**

- Sweeping every node pair of 300 random weighted graphs and comparing `aStar()` against `floydWarshall()`: **27 of 15,510 queries wrong before this change (0.17%), 0 after.** The same sweep also checks that the returned `path` is a connected walk from root to goal whose weights sum to `distance` — that held both before and after, so the old failure was silent rather than malformed.
- The three new tests fail on current `master` (`expected 4 to equal 3`) and pass with the fix; the seven pre-existing `aStar()` tests pass either way.
- `npm test` is green: 739 mocha + 46 module tests, 18 Playwright chromium tests, and `lint` reporting 0 errors (the 12 warnings are pre-existing and in unrelated files).
- Cost of the added `updateItem`: measured in one process with the two variants interleaved over 9 rounds, corner-to-corner on a 100×100 weighted grid (10,000 nodes / 19,800 edges — the worst case for open-set size). Without: median 23 ms, range 21–30 ms. With: median 23 ms, range 21–25 ms. No difference outside noise.

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).
- [x] For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.  (No API change, so no update needed.)

`a-star.mjs` is byte-identical on `master` and `unstable`, so this cherry-picks cleanly to `unstable`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved A* pathfinding so lower-cost routes are correctly prioritized during searches.
  - Weighted graphs now produce accurate shortest paths across directed and undirected traversal.
  - Corrected route selection when a more affordable path is discovered after an initial route.

- **Tests**
  - Added coverage for weighted A* searches and verified results against Dijkstra’s algorithm across multiple node pairs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->