### PR TITLE
Add multiClickDebounceTime to CytoscapeOptions typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -337,6 +337,12 @@ declare namespace cytoscape {
          * The default value is false.
          */
         autounselectify?: boolean;
+        /**
+         * Debounce time in milliseconds to check for a `dblclick` event before executing the `oneclick` event.
+         *
+         * The default value is 250.
+         */
+        multiClickDebounceTime?: number;
 
         ///////////////////////////////////////
         // rendering options:


### PR DESCRIPTION
**Cross-references to related issues.**

Associated issues:

- #3514

**Notes re. the content of the pull request.**

- `multiClickDebounceTime` is read in [`src/core/index.mjs`](https://github.com/cytoscape/cytoscape.js/blob/unstable/src/core/index.mjs#L95) and documented under [`#init-opts/multiClickDebounceTime`](https://js.cytoscape.org/#init-opts/multiClickDebounceTime), but it was missing from the `CytoscapeOptions` interface in `index.d.ts`. Passing it therefore failed to compile with `TS2353: Object literal may only specify known properties`.
- This PR adds the field to `CytoscapeOptions`, placed directly after `autounselectify` so the ordering matches the interaction-options list in `documentation/md/core/init.md`.

Verification:

- Compiled the reporter's repro against the modified `index.d.ts`. Before the change it produces exactly the reported `TS2353`; after it, the file compiles. A `@ts-expect-error` guard confirms a wrong type (`multiClickDebounceTime: "250"`) is still rejected.
- `npm run lint` — 0 errors (12 pre-existing warnings in untouched `src/` files)
- `npm run test:js` — 768 passing
- `npm run test:modules` — 68 passing

One related observation while working on this, possibly of interest for #3476:

- There is no TypeScript verification in the repo (no `tsconfig`, no dtslint setup), so `index.d.ts` drift of this kind cannot be caught by CI. The repro above was compiled outside the repo and is not included here.

Happy to follow up on that in a separate PR if that would be useful.

**Checklist**

Author:

- [x] The proper base branch has been selected.  New features go on `unstable`.  Bug-fix patches can go on either `unstable` or `master`.
- [x] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.  Check this box if tests are not pragmatically possible (e.g. rendering features could include screenshots or videos instead of automated tests).  <!-- The repo has no TypeScript test harness to add a case to; see the note above. -->
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (above).
- [x] For new or updated API, the `index.d.ts` Typescript definition file has been appropriately updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the optional `multiClickDebounceTime` configuration setting.
  - Configure the delay, in milliseconds, used when distinguishing single clicks from double clicks.
  - The default delay is 250 milliseconds.
  - TypeScript users now receive declaration support and editor guidance for this option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->